### PR TITLE
[menu-bar] Add drag and drop support to menu bar icon 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Added drag and drop support for installing apps. ([#57](https://github.com/expo/orbit/pull/57) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added support for installing apps directly from Finder. ([#56](https://github.com/expo/orbit/pull/56) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52), [#53](https://github.com/expo/orbit/pull/53), [#54](https://github.com/expo/orbit/pull/54), [#55](https://github.com/expo/orbit/pull/55) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Show dock icon while windows are opened. ([#50](https://github.com/expo/orbit/pull/50) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.m
@@ -9,6 +9,7 @@
 #import "WindowNavigator.h"
 #import "FileHandler.h"
 #import "Expo_Orbit-Swift.h"
+#import "DragDropStatusItemView.h"
 
 
 @interface AppDelegate () <RCTBridgeDelegate>
@@ -28,9 +29,11 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
   statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
-  NSImage *image = [NSImage imageNamed:@"menu-bar-icon"];
-  [image setTemplate:YES];
-  statusItem.button.image = image;
+  DragDropStatusItemView *dragDropView = [[DragDropStatusItemView alloc] initWithFrame:NSMakeRect(0, 0, 22, 22)];
+   dragDropView.openPopoverAction = ^{
+     [self openPopover];
+   };
+  [statusItem.button addSubview:dragDropView];
   [statusItem.button setTarget:self];
   [statusItem.button sendActionOn:NSEventMaskRightMouseUp | NSEventMaskLeftMouseUp];
   [statusItem.button setAction:@selector(onPressStatusItem:)];

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/DragDropStatusItemView.h
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/DragDropStatusItemView.h
@@ -1,0 +1,8 @@
+#import <Cocoa/Cocoa.h>
+
+@interface DragDropStatusItemView : NSView <NSDraggingSource, NSDraggingDestination>
+
+@property (nonatomic, copy) void (^openPopoverAction)(void);
+- (instancetype)initWithFrame:(NSRect)frame;
+
+@end

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/DragDropStatusItemView.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/DragDropStatusItemView.m
@@ -1,0 +1,60 @@
+// DragDropStatusItemView.m
+#import <Cocoa/Cocoa.h>
+
+#import "DragDropStatusItemView.h"
+#import "FileHandler.h"
+
+@implementation DragDropStatusItemView
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+  self = [super initWithFrame:frameRect];
+  if (self) {
+    [self registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
+
+    NSImage *image = [NSImage imageNamed:@"menu-bar-icon"];
+    [image setTemplate:YES];
+
+    NSImageView *imageView = [[NSImageView alloc] initWithFrame:self.bounds];
+    [imageView setImage:image];
+    [imageView setImageAlignment:NSImageAlignCenter];
+    [imageView setImageScaling:NSImageScaleProportionallyDown];
+    [imageView unregisterDraggedTypes];
+    [self addSubview:imageView];
+  }
+  return self;
+}
+
+
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
+  NSPasteboard *pasteboard = [sender draggingPasteboard];
+  NSArray<NSURL*> *files = [pasteboard readObjectsForClasses:@[[NSURL class]] options:@{}];
+  NSArray<NSString *> *allowedExtensions = @[@"apk", @"ipa", @"app", @"gz"];
+
+  for (NSURL *url in files)
+  {
+    NSString *fileExtension = [url pathExtension];
+    if (![allowedExtensions containsObject:[fileExtension lowercaseString]]) {
+      return NSDragOperationNone;
+    }
+  }
+
+  return NSDragOperationCopy;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender {
+  if (self.openPopoverAction) {
+    self.openPopoverAction();
+  }
+  
+  NSPasteboard *pasteboard = [sender draggingPasteboard];
+  NSArray<NSURL*> *files = [pasteboard readObjectsForClasses:@[[NSURL class]] options:@{}];
+  
+  for (NSURL *url in files) {
+    NSString *filePath = [url path];
+    [[FileHandler shared] notifyFileOpened:filePath];
+  }
+
+  return YES;
+}
+
+@end

--- a/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
+++ b/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		C061C7A82A26DD9A00A53D8D /* SystemIconViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C061C7A72A26DD9A00A53D8D /* SystemIconViewManager.m */; };
 		C06B8F8A2AAA9024009F2BB5 /* FileHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = C06B8F892AAA9024009F2BB5 /* FileHandler.m */; };
 		C06B8F8D2AAA9058009F2BB5 /* FileHandlerManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C06B8F8C2AAA9058009F2BB5 /* FileHandlerManager.m */; };
