### PR TITLE
[menu-bar] Add CORS headers to local HTTP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52), [#53](https://github.com/expo/orbit/pull/53) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Show dock icon while windows are opened. ([#50](https://github.com/expo/orbit/pull/50) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

Closes ENG-9945
Follow up of #52

# How

Unfortunately, the most recent version of [Swifter](https://github.com/httpswift/swifter), v1.5.0, does not yet support custom headers when using the default `.ok` `HttpResponse`, because of that we need to use the `.raw` response in order to pass the custom `Access-Control-Allow-Origin` header. This PR also adds `exp.host` (used by Snack) to the list of allowed domains 

# Test Plan

Tested fetching the local server from the website 
