### PR TITLE
[menu-bar][cli] Fix device list when Android SDK path is not configured correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed listing devices when Android SDK path or `xcrun` is not configured correctly. ([#22537](https://github.com/expo/orbit/pull/26) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 0.1.0 — 2023-08-10

--- a/apps/menu-bar/src/utils/device.ts
+++ b/apps/menu-bar/src/utils/device.ts
@@ -40,29 +40,31 @@ export function getDeviceId(device: Device): string {
 export function getSectionsFromDeviceList(
   devices: Device[],
 ): Array<SectionListData<Device, {label: string}>> {
-  const sections = devices.reduce(
-    (acc, device) => {
-      if (device.osType === 'iOS') {
-        acc[0].data.push(device);
-      } else {
-        acc[1].data.push(device);
-      }
+  const sections = devices
+    .reduce(
+      (acc, device) => {
+        if (device.osType === 'iOS') {
+          acc[0].data.push(device);
+        } else {
+          acc[1].data.push(device);
+        }
 
-      return acc;
-    },
-    [
-      {
-        data: [] as Device[],
-        key: 'ios',
-        label: 'iOS',
+        return acc;
       },
-      {
-        data: [] as Device[],
-        key: 'android',
-        label: 'Android',
-      },
-    ],
-  );
+      [
+        {
+          data: [] as Device[],
+          key: 'ios',
+          label: 'iOS',
+        },
+        {
+          data: [] as Device[],
+          key: 'android',
+          label: 'Android',
+        },
+      ],
+    )
+    .filter(section => section.data.length > 0);
 
   return sections;
 }

--- a/packages/eas-shared/src/run/android/adb.ts
+++ b/packages/eas-shared/src/run/android/adb.ts
@@ -22,6 +22,12 @@ export async function adbAsync(...args: string[]): Promise<SpawnResult> {
   try {
     return await spawnAsync(adbExecutable, args);
   } catch (error: any) {
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `adb command not found, please install it globally or configure the ANDROID_HOME environment variable`
+      );
+    }
+
     let errorMessage = (error.stderr || error.stdout || error.message).trim();
     if (errorMessage.startsWith(BEGINNING_OF_ADB_ERROR_MESSAGE)) {
       errorMessage = errorMessage.substring(


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/23
Closes https://github.com/expo/orbit/issues/18

# How

- Wrap CLI commands to list iOS and Android devices into `try{}catch`  so the `list-devices` command always returns an array even if the native commands fail
- Filter empty sections from Devices List

# Test Plan

Configure a wrong "Custom Android SDK root location" and check if the devices list will show iOS devices 
<img width="452" alt="Screenshot 2023-08-10 at 10 53 45" src="https://github.com/expo/orbit/assets/11707729/547dfee3-c01c-46d6-8a59-2f7f874eeb90">

Run `ANDROID_HOME=/Users/wrong/path yarn cli list-devices` and make sure CLI still outputs iOS devices

<img width="868" alt="image" src="https://github.com/expo/orbit/assets/11707729/c03bf0cc-f958-4a26-a4d8-20ba83811a8d">

