### PR TITLE
[menu-bar] Terminate Auto Launcher after launching main Orbit application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent the AutoLauncher process from running in the background after launching the main app. ([#51](https://github.com/expo/orbit/pull/51) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Add check for missing changelogs. ([#49](https://github.com/expo/orbit/pull/49) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/macos/AutoLauncher/AppDelegate.swift
+++ b/apps/menu-bar/macos/AutoLauncher/AppDelegate.swift
@@ -8,25 +8,28 @@
 import Cocoa
 
 class AutoLauncherAppDelegate: NSObject, NSApplicationDelegate {
+  struct Constants {
+    static let menuBarBundleID = "dev.expo.orbit"
+  }
 
-    struct Constants {
-        static let menuBarBundleID = "dev.expo.orbit"
+  func applicationDidFinishLaunching(_ aNotification: Notification) {
+    let runningApps = NSWorkspace.shared.runningApplications
+    let isRunning = runningApps.contains {
+      $0.bundleIdentifier == Constants.menuBarBundleID
     }
 
-    func applicationDidFinishLaunching(_ aNotification: Notification) {
-        let runningApps = NSWorkspace.shared.runningApplications
-        let isRunning = runningApps.contains {
-            $0.bundleIdentifier == Constants.menuBarBundleID
+    if !isRunning, let mainAppURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: Constants.menuBarBundleID) {
+      NSWorkspace.shared.openApplication(at: mainAppURL, configuration: NSWorkspace.OpenConfiguration()) { (_, error) in
+        if let error = error {
+          print("Error opening Expo Orbit: \(error)")
         }
-
-        if !isRunning {
-          guard let mainAppURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: Constants.menuBarBundleID) else { return }
-          
-          NSWorkspace.shared.openApplication(at: mainAppURL,
-                                             configuration: NSWorkspace.OpenConfiguration(),
-                                             completionHandler: nil
-          )
+        
+        DispatchQueue.main.async {
+          NSApp.terminate(nil)
         }
+      }
+    } else {
+      NSApp.terminate(nil)
     }
-
+  }
 }


### PR DESCRIPTION
# Why

Closes ENG-9963

# How

The AutoLauncher process should be terminated after successfully launching Orbit otherwise users will see the AutoLauncher process in their Action Monitor running all the time, even after closing Orbit, which sounds dodgy.

# Test Plan

Build using the AutoLauncher scheme and ensure Orbit is launched and the AutoLauncher process is terminated

https://github.com/expo/orbit/assets/11707729/bfbb6a39-42a4-4bc4-a243-712d55427919

