### PR TITLE
[menu-bar] Refetch devices list after launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Refetch devices list after launching a simulator. ([#37](https://github.com/expo/orbit/pull/37) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.1.1 — 2023-08-10
 
 ### 🐛 Bug fixes

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -262,7 +262,7 @@ function Core(props: Props) {
               </View>
             );
           }}
-          renderItem={({item: device}) => {
+          renderItem={({item: device}: {item: Device}) => {
             const platform = getDeviceOS(device);
             const id = getDeviceId(device);
             return (
@@ -272,6 +272,7 @@ function Core(props: Props) {
                 onPress={() => onSelectDevice(device)}
                 onPressLaunch={async () => {
                   await bootDeviceAsync({platform, id});
+                  refetch();
                 }}
                 selected={selectedDevicesIds[platform] === id}
               />


### PR DESCRIPTION
# Why

To ensure we always keep the devices list up to date we should refetch the devices list after launching 

# How

Add a refetch call after finishing launching a device

# Test Plan
 

https://github.com/expo/orbit/assets/11707729/14947a1c-db7a-471e-9c73-b9d66465dbb4

