### PR TITLE
[menu-bar] Add arm64 and x64 CLI versions to bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ packages/*/build
 apps/*/build
 
 apps/menu-bar/cli/expo-orbit-cli
+apps/menu-bar/cli/orbit-cli*
 
 .idea

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,7 +11,7 @@
     "cli": "node ./build/index.js",
     "start": "yarn run prepare && yarn run watch",
     "build": "tsc --project tsconfig.build.json",
-    "archive": "yarn build && pkg build/index.js -o dist/expo-orbit-cli",
+    "archive": "yarn build && pkg build/index.js --targets macos-arm64,macos-x64 -o dist/orbit-cli",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "prepare": "yarn run clean && yarn run build",
     "watch": "tsc --watch --preserveWatchOutput",

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
@@ -1,5 +1,6 @@
 #import "MenuBarModule.h"
 #import "AppDelegate.h"
+#import <sys/utsname.h>
 
 #import <React/RCTLog.h>
 #import <ServiceManagement/ServiceManagement.h>
@@ -100,6 +101,23 @@ RCT_EXPORT_METHOD(runCommand:(NSString *)command
   resolve(returnOutput);
 }
 
+NSString *getMachineHardwareName(void) {
+    struct utsname sysinfo;
+    int retVal = uname(&sysinfo);
+    if (EXIT_SUCCESS != retVal) return nil;
+
+    return [NSString stringWithUTF8String:sysinfo.machine];
+}
+
+NSString *getCliResourceNameForArch(void) {
+    NSString *arch = getMachineHardwareName();
+    if([arch compare:@"arm64"]){
+      return @"orbit-cli-arm64";
+    }
+
+    return @"orbit-cli-x64";
+}
+
 RCT_EXPORT_METHOD(runCli:(NSString *)command
                   arguments:(NSArray *)arguments
                   listenerId:(nonnull NSNumber *)listenerId
@@ -109,7 +127,7 @@ RCT_EXPORT_METHOD(runCli:(NSString *)command
   NSTask *task = [[NSTask alloc] init];
   NSPipe *pipe = [NSPipe pipe];
 
-  NSString *executablePath = [[NSBundle mainBundle] pathForResource:@"expo-orbit-cli" ofType:nil];
+  NSString *executablePath = [[NSBundle mainBundle] pathForResource:getCliResourceNameForArch() ofType:nil];
 
   [task setLaunchPath:executablePath];
   [task setArguments:[@[command] arrayByAddingObjectsFromArray:arguments]];

--- a/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
+++ b/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
@@ -13,7 +13,8 @@
 		514201582437B4B40078DB4F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 514201572437B4B40078DB4F /* main.m */; };
 		C0271C582A602CDE0065AB11 /* ProgressIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C0271C572A602CDE0065AB11 /* ProgressIndicatorManager.m */; };
 		C0271C5B2A602FF60065AB11 /* ProgressIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = C0271C5A2A602FF60065AB11 /* ProgressIndicatorView.m */; };
-		C032EDB72A1FE6F300FBC597 /* expo-orbit-cli in Resources */ = {isa = PBXBuildFile; fileRef = C032EDB62A1FE6F300FBC597 /* expo-orbit-cli */; };
+		C032EDB72A1FE6F300FBC597 /* orbit-cli-arm64 in Resources */ = {isa = PBXBuildFile; fileRef = C032EDB62A1FE6F300FBC597 /* orbit-cli-arm64 */; };
+		C051E6B62A83577800C6D615 /* orbit-cli-x64 in Resources */ = {isa = PBXBuildFile; fileRef = C051E6B52A83577800C6D615 /* orbit-cli-x64 */; };
 		C0523ECA2A545730003371AF /* FilePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = C0523EC92A545730003371AF /* FilePicker.m */; };
 		C0523ECC2A550983003371AF /* WindowManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C0523ECB2A550983003371AF /* WindowManager.m */; };
 		C0523ED02A55980D003371AF /* WindowWithDeallocCallback.m in Sources */ = {isa = PBXBuildFile; fileRef = C0523ECF2A55980D003371AF /* WindowWithDeallocCallback.m */; };
