### PR TITLE
[menu-bar] remove no longer needed spacing from Builds header

### DIFF
--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -226,7 +226,7 @@ function Core(props: Props) {
   return (
     <View shrink="1">
       <View style={{height: BUILDS_SECTION_HEIGHT}}>
-        <View px="medium" pt="2.5" pb="tiny">
+        <View pt="2.5" pb="tiny">
           <SectionHeader label="Builds" />
         </View>
         {status === Status.LISTENING ? (


### PR DESCRIPTION
# Why

<img width="452" alt="Screenshot 2023-08-16 at 19 37 01" src="https://github.com/expo/orbit/assets/719641/021c6628-9b3b-41c2-b4cd-c99f95bca5e9">

# How

Remove no longer needed horizontal spacing for the "Builds" header after latest layout/wrapper changes.

# Test Plan

Change has been reviewed by building and running Orbit locally.

# Preview

<img width="452" alt="Screenshot 2023-08-16 at 19 43 27" src="https://github.com/expo/orbit/assets/719641/5f9f51a2-19a6-4dd0-a357-677ece3b7adc">

