### PR TITLE
[menu-bar] Add custom prompt support to FilePicker module

### DIFF
--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/FilePicker.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/FilePicker.m
@@ -7,12 +7,16 @@
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(pickFileWithFilenameExtension:(NSArray<NSString *> *)filenameExtensions
+                  prompt:(NSString *)prompt
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
     [NSApp activateIgnoringOtherApps:YES];
     NSOpenPanel *panel = [NSOpenPanel openPanel];
+    if(prompt){
+      [panel setPrompt:prompt]; 
+    }
     [panel setAllowsMultipleSelection:NO];
     [panel setCanChooseDirectories:YES];
     [panel setCanCreateDirectories:YES];

--- a/apps/menu-bar/src/modules/FilePickerModule.ts
+++ b/apps/menu-bar/src/modules/FilePickerModule.ts
@@ -10,7 +10,10 @@ const FilePickerModule: FilePickerModuleType = NativeModules.FilePicker;
 export default {
   ...FilePickerModule,
   getAppAsync: () => {
-    return FilePickerModule.pickFileWithFilenameExtension(['apk', 'app', 'gzip', 'ipa', 'tar']);
+    return FilePickerModule.pickFileWithFilenameExtension(
+      ['apk', 'app', 'gzip', 'ipa', 'tar'],
+      'Select'
+    );
   },
   pickFolder: async () => FilePickerModule.pickFolder(),
 };

--- a/apps/menu-bar/src/modules/FilePickerModule.ts
+++ b/apps/menu-bar/src/modules/FilePickerModule.ts
@@ -1,7 +1,7 @@
 import { NativeModule, NativeModules } from 'react-native';
 
 type FilePickerModuleType = NativeModule & {
-  pickFileWithFilenameExtension: (extensions: string[]) => Promise<string>;
+  pickFileWithFilenameExtension: (extensions: string[], prompt?: string) => Promise<string>;
   pickFolder: () => Promise<string>;
 };
 


### PR DESCRIPTION
# Why

Close ENG-9947

# How

Add a new parameter to `pickFileWithFilenameExtension` so we can show the "Select"/"Install" text in the NSOpenPanel button 

# Test Plan

<img width="912" alt="image" src="https://github.com/expo/orbit/assets/11707729/f235afc8-a42a-4348-ad6d-0c15c2158ff2">

