### PR TITLE
[menu-bar] Fix CLI resource name on x64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed listing devices on Intel machines. ([#39](https://github.com/expo/orbit/pull/39) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Refetch devices list after launching a simulator. ([#37](https://github.com/expo/orbit/pull/37) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
@@ -111,7 +111,7 @@ NSString *getMachineHardwareName(void) {
 
 NSString *getCliResourceNameForArch(void) {
     NSString *arch = getMachineHardwareName();
-    if([arch compare:@"arm64"]){
+    if([arch isEqualToString:@"arm64"]){
       return @"orbit-cli-arm64";
     }
 


### PR DESCRIPTION
# Why

Intel Mac users are currently unable to list-devices and launch builds due to an incorrect string comparison to resolve the cli resource name 

# How

Update `getCliResourceNameForArch` method to use `isEqualToString` 

# Test Plan

Run Orbit in an x64 Intel machine and ensure communication between the menu-bar and cli is working as expected 