### PR TITLE
[cli] Fix build script not outputting transpiled files

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "cli": "node ./build/index.js",
     "start": "yarn run prepare && yarn run watch",
-    "build": "tsc --project tsconfig.build.json",
+    "build": "tsc",
     "archive": "yarn build && pkg build/index.js --targets macos-arm64,macos-x64 -o dist/orbit-cli",
     "clean": "rimraf build ./tsconfig.tsbuildinfo",
     "prepare": "yarn run clean && yarn run build",

--- a/apps/cli/tsconfig.build.json
+++ b/apps/cli/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
-}


### PR DESCRIPTION
# Why

Running `yarn build` inside the `cli` directory is not generating the build folder

# How

Remove the unnecessary `tsconfig.build.json` file and just use the one tsconfig file for everything

# Test Plan

Run `yarn build`
