### PR TITLE
[menu-bar] Fix WindowNavigator size calculations when showing an existing window

### DIFF
--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/WindowNavigator.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/WindowNavigator.m
@@ -60,9 +60,10 @@
       [self->_windowsMap setObject:newWindow forKey:moduleName];
       window = newWindow;
     }else{
-      NSRect currentFrame = [window frame];
-      if(currentFrame.size.width != width || currentFrame.size.height != height){
-        NSRect newFrame = NSMakeRect(originX, originY, width, height);
+      NSRect contentRect = [window contentRectForFrameRect:[window frame]];
+      if(contentRect.size.width != width || contentRect.size.height != height){
+        CGFloat titleBarHeight = [window frame].size.height - contentRect.size.height;
+        NSRect newFrame = NSMakeRect(originX, originY, width, height + titleBarHeight);
         [window setFrame:newFrame display:YES];
       }
     }

--- a/apps/menu-bar/src/windows/index.ts
+++ b/apps/menu-bar/src/windows/index.ts
@@ -11,8 +11,8 @@ export const WindowsNavigator = createWindowsNavigator({
         // eslint-disable-next-line no-bitwise
         mask: WindowStyleMask.Titled | WindowStyleMask.Closable,
         titlebarAppearsTransparent: true,
-        height: 275,
-        width: 400,
+        height: 352,
+        width: 500,
       },
     },
   },


### PR DESCRIPTION
# Why

Closes ENG-9954

# How

Instead of directly reading width and height from `[window frame]` we should use `contentRectForFrameRect` in order to get the actual height of the windows (without including the title bar) and prevent always resizing 

# Test Plan



https://github.com/expo/orbit/assets/11707729/9fa241d7-1459-44b6-8612-588d4d8e4d53


