### PR TITLE
[menu-bar] Add WebAuthenticationSession module

### DIFF
--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/WebAuthenticationSession.h
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/WebAuthenticationSession.h
@@ -1,0 +1,4 @@
+#import <React/RCTBridgeModule.h>
+
+@interface WebAuthenticationSession : NSObject <RCTBridgeModule>
+@end

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/WebAuthenticationSession.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/WebAuthenticationSession.m
@@ -1,0 +1,53 @@
+#import "WebAuthenticationSession.h"
+#import <React/RCTLog.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+
+@interface WebAuthenticationSession () <ASWebAuthenticationPresentationContextProviding>
+
+@property (nonatomic, strong) ASWebAuthenticationSession *authSession;
+
+@end
+
+@implementation WebAuthenticationSession
+
+RCT_EXPORT_MODULE();
+
+RCT_EXPORT_METHOD(openAuthSessionAsync:(NSString *)urlString
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  self.authSession = [[ASWebAuthenticationSession alloc]
+                      initWithURL:url
+                      callbackURLScheme:@"expo-orbit"
+                      completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
+    if (error) {
+      reject(@"AUTH_SESSION_ERROR", [error localizedDescription], error);
+    } else {
+      if(callbackURL){
+        resolve(@{@"type": @"success", @"url": callbackURL.absoluteString});
+      } else {
+        resolve(@{@"type": @"cancel"});
+      }
+    }
+  }];
+
+  if (@available(macOS 10.15, *)) {
+    self.authSession.presentationContextProvider = self;
+    [self.authSession start];
+  }
+}
+
+#pragma mark - ASWebAuthenticationPresentationContextProviding
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session API_AVAILABLE(macos(10.15)) {
+  __block ASPresentationAnchor anchor = nil;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    anchor = [NSApp mainWindow];
+  });
+  return anchor;
+}
+
+@end

--- a/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
+++ b/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		C0271C5B2A602FF60065AB11 /* ProgressIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = C0271C5A2A602FF60065AB11 /* ProgressIndicatorView.m */; };
 		C032EDB72A1FE6F300FBC597 /* orbit-cli-arm64 in Resources */ = {isa = PBXBuildFile; fileRef = C032EDB62A1FE6F300FBC597 /* orbit-cli-arm64 */; };
 		C051E6B62A83577800C6D615 /* orbit-cli-x64 in Resources */ = {isa = PBXBuildFile; fileRef = C051E6B52A83577800C6D615 /* orbit-cli-x64 */; };
+		C051E6BB2A991C4200C6D615 /* WebAuthenticationSession.m in Sources */ = {isa = PBXBuildFile; fileRef = C051E6BA2A991C4200C6D615 /* WebAuthenticationSession.m */; };
 		C0523ECA2A545730003371AF /* FilePicker.m in Sources */ = {isa = PBXBuildFile; fileRef = C0523EC92A545730003371AF /* FilePicker.m */; };
 		C0523ECC2A550983003371AF /* WindowManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C0523ECB2A550983003371AF /* WindowManager.m */; };
 		C0523ED02A55980D003371AF /* WindowWithDeallocCallback.m in Sources */ = {isa = PBXBuildFile; fileRef = C0523ECF2A55980D003371AF /* WindowWithDeallocCallback.m */; };
@@ -70,6 +71,8 @@
 		C051E6B32A83408800C6D615 /* ExpoMenuBar-macOSRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ExpoMenuBar-macOSRelease.entitlements"; sourceTree = "<group>"; };
 		C051E6B42A8340AF00C6D615 /* AutoLauncherRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AutoLauncherRelease.entitlements; sourceTree = "<group>"; };
 		C051E6B52A83577800C6D615 /* orbit-cli-x64 */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = "orbit-cli-x64"; path = "../../cli/orbit-cli-x64"; sourceTree = "<group>"; };
