### PR TITLE
[menu-bar] Add alert when trying to install build with no available devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### 💡 Others
 
 - Refetch devices list after launching a simulator. ([#37](https://github.com/expo/orbit/pull/37) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improve Popover height estimations. ([#38](https://github.com/expo/orbit/pull/38) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add alert when trying to install build with no available device. ([#38](https://github.com/expo/orbit/pull/38) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.1.1 — 2023-08-10
 

--- a/apps/menu-bar/src/popover/SectionHeader.tsx
+++ b/apps/menu-bar/src/popover/SectionHeader.tsx
@@ -1,7 +1,9 @@
 import React, {memo} from 'react';
 
-import {Text} from '../components';
+import {Text, View} from '../components';
 import {useTheme} from '../providers/ThemeProvider';
+
+export const SECTION_HEADER_HEIGHT = 20;
 
 type Props = {
   label: string;
@@ -10,15 +12,17 @@ type Props = {
 const SectionHeader = ({label}: Props) => {
   const theme = useTheme();
   return (
-    <Text
-      weight="semibold"
-      size="tiny"
-      color="default"
-      // @ts-ignore
-      // eslint-disable-next-line react-native/no-inline-styles
-      style={{opacity: theme === 'dark' ? 0.65 : 0.85}}>
-      {label}
-    </Text>
+    <View px="medium">
+      <Text
+        weight="semibold"
+        size="tiny"
+        color="default"
+        // @ts-ignore
+        // eslint-disable-next-line react-native/no-inline-styles
+        style={{opacity: theme === 'dark' ? 0.65 : 0.85}}>
+        {label}
+      </Text>
+    </View>
   );
 };
 


### PR DESCRIPTION
# Why

Minor adjustments to the UI to improve the user experience

# How

- Show an alert if there are no available devices when trying to launch a build from EAS
- Improve Popover height estimations

# Test Plan

<img width="452" alt="image" src="https://github.com/expo/orbit/assets/11707729/ada31a25-93c5-41bd-b0bb-260fb8b9e3eb">

