### PR TITLE
[menu-bar] Add support for installing apps from Finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 
 ### 🎉 New features
 
+- Added support for installing apps directly from Finder. ([#56](https://github.com/expo/orbit/pull/56) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52), [#53](https://github.com/expo/orbit/pull/53), [#54](https://github.com/expo/orbit/pull/54), [#55](https://github.com/expo/orbit/pull/55) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Show dock icon while windows are opened. ([#50](https://github.com/expo/orbit/pull/50) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add Projects section to the menu bar. ([#46](https://github.com/expo/orbit/pull/46) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add support for login to Expo. ([#41](https://github.com/expo/orbit/pull/41), [#43](https://github.com/expo/orbit/pull/43), [#44](https://github.com/expo/orbit/pull/44), [#45](https://github.com/expo/orbit/pull/45) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added Projects section to the menu bar. ([#46](https://github.com/expo/orbit/pull/46) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added support for login to Expo. ([#41](https://github.com/expo/orbit/pull/41), [#43](https://github.com/expo/orbit/pull/43), [#44](https://github.com/expo/orbit/pull/44), [#45](https://github.com/expo/orbit/pull/45) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.m
@@ -7,6 +7,7 @@
 
 #import "DevViewController.h"
 #import "WindowNavigator.h"
+#import "FileHandler.h"
 #import "Expo_Orbit-Swift.h"
 
 
@@ -60,8 +61,15 @@
   #endif
 #endif
   [NSApp activateIgnoringOtherApps:YES];
-  
-  httpServer = [[SwifterWrapper alloc] init]; 
+
+  httpServer = [[SwifterWrapper alloc] init];
+}
+
+- (BOOL)application:(NSApplication *)_ openFile:(NSString *)filename
+{
+  [self openPopover];
+  [[FileHandler shared] notifyFileOpened:filename];
+  return  YES;
 }
 
 - (NSMenu *)createContextMenu {

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandler.h
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandler.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+@interface FileHandler : NSObject
+
+@property (class, nonatomic, readonly) FileHandler * _Nullable shared;
+@property (nonatomic, copy, nullable) void (^sendOnOpenFileEvent)(NSString * _Nullable filename);
+
+- (void)notifyFileOpened:(NSString *_Nonnull)filename;
+
+@end
+

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandler.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandler.m
@@ -1,0 +1,23 @@
+#import <Cocoa/Cocoa.h>
+#import <React/RCTRootView.h>
+
+#import "FileHandler.h"
+
+@implementation FileHandler
+
++ (instancetype)shared {
+    static FileHandler *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+    });
+    return sharedInstance;
+}
+
+- (void)notifyFileOpened:(NSString *)filename {
+    if (self.sendOnOpenFileEvent) {
+        self.sendOnOpenFileEvent(filename);
+    }
+}
+
+@end

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandlerManager.h
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandlerManager.h
@@ -1,0 +1,10 @@
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+
+#import "FileHandler.h"
+
+@interface FileHandlerManager : RCTEventEmitter <RCTBridgeModule>
+  @property (nonatomic) BOOL hasListeners;
+  @property (nonatomic, strong) FileHandler *handler;
+@end
+

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandlerManager.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/FileHandlerManager.m
@@ -1,0 +1,47 @@
+#import <Cocoa/Cocoa.h>
+#import <React/RCTRootView.h>
+
+#import "FileHandlerManager.h"
+#import "FileHandler.h"
+
+@implementation FileHandlerManager
+
+RCT_EXPORT_MODULE();
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.handler = [FileHandler shared];
+    
+    __weak typeof(self) weakSelf = self;
+    self.handler.sendOnOpenFileEvent = ^(NSString *filename) {
+      [weakSelf sendOnOpenFileEvent:filename];
+    };
+  }
+  return self;
+}
+
+- (void)sendOnOpenFileEvent:(NSString*) filename {
+  if (_hasListeners) {
+    [self sendEventWithName:@"onOpenFile" body:filename];
+  }
+}
+
+- (void)startObserving {
+  _hasListeners = YES;
+}
+
+- (void)stopObserving {
+  _hasListeners = NO;
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[@"onOpenFile"];
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
+@end

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/Info.plist
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/Info.plist
@@ -6,6 +6,45 @@
 	<string>fonts</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+			<dict>
+					<key>CFBundleTypeExtensions</key>
+					<array>
+							<string>apk</string>
+					</array>
+					<key>CFBundleTypeName</key>
+					<string>APK</string>
+					<key>CFBundleTypeRole</key>
+					<string>Viewer</string>
+					<key>LSHandlerRank</key>
+					<string>Alternate</string>
+			</dict>
+			<dict>
+					<key>CFBundleTypeExtensions</key>
+					<array>
+							<string>ipa</string>
+					</array>
+					<key>CFBundleTypeName</key>
+					<string>IPA</string>
+					<key>CFBundleTypeRole</key>
+					<string>Viewer</string>
+					<key>LSHandlerRank</key>
+					<string>Alternate</string>
+			</dict>
+			<dict>
+					<key>LSItemContentTypes</key>
+					<array>
+							<string>org.gnu.gnu-zip-archive</string>
+					</array>
+					<key>CFBundleTypeName</key>
+					<string>tar.gz</string>
+					<key>CFBundleTypeRole</key>
+					<string>Viewer</string>
+					<key>LSHandlerRank</key>
+					<string>Alternate</string>
+			</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>

--- a/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
+++ b/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		C061C7A12A26B21C00A53D8D /* AutoResizerRootViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C061C7A02A26B21C00A53D8D /* AutoResizerRootViewManager.m */; };
 		C061C7A42A26B50200A53D8D /* AutoResizerRootView.m in Sources */ = {isa = PBXBuildFile; fileRef = C061C7A32A26B50200A53D8D /* AutoResizerRootView.m */; };
 		C061C7A82A26DD9A00A53D8D /* SystemIconViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C061C7A72A26DD9A00A53D8D /* SystemIconViewManager.m */; };
