### PR TITLE
separate platforms into sections, tweak displayed data

### DIFF
--- a/apps/menu-bar/src/components/DeviceItem.tsx
+++ b/apps/menu-bar/src/components/DeviceItem.tsx
@@ -11,6 +11,7 @@ import {useExpoTheme} from '../utils/useExpoTheme';
 import Button from './Button';
 import {palette} from '@expo/styleguide-native';
 import {useTheme} from '../providers/ThemeProvider';
+import {capitalize} from '../utils/helpers';
 
 interface Props {
   device: Device;
@@ -71,8 +72,9 @@ const DeviceItem = ({device, onPress, onPressLaunch, selected}: Props) => {
           <View flex="1" justify="center">
             <Text numberOfLines={1}>{device.name}</Text>
             <Text style={styles.description} color="secondary">
-              {device.osType} {device.osVersion}
-              {device.state === 'Booted' ? ' - Running' : ''}
+              {capitalize(device.deviceType)}
+              {device.osVersion && ` · ${device.osVersion}`}
+              {device.state === 'Booted' ? ' · Running' : ''}
             </Text>
           </View>
         </Row>

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -25,6 +25,7 @@ import {useDeviceAudioPreferences} from '../hooks/useDeviceAudioPreferences';
 import {useExpoTheme} from '../utils/useExpoTheme';
 import SectionHeader from './SectionHeader';
 import Item from './Item';
+import {partition} from '../utils/helpers';
 
 enum Status {
   LISTENING,
@@ -46,6 +47,11 @@ function Core(props: Props) {
   const {devices} = useListDevices();
   const {emulatorWithoutAudio} = useDeviceAudioPreferences();
   const theme = useExpoTheme();
+
+  const partitionedDevices = partition(
+    devices,
+    device => device.osType === 'iOS',
+  );
 
   useEffect(() => {
     getSelectedDevicesIds().then(setSelectedDevicesIds);
@@ -226,16 +232,14 @@ function Core(props: Props) {
       ) : null}
       <View shrink="1" overflow="hidden" pt="tiny">
         <View px="medium">
-          <SectionHeader label="Devices" />
+          <SectionHeader label="iOS" />
         </View>
         <View overflow="hidden" shrink="1" mb="tiny" mt="tiny">
           <FlatList
-            data={devices}
+            data={partitionedDevices[0]}
             alwaysBounceVertical={false}
             renderItem={({item: device}) => {
-              const platform = getDeviceOS(device);
               const id = getDeviceId(device);
-
               return (
                 <DeviceItem
                   device={device}
@@ -243,12 +247,38 @@ function Core(props: Props) {
                   onPress={() => onSelectDevice(device)}
                   onPressLaunch={() =>
                     bootDeviceAsync({
-                      platform,
+                      platform: 'ios',
+                      id,
+                    })
+                  }
+                  selected={selectedDevicesIds.ios === id}
+                />
+              );
+            }}
+          />
+        </View>
+        <View px="medium">
+          <SectionHeader label="Android" />
+        </View>
+        <View overflow="hidden" shrink="1" mb="tiny" mt="tiny">
+          <FlatList
+            data={partitionedDevices[1]}
+            alwaysBounceVertical={false}
+            renderItem={({item: device}) => {
+              const id = getDeviceId(device);
+              return (
+                <DeviceItem
+                  device={device}
+                  key={device.name}
+                  onPress={() => onSelectDevice(device)}
+                  onPressLaunch={() =>
+                    bootDeviceAsync({
+                      platform: 'android',
                       id,
                       noAudio: emulatorWithoutAudio,
                     })
                   }
-                  selected={selectedDevicesIds[platform] === id}
+                  selected={selectedDevicesIds.android === id}
                 />
               );
             }}

--- a/apps/menu-bar/src/utils/helpers.ts
+++ b/apps/menu-bar/src/utils/helpers.ts
@@ -1,0 +1,10 @@
+export function partition<T>(array: T[], predicate: (item: T) => boolean) {
+  return array.reduce(
+    (acc: T[][], item: T) => (acc[+!predicate(item)].push(item), acc),
+    [[], []],
+  );
+}
+
+export function capitalize(word: string) {
+  return `${word.toUpperCase()[0]}${word.substring(1)}`;
+}


### PR DESCRIPTION
# Why

After discussion with Gabriel, we decided to give the devices list separation by platform a try.

It should make more obvious for user the current preferred device markings since now there will be only one selected entry per section.

# How

Add partition helper and partition data on display. Add device type and remove platform name from device entries rows.

# Preview

<img width="431" alt="Screenshot 2023-08-08 at 16 39 10" src="https://github.com/expo/orbit/assets/719641/71a113c1-a9ed-4ab2-a708-8c5f961d9571">


