### PR TITLE
[menu-bar] prevent multiple "launch" clicks, add indicator when booting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed listing devices when Android SDK path or `xcrun` is not configured correctly. ([#26](https://github.com/expo/orbit/pull/26) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fixed menu bar popover height after putting Mac to sleep. ([#29](https://github.com/expo/orbit/pull/29) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Prevent multiple "Launch" clicks, add label when booting. ([#29](https://github.com/expo/orbit/pull/29) by [@Simek](https://github.com/Simek))
 
 ### 💡 Others
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed listing devices when Android SDK path or `xcrun` is not configured correctly. ([#26](https://github.com/expo/orbit/pull/26) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Fixed menu bar popover height after putting Mac to sleep. ([#29](https://github.com/expo/orbit/pull/29) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fixed menu bar popover height after putting Mac to sleep. ([#28](https://github.com/expo/orbit/pull/28) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Prevent multiple "Launch" clicks, add label when booting. ([#29](https://github.com/expo/orbit/pull/29) by [@Simek](https://github.com/Simek))
 
 ### 💡 Others

--- a/apps/menu-bar/src/components/Button.tsx
+++ b/apps/menu-bar/src/components/Button.tsx
@@ -14,10 +14,9 @@ import {useCurrentTheme} from '../utils/useExpoTheme';
 import {addOpacity} from '../utils/theme';
 
 type Color = 'default' | 'primary';
-interface Props extends TouchableOpacityProps {
-  children: string;
+type Props = TouchableOpacityProps & {
   color?: Color;
-}
+};
 
 const Button = ({
   children,

--- a/apps/menu-bar/src/components/Button.tsx
+++ b/apps/menu-bar/src/components/Button.tsx
@@ -16,14 +16,10 @@ import {addOpacity} from '../utils/theme';
 type Color = 'default' | 'primary';
 type Props = TouchableOpacityProps & {
   color?: Color;
+  title: string;
 };
 
-const Button = ({
-  children,
-  color = 'default',
-  disabled,
-  ...otherProps
-}: Props) => {
+const Button = ({title, color = 'default', disabled, ...otherProps}: Props) => {
   const theme = useCurrentTheme();
   const {textStyle, touchableStyle} = getStylesForColor(color, theme);
 
@@ -38,7 +34,7 @@ const Button = ({
         otherProps.style,
       ]}>
       <Text style={textStyle} size="tiny" weight="semibold">
-        {children}
+        {title}
       </Text>
     </TouchableOpacity>
   );

--- a/apps/menu-bar/src/components/DeviceItem.tsx
+++ b/apps/menu-bar/src/components/DeviceItem.tsx
@@ -116,16 +116,21 @@ const DeviceItem = ({device, onPress, onPressLaunch, selected}: Props) => {
           device.state === 'Shutdown' &&
           !isDeviceLaunching && (
             <Button
+              title="Launch"
               disabled={isDeviceLaunching}
               color="primary"
               onPress={async () => {
                 setDeviceLaunching(true);
-                await onPressLaunch();
-                setDeviceLaunching(false);
+                try {
+                  await onPressLaunch();
+                } catch (error) {
+                  console.warn(error);
+                } finally {
+                  setDeviceLaunching(false);
+                }
               }}
-              style={[styles.button]}>
-              Launch
-            </Button>
+              style={styles.button}
+            />
           )}
       </Row>
     </Pressable>

--- a/apps/menu-bar/src/components/DeviceItem.tsx
+++ b/apps/menu-bar/src/components/DeviceItem.tsx
@@ -18,7 +18,7 @@ export const DEVICE_ITEM_HEIGHT = 42;
 interface Props {
   device: Device;
   onPress: () => void;
-  onPressLaunch: () => void;
+  onPressLaunch: () => Promise<void>;
   selected?: boolean;
 }
 
@@ -26,6 +26,7 @@ const DeviceItem = ({device, onPress, onPressLaunch, selected}: Props) => {
   const theme = useExpoTheme();
   const currentTheme = useTheme();
   const [isHovered, setIsHovered] = useState(false);
+  const [isDeviceLaunching, setDeviceLaunching] = useState(false);
 
   return (
     <Pressable
@@ -94,22 +95,35 @@ const DeviceItem = ({device, onPress, onPressLaunch, selected}: Props) => {
         )}
         {device.deviceType !== 'device' && device.state === 'Booted' && (
           <>
-            <Text color="success" style={styles.runIndicator}>
+            <Text color="success" style={styles.indicator}>
               ●
             </Text>
-            <Text color="secondary" style={styles.runIndicator}>
+            <Text color="secondary" style={styles.indicator}>
               {' '}
               Running
             </Text>
           </>
         )}
+        {device.deviceType !== 'device' &&
+          device.state === 'Shutdown' &&
+          isDeviceLaunching && (
+            <Text color="secondary" style={styles.indicator}>
+              Launching…
+            </Text>
+          )}
         {isHovered &&
           device.deviceType !== 'device' &&
-          device.state === 'Shutdown' && (
+          device.state === 'Shutdown' &&
+          !isDeviceLaunching && (
             <Button
+              disabled={isDeviceLaunching}
               color="primary"
-              onPress={onPressLaunch}
-              style={styles.button}>
+              onPress={async () => {
+                setDeviceLaunching(true);
+                await onPressLaunch();
+                setDeviceLaunching(false);
+              }}
+              style={[styles.button]}>
               Launch
             </Button>
           )}
@@ -137,7 +151,7 @@ const styles = StyleSheet.create({
   button: {
     marginLeft: 8,
   },
-  runIndicator: {
+  indicator: {
     fontSize: 11,
   },
 });

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -270,7 +270,9 @@ function Core(props: Props) {
                 device={device}
                 key={device.name}
                 onPress={() => onSelectDevice(device)}
-                onPressLaunch={() => bootDeviceAsync({platform, id})}
+                onPressLaunch={async () => {
+                  await bootDeviceAsync({platform, id});
+                }}
                 selected={selectedDevicesIds[platform] === id}
               />
             );

--- a/apps/menu-bar/src/windows/Onboarding.tsx
+++ b/apps/menu-bar/src/windows/Onboarding.tsx
@@ -74,7 +74,7 @@ const Onboarding = () => {
         />
       </View>
       <View px="large" py="medium">
-        <Button onPress={closeOnboarding}>Get Started</Button>
+        <Button title="Get Started" onPress={closeOnboarding} />
       </View>
     </View>
   );


### PR DESCRIPTION
# Why

It was possible to click "Launch" button multiple time for a device, which lead to restarting the same emulator/simulator and delaying the actual launch.

# How

After first press replace the button with launching label, await for boot command to finish, to hide label.

# Test Plan

The changes have been tested by running Orbit app locally.

# Preview

https://github.com/expo/orbit/assets/719641/78d2e60f-6930-4333-ad1a-5080582a31c9