+		C06B8F8A2AAA9024009F2BB5 /* FileHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C06B8F892AAA9024009F2BB5 /* FileHandler.m */; };
+		C06B8F8D2AAA9058009F2BB5 /* FileHandlerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C06B8F8C2AAA9058009F2BB5 /* FileHandlerManager.m */; };
 		C081507F2A610E9C00E8890F /* fonts in Resources */ = {isa = PBXBuildFile; fileRef = C081507E2A610E9C00E8890F /* fonts */; };
 		C08E65212A5C411D0079E3A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08E65202A5C411D0079E3A9 /* AppDelegate.swift */; };
 		C08E652E2A5C42950079E3A9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08E652D2A5C42950079E3A9 /* main.swift */; };
@@ -92,6 +94,10 @@
 		C061C7A62A26DD8C00A53D8D /* SystemIconViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemIconViewManager.h; sourceTree = "<group>"; };
 		C061C7A72A26DD9A00A53D8D /* SystemIconViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SystemIconViewManager.m; sourceTree = "<group>"; };
 		C061C7A92A26EDB800A53D8D /* RCTImageView+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "RCTImageView+Private.h"; sourceTree = "<group>"; };
+		C06B8F892AAA9024009F2BB5 /* FileHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FileHandler.m; sourceTree = "<group>"; };
+		C06B8F8B2AAA9032009F2BB5 /* FileHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileHandler.h; sourceTree = "<group>"; };
+		C06B8F8C2AAA9058009F2BB5 /* FileHandlerManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FileHandlerManager.m; sourceTree = "<group>"; };
+		C06B8F8E2AAA906A009F2BB5 /* FileHandlerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileHandlerManager.h; sourceTree = "<group>"; };
 		C081507E2A610E9C00E8890F /* fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fonts; path = ../../src/assets/fonts; sourceTree = "<group>"; };
 		C08E651E2A5C411D0079E3A9 /* AutoLauncher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AutoLauncher.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C08E65202A5C411D0079E3A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -201,6 +207,10 @@
 				C051E6BA2A991C4200C6D615 /* WebAuthenticationSession.m */,
 				C051EC0D2AA227C600C6D615 /* SwifterWrapper.swift */,
 				C051EC0C2AA227C600C6D615 /* ExpoMenuBar-macOS-Bridging-Header.h */,
+				C06B8F892AAA9024009F2BB5 /* FileHandler.m */,
+				C06B8F8B2AAA9032009F2BB5 /* FileHandler.h */,
+				C06B8F8C2AAA9058009F2BB5 /* FileHandlerManager.m */,
+				C06B8F8E2AAA906A009F2BB5 /* FileHandlerManager.h */,
 			);
 			path = "ExpoMenuBar-macOS";
 			sourceTree = "<group>";
@@ -462,10 +472,12 @@
 			files = (
 				C0B36EA22A65E25A004F2D8C /* Checkbox.m in Sources */,
 				C061C7A82A26DD9A00A53D8D /* SystemIconViewManager.m in Sources */,
+				C06B8F8A2AAA9024009F2BB5 /* FileHandler.m in Sources */,
 				C0523ED02A55980D003371AF /* WindowWithDeallocCallback.m in Sources */,
 				C0271C582A602CDE0065AB11 /* ProgressIndicatorManager.m in Sources */,
 				C0B36EA32A65E25A004F2D8C /* CheckboxManager.m in Sources */,
 				C0E7CF482A15378D00C59DE5 /* MenuBarModule.m in Sources */,
+				C06B8F8D2AAA9058009F2BB5 /* FileHandlerManager.m in Sources */,
 				C0271C5B2A602FF60065AB11 /* ProgressIndicatorView.m in Sources */,
 				C051EC0E2AA227C600C6D615 /* SwifterWrapper.swift in Sources */,
 				C051E6BB2A991C4200C6D615 /* WebAuthenticationSession.m in Sources */,
@@ -517,10 +529,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Expo Orbit";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_CFLAGS = "$(inherited)  ";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -552,10 +561,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Expo Orbit";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_CFLAGS = "$(inherited)  ";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/apps/menu-bar/src/modules/FileHandlerModule.ts
+++ b/apps/menu-bar/src/modules/FileHandlerModule.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { NativeEventEmitter, NativeModules } from 'react-native';
+
+const FileHandlerManager = NativeModules.FileHandlerManager;
+const emitter = new NativeEventEmitter(FileHandlerManager);
+
+type UseFileHandlerParams = {
+  onOpenFile: (path: string) => void;
+};
+
+export const useFileHandler = ({ onOpenFile }: UseFileHandlerParams) => {
+  useEffect(() => {
+    const listener = emitter.addListener('onOpenFile', (path: string) => {
+      onOpenFile(path);
+    });
+
+    return listener.remove;
+  }, [onOpenFile]);
+};


### PR DESCRIPTION
# Why

Closes ENG-10029

# How

- Update Info.plist to include document type definitions for APKs, IPAs and tar.gz files and added a new FileHandler module to dispatch the openFile event to the JS side 
- Refactor Core component logic to download and install apps

# Test Plan


https://github.com/expo/orbit/assets/11707729/6ce60441-caae-44bc-9805-45fcb6c0febe