+		C06B8F902AAB77D0009F2BB5 /* DragDropStatusItemView.m in Sources */ = {isa = PBXBuildFile; fileRef = C06B8F8F2AAB77D0009F2BB5 /* DragDropStatusItemView.m */; };
 		C081507F2A610E9C00E8890F /* fonts in Resources */ = {isa = PBXBuildFile; fileRef = C081507E2A610E9C00E8890F /* fonts */; };
 		C08E65212A5C411D0079E3A9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08E65202A5C411D0079E3A9 /* AppDelegate.swift */; };
 		C08E652E2A5C42950079E3A9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08E652D2A5C42950079E3A9 /* main.swift */; };
@@ -98,6 +99,8 @@
 		C06B8F8B2AAA9032009F2BB5 /* FileHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileHandler.h; sourceTree = "<group>"; };
 		C06B8F8C2AAA9058009F2BB5 /* FileHandlerManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FileHandlerManager.m; sourceTree = "<group>"; };
 		C06B8F8E2AAA906A009F2BB5 /* FileHandlerManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FileHandlerManager.h; sourceTree = "<group>"; };
+		C06B8F8F2AAB77D0009F2BB5 /* DragDropStatusItemView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DragDropStatusItemView.m; sourceTree = "<group>"; };
+		C06B8F912AAB77EC009F2BB5 /* DragDropStatusItemView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DragDropStatusItemView.h; sourceTree = "<group>"; };
 		C081507E2A610E9C00E8890F /* fonts */ = {isa = PBXFileReference; lastKnownFileType = folder; name = fonts; path = ../../src/assets/fonts; sourceTree = "<group>"; };
 		C08E651E2A5C411D0079E3A9 /* AutoLauncher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AutoLauncher.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C08E65202A5C411D0079E3A9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -211,6 +214,8 @@
 				C06B8F8B2AAA9032009F2BB5 /* FileHandler.h */,
 				C06B8F8C2AAA9058009F2BB5 /* FileHandlerManager.m */,
 				C06B8F8E2AAA906A009F2BB5 /* FileHandlerManager.h */,
+				C06B8F8F2AAB77D0009F2BB5 /* DragDropStatusItemView.m */,
+				C06B8F912AAB77EC009F2BB5 /* DragDropStatusItemView.h */,
 			);
 			path = "ExpoMenuBar-macOS";
 			sourceTree = "<group>";
@@ -474,6 +479,7 @@
 				C061C7A82A26DD9A00A53D8D /* SystemIconViewManager.m in Sources */,
 				C06B8F8A2AAA9024009F2BB5 /* FileHandler.m in Sources */,
 				C0523ED02A55980D003371AF /* WindowWithDeallocCallback.m in Sources */,
+				C06B8F902AAB77D0009F2BB5 /* DragDropStatusItemView.m in Sources */,
 				C0271C582A602CDE0065AB11 /* ProgressIndicatorManager.m in Sources */,
 				C0B36EA32A65E25A004F2D8C /* CheckboxManager.m in Sources */,
 				C0E7CF482A15378D00C59DE5 /* MenuBarModule.m in Sources */,


### PR DESCRIPTION
# Why

Closes ENG-10049

# How 

Add drag and drop support to the menu bar icon by implementing a custom NSView class with `registerForDraggedTypes` and the associated functions. Currently we only support files using the following extensions: `apk`, `ipa`, `app` and `gz`

# Test Plan

https://github.com/expo/orbit/assets/11707729/6e4862dd-57b7-4473-9c98-4b09c795dd15