@@ -65,9 +66,10 @@
 		C0271C572A602CDE0065AB11 /* ProgressIndicatorManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProgressIndicatorManager.m; sourceTree = "<group>"; };
 		C0271C592A602FEC0065AB11 /* ProgressIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProgressIndicatorView.h; sourceTree = "<group>"; };
 		C0271C5A2A602FF60065AB11 /* ProgressIndicatorView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ProgressIndicatorView.m; sourceTree = "<group>"; };
-		C032EDB62A1FE6F300FBC597 /* expo-orbit-cli */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = "expo-orbit-cli"; path = "../../cli/expo-orbit-cli"; sourceTree = "<group>"; };
+		C032EDB62A1FE6F300FBC597 /* orbit-cli-arm64 */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = "orbit-cli-arm64"; path = "../../cli/orbit-cli-arm64"; sourceTree = "<group>"; };
 		C051E6B32A83408800C6D615 /* ExpoMenuBar-macOSRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ExpoMenuBar-macOSRelease.entitlements"; sourceTree = "<group>"; };
 		C051E6B42A8340AF00C6D615 /* AutoLauncherRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AutoLauncherRelease.entitlements; sourceTree = "<group>"; };
+		C051E6B52A83577800C6D615 /* orbit-cli-x64 */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = "orbit-cli-x64"; path = "../../cli/orbit-cli-x64"; sourceTree = "<group>"; };
 		C0523EC82A54571F003371AF /* FilePicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilePicker.h; sourceTree = "<group>"; };
 		C0523EC92A545730003371AF /* FilePicker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FilePicker.m; sourceTree = "<group>"; };
 		C0523ECB2A550983003371AF /* WindowManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WindowManager.m; sourceTree = "<group>"; };
@@ -152,7 +154,8 @@
 			children = (
 				C051E6B32A83408800C6D615 /* ExpoMenuBar-macOSRelease.entitlements */,
 				C081507C2A610E2F00E8890F /* Resources */,
-				C032EDB62A1FE6F300FBC597 /* expo-orbit-cli */,
+				C032EDB62A1FE6F300FBC597 /* orbit-cli-arm64 */,
+				C051E6B52A83577800C6D615 /* orbit-cli-x64 */,
 				38423A3E24576CBC00BC2EAC /* main.jsbundle */,
 				5142014B2437B4B30078DB4F /* AppDelegate.h */,
 				5142014C2437B4B30078DB4F /* AppDelegate.m */,
@@ -328,7 +331,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C032EDB72A1FE6F300FBC597 /* expo-orbit-cli in Resources */,
+				C051E6B62A83577800C6D615 /* orbit-cli-x64 in Resources */,
+				C032EDB72A1FE6F300FBC597 /* orbit-cli-arm64 in Resources */,
 				C081507F2A610E9C00E8890F /* fonts in Resources */,
 				514201522437B4B40078DB4F /* Assets.xcassets in Resources */,
 				514201552437B4B40078DB4F /* Main.storyboard in Resources */,

--- a/apps/menu-bar/package.json
+++ b/apps/menu-bar/package.json
@@ -7,7 +7,7 @@
     "macos": "react-native run-macos",
     "start": "react-native start",
     "test": "jest",
-    "update-cli": "mkdir -p cli && cp ../cli/dist/expo-orbit-cli cli/expo-orbit-cli"
+    "update-cli": "mkdir -p cli && cp -R ../cli/dist/ cli/"
   },
   "dependencies": {
     "@expo/styleguide-native": "^1.0.1",


### PR DESCRIPTION
# Why

To support both Apple Silicon e Intel Macs we must compile both versions of the CLI, one for arm64 and the other x64.

TODO:
Once we have an automated release process we can create individual apps releases for each platform and avoid shipping both CLIs

# How

- Update the `archive` script to explicitly generate arm64 and x64 binaries
- Update native `runCli` method to check which CLI it should use 

 
