### PR TITLE
[github] Add check for missing changelogs

### DIFF
--- a/.github/workflows/lint-and-tsc.yml
+++ b/.github/workflows/lint-and-tsc.yml
@@ -1,4 +1,4 @@
-name: Lint and TSC
+name: Lint, TSC and Changelog checker
 
 on:
   push:
@@ -9,6 +9,11 @@ on:
       - packages/**
       - ts-declarations/**
   pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths:
       - .github/workflows/lint-and-tsc.yml
       - apps/**
@@ -51,3 +56,9 @@ jobs:
       - name: 🏗️ TSC "CLI" app files
         run: yarn tsc --noEmit
         working-directory: apps/cli
+
+      - name: Check CHANGELOG entry
+        uses: dangoslen/changelog-enforcer@v3.2.0
+        with:
+          skipLabels: "skip-changelog-check"
+          missingUpdateErrorMessage: "Your changes should be noted in the changelog. Read [Updating Changelogs](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelogs.md) guide and consider adding an appropriate entry."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add check for missing changelogs. ([#49](https://github.com/expo/orbit/pull/49) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 0.1.2 — 2023-08-13
 
 ### 🎉 New features


### PR DESCRIPTION
# Why

To help us remember to always keep the changelog file up to date we should add an action that checks all PRs for changes on CHANGELOG.md

# How


This PR uses the [changelog-enforcer](https://github.com/dangoslen/changelog-enforcer) action to enforce that every pull request in this repo includes a change to the changelog file. When necessary this check can be skipped by adding the `skip-changelog-check` label to the PR

# Test Plan

Don't change the changelog and check if the action fails
