### PR TITLE
[menu-bar] Improve performance when running cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Improved performance when running `cli` commands. ([#61](https://github.com/expo/orbit/pull/61) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added drag and drop support for installing apps. ([#57](https://github.com/expo/orbit/pull/57) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added support for installing apps directly from Finder. ([#56](https://github.com/expo/orbit/pull/56) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added local HTTP server to circumvent deep-link limitations. ([#52](https://github.com/expo/orbit/pull/52), [#53](https://github.com/expo/orbit/pull/53), [#54](https://github.com/expo/orbit/pull/54), [#55](https://github.com/expo/orbit/pull/55) by [@gabrieldonadel](https://github.com/gabrieldonadel))


### PR DESCRIPTION
# Why

Closes ENG-10052

# How

To improve the performance of the `runCommand` method, this PR introduces the following optimizations:

-  Remove `[task waitUntilExit]`, which blocks the main thread until the task is completed and use `setReadabilityHandler` and `setTerminationHandler`instead of relying on NSNotificationCenter for updates to allow asynchronous execution.

- Move the NSTask execution and reading of output to a background queue

- Use NSMutableString to avoid String concatenation on every update
 

# Test Plan

Use Xcode Instruments to profile CPU usage

Before
<img width="1035" alt="image" src="https://github.com/expo/orbit/assets/11707729/df9cfa24-a28f-468f-81f1-fd9c91e3dec7">


After

<img width="1185" alt="image" src="https://github.com/expo/orbit/assets/11707729/5311400e-48bb-4bc3-a8e0-757f90a0fb73">

