### PR TITLE
[eas-shared] Remove unnecessary dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### 💡 Others
 
 - Add check for missing changelogs. ([#49](https://github.com/expo/orbit/pull/49) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Clean up eas-shared package. ([#60](https://github.com/expo/orbit/pull/60) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.1.2 — 2023-08-13
 

--- a/packages/eas-shared/package.json
+++ b/packages/eas-shared/package.json
@@ -9,7 +9,6 @@
     "typecheck": "tsc"
   },
   "devDependencies": {
-    "@types/cli-progress": "^3.11.0",
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^11.0.1",
     "@types/getenv": "^1.0.0",
@@ -27,11 +26,9 @@
     "@expo/spawn-async": "^1.7.2",
     "axios": "0.27.2",
     "bplist-parser": "^0.3.0",
-    "cli-progress": "^3.12.0",
     "debug": "^4.3.4",
     "env-paths": "2.2.0",
     "exec-async": "2.2.0",
-    "figures": "3.2.0",
     "getenv": "^1.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "2.6.7",
@@ -40,7 +37,6 @@
     "querystring": "0.2.0",
     "semver": "7.3.2",
     "tar": "6.1.13",
-    "terminal-link": "2.1.1",
     "uuid": "9.0.0"
   }
 }

--- a/packages/eas-shared/src/log.ts
+++ b/packages/eas-shared/src/log.ts
@@ -1,8 +1,6 @@
 import chalk from "chalk";
-import figures from "figures";
 import { boolish } from "getenv";
 import logSymbols from "log-symbols";
-import terminalLink from "terminal-link";
 
 type Color = (...text: string[]) => string;
 
@@ -53,10 +51,6 @@ export default class Log {
     Log.log(`${chalk.green(logSymbols.success)} ${message}`);
   }
 
-  public static withTick(...args: any[]): void {
-    Log.consoleLog(chalk.green(figures.tick), ...args);
-  }
-
   private static consoleLog(...args: any[]): void {
     Log.updateIsLastLineNewLine(args);
     // eslint-disable-next-line no-console
@@ -83,47 +77,6 @@ export default class Log {
       }
     }
   }
-}
-
-/**
- * Prints a link for given URL, using text if provided, otherwise text is just the URL.
- * Format links as dim (unless disabled) and with an underline.
- *
- * @example https://expo.dev
- */
-export function link(
-  url: string,
-  {
-    text = url,
-    fallback,
-    dim = true,
-  }: { text?: string; dim?: boolean; fallback?: string } = {}
-): string {
-  // Links can be disabled via env variables https://github.com/jamestalmage/supports-hyperlinks/blob/master/index.js
-  const output = terminalLink(text, url, {
-    fallback: () =>
-      fallback ??
-      (text === url
-        ? chalk.underline(url)
-        : `${text}: ${chalk.underline(url)}`),
-  });
-  return dim ? chalk.dim(output) : output;
-}
-
-/**
- * Provide a consistent "Learn more" link experience.
- * Format links as dim (unless disabled) with an underline.
- *
- * @example Learn more: https://expo.dev
- */
-export function learnMore(
-  url: string,
-  {
-    learnMoreMessage: maybeLearnMoreMessage,
-    dim = true,
-  }: { learnMoreMessage?: string; dim?: boolean } = {}
-): string {
-  return link(url, { text: maybeLearnMoreMessage ?? "Learn more", dim });
 }
 
 export function log(...message: string[]): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,13 +2540,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/cli-progress@^3.11.0":
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/@types/cli-progress/-/cli-progress-3.11.0.tgz#ec79df99b26757c3d1c7170af8422e0fc95eef7e"
-  integrity sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/debug@^4.1.7":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
@@ -3854,13 +3847,6 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-progress@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/cli-progress/-/cli-progress-3.12.0.tgz#807ee14b66bcc086258e444ad0f19e7d42577942"
-  integrity sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==
-  dependencies:
-    string-width "^4.2.3"
-
 cli-spinners@^2.4.0, cli-spinners@^2.5.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.0.tgz#5881d0ad96381e117bbe07ad91f2008fe6ffd8db"
@@ -5157,7 +5143,7 @@ fbjs@^3.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^1.0.35"
 
-figures@3.2.0, figures@^3.0.0:
+figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
@@ -9413,7 +9399,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -9426,14 +9412,6 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
-
-supports-hyperlinks@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
-  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
-  dependencies:
-    has-flag "^4.0.0"
-    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -9525,14 +9503,6 @@ temp@^0.8.4:
   integrity sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==
   dependencies:
     rimraf "~2.6.2"
-
-terminal-link@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
-  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    supports-hyperlinks "^2.0.0"
 
 terser@^5.15.0:
   version "5.17.6"


### PR DESCRIPTION
# Why

Close ENG-10132

When copying part of the code from `eas-cli` and `expo-cli` we ended up adding some unnecessary dependencies

# How

Remove unnecessary dependencies

# Test Plan

build `eas-shared` and `cli` and run menu-bar locally 
