### PR TITLE
[menu-bar] move device running indicator to the right, add dot

### DIFF
--- a/apps/menu-bar/src/components/DeviceItem.tsx
+++ b/apps/menu-bar/src/components/DeviceItem.tsx
@@ -73,14 +73,13 @@ const DeviceItem = ({device, onPress, onPressLaunch, selected}: Props) => {
           </View>
           <View flex="1" justify="center">
             <Text numberOfLines={1}>{device.name}</Text>
-            <Text style={styles.description} color="secondary">
+            <Text style={styles.description} color="secondary" leading="small">
               {capitalize(device.deviceType)}
               {device.osVersion && ` · ${device.osVersion}`}
-              {device.state === 'Booted' ? ' · Running' : ''}
             </Text>
           </View>
         </Row>
-        {device.deviceType === 'device' ? (
+        {device.deviceType === 'device' && (
           <>
             {device.connectionType === 'Network' ? (
               <WifiIcon height={20} width={20} fill={PlatformColor('text')} />
@@ -92,11 +91,28 @@ const DeviceItem = ({device, onPress, onPressLaunch, selected}: Props) => {
               />
             )}
           </>
-        ) : isHovered && device.state === 'Shutdown' ? (
-          <Button color="primary" onPress={onPressLaunch} style={styles.button}>
-            Launch
-          </Button>
-        ) : null}
+        )}
+        {device.deviceType !== 'device' && device.state === 'Booted' && (
+          <>
+            <Text color="success" style={styles.runIndicator}>
+              ●
+            </Text>
+            <Text color="secondary" style={styles.runIndicator}>
+              {' '}
+              Running
+            </Text>
+          </>
+        )}
+        {isHovered &&
+          device.deviceType !== 'device' &&
+          device.state === 'Shutdown' && (
+            <Button
+              color="primary"
+              onPress={onPressLaunch}
+              style={styles.button}>
+              Launch
+            </Button>
+          )}
       </Row>
     </Pressable>
   );
@@ -113,13 +129,15 @@ const styles = StyleSheet.create({
     marginHorizontal: 6,
     borderRadius: 4,
   },
-  circle: {width: 32, height: 32, marginRight: 8, opacity: 0.85},
+  circle: {width: 32, height: 32, marginRight: 8, opacity: 0.8},
   description: {
     fontSize: 11,
-    lineHeight: 13,
     opacity: 0.8,
   },
   button: {
     marginLeft: 8,
+  },
+  runIndicator: {
+    fontSize: 11,
   },
 });

--- a/apps/menu-bar/src/utils/theme.ts
+++ b/apps/menu-bar/src/utils/theme.ts
@@ -118,6 +118,8 @@ export const text = {
 
   leading: {
     large: {lineHeight: 18},
+    medium: {lineHeight: 15},
+    small: {lineHeight: 13},
   },
 
   type: {


### PR DESCRIPTION
# Why

It could be hard, at first glance, to see which devices are running, because device state is a part of device description line.

# How

Emphasize the device state a bit by adding a green dot indicator and moving the label to the right side of the item, when also related to state "Launch" button is places for turned off devices.

# Test Plan

The changes have been tested locally.

# Preview

<img width="390" alt="Screenshot 2023-08-09 at 15 02 10" src="https://github.com/expo/orbit/assets/719641/8f4a0445-7e7f-4ad2-a1f3-5ac063e48f10"  align="left">
<img width="390" alt="Screenshot 2023-08-09 at 15 29 16" src="https://github.com/expo/orbit/assets/719641/c546b373-7214-4b08-913e-79fda09515c8">
