### PR TITLE
[menu-bar] Fix local server query params decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52), [#53](https://github.com/expo/orbit/pull/53) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52), [#53](https://github.com/expo/orbit/pull/53), [#54](https://github.com/expo/orbit/pull/54) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Show dock icon while windows are opened. ([#50](https://github.com/expo/orbit/pull/50) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
@@ -75,7 +75,7 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host"]
   }
 
   private func extractRootDomain(from urlString: String) -> String {
-    guard let originUrl = URL(string: urlString),
+    guard let originUrl = URL(string: urlString.removingPercentEncoding ?? ""),
           let hostName = originUrl.host else {
       return ""
     }


### PR DESCRIPTION
# Why

Closes ENG-9945

# How

Properly parse query params by removing the percent-encoding before checking the root domain of the URL

# Test Plan

Fetch the `orbit/open` from the website and ensure everything is working as expected 
