### PR TITLE
[menu-bar] Fix Popover height after putting Mac to sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed listing devices when Android SDK path or `xcrun` is not configured correctly. ([#26](https://github.com/expo/orbit/pull/26) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fixed menu bar popover height after putting Mac to sleep. ([#29](https://github.com/expo/orbit/pull/29) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/apps/menu-bar/src/hooks/useSafeDisplayDimensions.ts
+++ b/apps/menu-bar/src/hooks/useSafeDisplayDimensions.ts
@@ -1,13 +1,15 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {DeviceEventEmitter, Dimensions} from 'react-native';
 
 export const SAFE_AREA_FACTOR = 0.85;
 
 export const useSafeDisplayDimensions = () => {
   const [dimensions, setDimensions] = useState(Dimensions.get('screen'));
+  const attemptsToGetDimensions = useRef(0);
 
   useEffect(() => {
     const listener = DeviceEventEmitter.addListener('popoverFocused', () => {
+      attemptsToGetDimensions.current = 0;
       setDimensions(Dimensions.get('screen'));
     });
 
@@ -16,9 +18,24 @@ export const useSafeDisplayDimensions = () => {
     };
   }, []);
 
+  /**
+   * Sometimes Dimensions.get('screen') returns height 0 after the computer goes to sleep
+   * from one monitor and that same monitor gets unplugged. This workaround attempts to mitigate
+   * this problem by waiting 100ms and trying to get the dimensions again.
+   */
+  if (dimensions?.height === 0 && attemptsToGetDimensions.current < 5) {
+    attemptsToGetDimensions.current++;
+    setTimeout(() => {
+      setDimensions(Dimensions.get('screen'));
+    }, 100);
+  }
+
   return {
     ...dimensions,
-    height: dimensions.height * SAFE_AREA_FACTOR,
+    height:
+      dimensions.height !== 0
+        ? dimensions.height * SAFE_AREA_FACTOR
+        : undefined,
     width: dimensions.width * SAFE_AREA_FACTOR,
   };
 };

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -60,10 +60,14 @@ function Core(props: Props) {
 
   const displayDimensions = useSafeDisplayDimensions();
   const estimatedAvailableSizeForDevices =
-    displayDimensions.height - FOOTER_HEIGHT - BUILDS_SECTION_HEIGHT - 30;
+    (displayDimensions.height || 0) -
+    FOOTER_HEIGHT -
+    BUILDS_SECTION_HEIGHT -
+    30;
   const heightOfAllDevices = DEVICE_ITEM_HEIGHT * devices?.length;
   const estimatedListHeight =
-    heightOfAllDevices <= estimatedAvailableSizeForDevices
+    heightOfAllDevices <= estimatedAvailableSizeForDevices ||
+    estimatedAvailableSizeForDevices <= 0
       ? heightOfAllDevices
       : estimatedAvailableSizeForDevices;
 


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/22


It seems that there is a bug in `react-native-macos` when calling `Dimensions.get('screen')` right after unplugging a display and awaking the computer, which results in the Dimensions API returning `height: 0`

TODO
- [ ] Open an issue on https://github.com/microsoft/react-native-macos reporting this Dimensions bug

# How

This PR adds a workaround that attempts to mitigate this problem by waiting 100ms and trying to get the screen dimensions again.

# Test Plan

1. Open the Popover on a second monitor
2. Put your Mac to sleep from the second monitor
3. Unplug the monitor
4. Wake up your Mac and press the Orbit Icon on the menu bar
5. Ensure the devices list is displayed correctly 
