### PR TITLE
[menu-bar] spacing tweaks after header removal

### DIFF
--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -39,7 +39,7 @@ enum Status {
   INSTALLING,
 }
 
-const BUILDS_SECTION_HEIGHT = 92;
+const BUILDS_SECTION_HEIGHT = 88;
 
 type Props = {
   isDevWindow: boolean;
@@ -217,7 +217,7 @@ function Core(props: Props) {
   return (
     <View shrink="1">
       <View style={{height: BUILDS_SECTION_HEIGHT}}>
-        <View padding="medium" pb="tiny">
+        <View px="medium" pt="2.5" pb="tiny">
           <SectionHeader label="Builds" />
         </View>
         {status === Status.LISTENING ? (


### PR DESCRIPTION
# Why

After header removal the build section was a bit too spaced out in comparision to the content below.

# How

Adjust the builds section padding and static height.

# Preview

<img width="420" alt="Screenshot 2023-08-09 at 13 50 20" src="https://github.com/expo/orbit/assets/719641/2a2c84b3-d3f1-4bca-b557-c8393860049c">