+		C051E6B92A991C0A00C6D615 /* WebAuthenticationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebAuthenticationSession.h; sourceTree = "<group>"; };
+		C051E6BA2A991C4200C6D615 /* WebAuthenticationSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WebAuthenticationSession.m; sourceTree = "<group>"; };
 		C0523EC82A54571F003371AF /* FilePicker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FilePicker.h; sourceTree = "<group>"; };
 		C0523EC92A545730003371AF /* FilePicker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FilePicker.m; sourceTree = "<group>"; };
 		C0523ECB2A550983003371AF /* WindowManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WindowManager.m; sourceTree = "<group>"; };
@@ -191,6 +194,8 @@
 				C0271C572A602CDE0065AB11 /* ProgressIndicatorManager.m */,
 				C0271C592A602FEC0065AB11 /* ProgressIndicatorView.h */,
 				C0271C5A2A602FF60065AB11 /* ProgressIndicatorView.m */,
+				C051E6B92A991C0A00C6D615 /* WebAuthenticationSession.h */,
+				C051E6BA2A991C4200C6D615 /* WebAuthenticationSession.m */,
 			);
 			path = "ExpoMenuBar-macOS";
 			sourceTree = "<group>";
@@ -457,6 +462,7 @@
 				C0B36EA32A65E25A004F2D8C /* CheckboxManager.m in Sources */,
 				C0E7CF482A15378D00C59DE5 /* MenuBarModule.m in Sources */,
 				C0271C5B2A602FF60065AB11 /* ProgressIndicatorView.m in Sources */,
+				C051E6BB2A991C4200C6D615 /* WebAuthenticationSession.m in Sources */,
 				C0523ECC2A550983003371AF /* WindowManager.m in Sources */,
 				514201582437B4B40078DB4F /* main.m in Sources */,
 				5142014D2437B4B30078DB4F /* AppDelegate.m in Sources */,

--- a/apps/menu-bar/src/modules/WebAuthenticationSessionModule.ts
+++ b/apps/menu-bar/src/modules/WebAuthenticationSessionModule.ts
@@ -1,4 +1,4 @@
-import {NativeModule, NativeModules} from 'react-native';
+import { NativeModules } from 'react-native';
 
 export enum WebBrowserResultType {
   CANCEL = 'cancel',
@@ -14,11 +14,11 @@ export type WebBrowserResult =
       url: string;
     };
 
-type WebAuthenticationSessionModule = {
+type WebAuthenticationSessionModuleType = {
   openAuthSessionAsync: (url: string) => Promise<WebBrowserResult>;
 };
 
-const WebAuthenticationSessionModule: WebAuthenticationSessionModule =
+const WebAuthenticationSessionModule: WebAuthenticationSessionModuleType =
   NativeModules.WebAuthenticationSession;
 
 export default WebAuthenticationSessionModule;

--- a/apps/menu-bar/src/modules/WebAuthenticationSessionModule.ts
+++ b/apps/menu-bar/src/modules/WebAuthenticationSessionModule.ts
@@ -1,0 +1,24 @@
+import {NativeModule, NativeModules} from 'react-native';
+
+export enum WebBrowserResultType {
+  CANCEL = 'cancel',
+  SUCCESS = 'success',
+}
+
+export type WebBrowserResult =
+  | {
+      type: WebBrowserResultType.CANCEL;
+    }
+  | {
+      type: WebBrowserResultType.SUCCESS;
+      url: string;
+    };
+
+type WebAuthenticationSessionModule = {
+  openAuthSessionAsync: (url: string) => Promise<WebBrowserResult>;
+};
+
+const WebAuthenticationSessionModule: WebAuthenticationSessionModule =
+  NativeModules.WebAuthenticationSession;
+
+export default WebAuthenticationSessionModule;


### PR DESCRIPTION
# Why

Part 1 of a series of PRs to allow users to log in to their Expo accounts from Orbit
 
Closes ENG-9875

# How

This introduces a new `WebAuthenticationSession` native module that uses `ASWebAuthenticationSession` to do the OAuth flow in the same way Expo Go and dev-client authenticate on iOS 

# Test Plan


https://github.com/expo/orbit/assets/11707729/5115fed8-b1cc-4a6b-9542-6f0767f9d31a


