### PR TITLE
[menu-bar][cli] Extract device types in a common file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Add check for missing changelogs. ([#49](https://github.com/expo/orbit/pull/49) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Clean up eas-shared package. ([#60](https://github.com/expo/orbit/pull/60) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Unify device types across menu-bar, cli and eas-shared package. ([#66](https://github.com/expo/orbit/pull/66) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.1.2 — 2023-08-13
 

--- a/apps/cli/src/commands/BootDevice.ts
+++ b/apps/cli/src/commands/BootDevice.ts
@@ -1,3 +1,4 @@
+import { AndroidEmulator, IosSimulator } from "common-types/devices";
 import { Emulator, Simulator } from "eas-shared";
 import { getRunningDevicesAsync } from "eas-shared/build/run/android/adb";
 
@@ -16,7 +17,7 @@ export async function bootDeviceAsync({
     try {
       await Simulator.ensureSimulatorBootedAsync({
         udid: id,
-      } as Simulator.IosSimulator);
+      } as IosSimulator);
     } catch (error) {
       if (
         error instanceof Error &&
@@ -39,7 +40,7 @@ export async function bootDeviceAsync({
   await Emulator.bootEmulatorAsync(
     {
       name: id,
-    } as Emulator.AndroidDevice,
+    } as AndroidEmulator,
     { noAudio }
   );
 }

--- a/apps/cli/src/commands/ListDevices.ts
+++ b/apps/cli/src/commands/ListDevices.ts
@@ -1,31 +1,31 @@
-import {
-  AppleConnectedDevice,
-  AppleDevice,
-  Emulator,
-  Simulator,
-} from "eas-shared";
+import { AppleDevice, Emulator, Simulator } from "eas-shared";
 import { Platform } from "../utils";
+import {
+  IosSimulator,
+  AppleConnectedDevice,
+  AndroidConnectedDevice,
+  AndroidEmulator,
+} from "common-types/devices";
 
 type Device<P> = P extends Platform.Ios
-  ? Simulator.IosSimulator
+  ? IosSimulator | AppleConnectedDevice
   : P extends Platform.Android
-  ? Emulator.AndroidDevice
-  : Simulator.IosSimulator | Emulator.AndroidDevice;
+  ? AndroidConnectedDevice | AndroidEmulator
+  : never;
 
 export async function listDevicesAsync<P extends Platform>({
   platform,
 }: {
   platform: P;
 }): Promise<Device<P>[]> {
-  let availableAndroidDevices: Emulator.AndroidDevice[] = [];
-  let availableIosDevices: Array<
-    Simulator.IosSimulator | AppleConnectedDevice
-  > = [];
+  let availableAndroidDevices: (AndroidConnectedDevice | AndroidEmulator)[] =
+    [];
+  let availableIosDevices: Array<IosSimulator | AppleConnectedDevice> = [];
 
   if (platform === "ios" || platform === "all") {
     try {
       availableIosDevices = availableIosDevices.concat(
-        await Simulator.getAvaliableIosSimulatorsListAsync()
+        await Simulator.getAvailableIosSimulatorsListAsync()
       );
 
       const connectedDevices = await AppleDevice.getConnectedDevicesAsync();

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
+    "paths": {
+      "common-types/*": ["../../common-types/src/*"]
+    }
   },
   "include": ["src"],
-  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"],
+  "references": [{ "path": "../../common-types/tsconfig.json" }]
 }

--- a/apps/menu-bar/src/commands/listDevicesAsync.ts
+++ b/apps/menu-bar/src/commands/listDevicesAsync.ts
@@ -1,5 +1,6 @@
+import { Device } from 'common-types/devices';
+
 import MenuBarModule from '../modules/MenuBarModule';
-import { Device } from '../utils/device';
 
 type ListDevicesAsyncOptions = {
   platform: 'android' | 'ios' | 'all';

--- a/apps/menu-bar/src/components/DeviceItem.tsx
+++ b/apps/menu-bar/src/components/DeviceItem.tsx
@@ -1,4 +1,5 @@
 import { palette } from '@expo/styleguide-native';
+import { Device } from 'common-types/devices';
 import { useState } from 'react';
 import { StyleSheet, Pressable, PlatformColor } from 'react-native';
 
@@ -9,7 +10,7 @@ import CableConnectorIcon from '../assets/icons/cable-connector.svg';
 import IphoneIcon from '../assets/icons/iphone.svg';
 import WifiIcon from '../assets/icons/wifi.svg';
 import { useTheme } from '../providers/ThemeProvider';
-import { Device } from '../utils/device';
+import { isVirtualDevice } from '../utils/device';
 import { capitalize } from '../utils/helpers';
 import { useExpoTheme } from '../utils/useExpoTheme';
 
@@ -27,6 +28,8 @@ const DeviceItem = ({ device, onPress, onPressLaunch, selected }: Props) => {
   const currentTheme = useTheme();
   const [isHovered, setIsHovered] = useState(false);
   const [isDeviceLaunching, setDeviceLaunching] = useState(false);
+
+  const isVirtual = isVirtualDevice(device);
 
   return (
     <Pressable
@@ -71,11 +74,11 @@ const DeviceItem = ({ device, onPress, onPressLaunch, selected }: Props) => {
             <Text numberOfLines={1}>{device.name}</Text>
             <Text style={styles.description} color="secondary" leading="small">
               {capitalize(device.deviceType)}
-              {device.osVersion && ` · ${device.osVersion}`}
+              {'osVersion' in device && ` · ${device.osVersion}`}
             </Text>
           </View>
         </Row>
-        {device.deviceType === 'device' && (
+        {!isVirtual && (
           <>
             {device.connectionType === 'Network' ? (
               <WifiIcon height={20} width={20} fill={PlatformColor('text')} />
@@ -84,7 +87,7 @@ const DeviceItem = ({ device, onPress, onPressLaunch, selected }: Props) => {
             )}
           </>
         )}
-        {device.deviceType !== 'device' && device.state === 'Booted' && (
+        {isVirtual && device.state === 'Booted' && (
           <>
             <Text color="success" style={styles.indicator}>
               ●
@@ -95,32 +98,29 @@ const DeviceItem = ({ device, onPress, onPressLaunch, selected }: Props) => {
             </Text>
           </>
         )}
-        {device.deviceType !== 'device' && device.state === 'Shutdown' && isDeviceLaunching && (
+        {isVirtual && device.state === 'Shutdown' && isDeviceLaunching && (
           <Text color="secondary" style={styles.indicator}>
             Launching…
           </Text>
         )}
-        {isHovered &&
-          device.deviceType !== 'device' &&
-          device.state === 'Shutdown' &&
-          !isDeviceLaunching && (
-            <Button
-              title="Launch"
-              disabled={isDeviceLaunching}
-              color="primary"
-              onPress={async () => {
-                setDeviceLaunching(true);
-                try {
-                  await onPressLaunch();
-                } catch (error) {
-                  console.warn(error);
-                } finally {
-                  setDeviceLaunching(false);
-                }
-              }}
-              style={styles.button}
-            />
-          )}
+        {isHovered && isVirtual && device.state === 'Shutdown' && !isDeviceLaunching && (
+          <Button
+            title="Launch"
+            disabled={isDeviceLaunching}
+            color="primary"
+            onPress={async () => {
+              setDeviceLaunching(true);
+              try {
+                await onPressLaunch();
+              } catch (error) {
+                console.warn(error);
+              } finally {
+                setDeviceLaunching(false);
+              }
+            }}
+            style={styles.button}
+          />
+        )}
       </Row>
     </Pressable>
   );

--- a/apps/menu-bar/src/hooks/useListDevices.ts
+++ b/apps/menu-bar/src/hooks/useListDevices.ts
@@ -1,8 +1,8 @@
+import { Device } from 'common-types/devices';
 import { useCallback, useEffect, useState } from 'react';
 import { DeviceEventEmitter } from 'react-native';
 
 import { listDevicesAsync } from '../commands/listDevicesAsync';
-import { Device } from '../utils/device';
 
 export const useListDevices = () => {
   const [devices, setDevices] = useState<Device[]>([]);

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -1,3 +1,4 @@
+import { Device } from 'common-types/devices';
 import React, { memo, useCallback, useEffect, useState } from 'react';
 import { Alert, SectionList } from 'react-native';
 
@@ -28,7 +29,12 @@ import {
   saveSelectedDevicesIds,
 } from '../modules/Storage';
 import { openProjectsSelectorURL } from '../utils/constants';
-import { Device, getDeviceId, getDeviceOS, getSectionsFromDeviceList } from '../utils/device';
+import {
+  getDeviceId,
+  getDeviceOS,
+  getSectionsFromDeviceList,
+  isVirtualDevice,
+} from '../utils/device';
 import { getPlatformFromURI } from '../utils/parseUrl';
 import { useExpoTheme } from '../utils/useExpoTheme';
 
@@ -86,7 +92,7 @@ function Core(props: Props) {
       return (
         devices.find((d) => getDeviceId(d) === selectedDevicesIds.ios) ??
         devices.find((d) => getDeviceId(d) === selectedDevicesIds.android) ??
-        devices?.find((d) => d.state === 'Booted')
+        devices?.find((d) => isVirtualDevice(d) && d.state === 'Booted')
       );
     },
     [devices, selectedDevicesIds]
@@ -94,7 +100,7 @@ function Core(props: Props) {
 
   const ensureDeviceIsRunning = useCallback(
     async (device: Device) => {
-      if (device.state !== 'Shutdown') {
+      if (!isVirtualDevice(device) || device.state === 'Booted') {
         return;
       }
 

--- a/apps/menu-bar/src/utils/device.ts
+++ b/apps/menu-bar/src/utils/device.ts
@@ -1,3 +1,4 @@
+import { Device, IosSimulator, AndroidEmulator } from 'common-types/devices';
 import { SectionListData } from 'react-native';
 
 export type BaseDevice = {
@@ -14,20 +15,6 @@ export type BaseDevice = {
       deviceType: 'simulator' | 'emulator';
     }
 );
-
-export type IOSDevice = BaseDevice & {
-  osType: 'iOS';
-  udid: string;
-  deviceType: 'simulator' | 'device';
-};
-
-export type AndroidDevice = BaseDevice & {
-  osType: 'android';
-  pid?: number;
-  deviceType: 'emulator' | 'device';
-};
-
-export type Device = AndroidDevice | IOSDevice;
 
 export function getDeviceOS(device: Device): 'android' | 'ios' {
   return device.osType.toLowerCase() as 'android' | 'ios';
@@ -67,4 +54,8 @@ export function getSectionsFromDeviceList(
     .filter((section) => section.data.length > 0);
 
   return sections;
+}
+
+export function isVirtualDevice(device: Device): device is IosSimulator | AndroidEmulator {
+  return device.deviceType === 'simulator' || device.deviceType === 'emulator';
 }

--- a/apps/menu-bar/tsconfig.json
+++ b/apps/menu-bar/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "@tsconfig/react-native/tsconfig.json"
+  "extends": "@tsconfig/react-native/tsconfig.json",
+  "compilerOptions": {
+    "paths": {
+      "common-types/*": ["../../common-types/src/*"]
+    }
+  },
+  "references": [{ "path": "../../common-types/tsconfig.json" }]
 }

--- a/common-types/src/devices.d.ts
+++ b/common-types/src/devices.d.ts
@@ -1,0 +1,51 @@
+export interface AppleConnectedDevice {
+  /** @example `00008101-001964A22629003A` */
+  udid: string;
+  /** @example `Evan's phone` */
+  name: string;
+  /** @example `iPhone13,4` */
+  model: string;
+  /** @example `device` */
+  deviceType: "device" | "catalyst";
+  /** @example `USB` */
+  connectionType: "USB" | "Network";
+  /** @example `15.4.1` */
+  osVersion: string;
+  osType: "iOS";
+}
+
+export interface IosSimulator {
+  runtime: string;
+  osVersion: string;
+  windowName: string;
+  osType: "iOS";
+  state: "Booted" | "Shutdown";
+  isAvailable: boolean;
+  name: string;
+  udid: string;
+  lastBootedAt?: number;
+  deviceType: "simulator";
+}
+
+export interface AndroidEmulator {
+  pid?: string;
+  name: string;
+  osType: "Android";
+  deviceType: "emulator";
+  state: "Booted" | "Shutdown";
+}
+
+export interface AndroidConnectedDevice {
+  pid?: string;
+  model: string;
+  name: string;
+  osType: "Android";
+  deviceType: "device";
+  connectionType?: "USB" | "Network";
+}
+
+export type Device =
+  | AppleConnectedDevice
+  | IosSimulator
+  | AndroidEmulator
+  | AndroidConnectedDevice;

--- a/common-types/tsconfig.json
+++ b/common-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/eas-shared/src/index.ts
+++ b/packages/eas-shared/src/index.ts
@@ -6,7 +6,7 @@ import {
 import { runAppOnIosSimulatorAsync, runAppOnAndroidEmulatorAsync } from "./run";
 import * as Emulator from "./run/android/emulator";
 import { assertExecutablesExistAsync as validateAndroidSystemRequirementsAsync } from "./run/android/systemRequirements";
-import AppleDevice, { AppleConnectedDevice } from "./run/ios/device";
+import AppleDevice from "./run/ios/device";
 import * as Simulator from "./run/ios/simulator";
 import { validateSystemRequirementsAsync as validateIOSSystemRequirementsAsync } from "./run/ios/systemRequirements";
 
@@ -21,5 +21,4 @@ export {
   Emulator,
   Simulator,
   AppleDevice,
-  AppleConnectedDevice,
 };

--- a/packages/eas-shared/src/run/index.ts
+++ b/packages/eas-shared/src/run/index.ts
@@ -1,3 +1,5 @@
+import { AndroidEmulator, IosSimulator } from "common-types/devices";
+
 import * as Emulator from "./android/emulator";
 import * as Simulator from "./ios/simulator";
 import { validateSystemRequirementsAsync } from "./ios/systemRequirements";
@@ -6,7 +8,7 @@ import { getAptParametersAsync } from "./android/aapt";
 
 export async function runAppOnIosSimulatorAsync(
   appPath: string,
-  simulator: Simulator.IosSimulator
+  simulator: IosSimulator
 ): Promise<void> {
   await validateSystemRequirementsAsync();
 
@@ -22,7 +24,7 @@ export async function runAppOnIosSimulatorAsync(
 
 export async function runAppOnAndroidEmulatorAsync(
   appPath: string,
-  emulator: Emulator.AndroidDevice
+  emulator: AndroidEmulator
 ): Promise<void> {
   await assertExecutablesExistAsync();
   const bootedEmulator = await Emulator.ensureEmulatorBootedAsync(emulator);

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import { AppleConnectedDevice } from "common-types/devices";
 
 import { ClientManager } from "./ClientManager";
 import { XcodeDeveloperDiskImagePrerequisite } from "./XcodeDeveloperDiskImagePrerequisite";
@@ -14,23 +15,6 @@ import { delayAsync } from "../../../utils/delayAsync";
 import { CommandError } from "../../../utils/errors";
 import { installExitHooks } from "../../../utils/exit";
 
-// NOTE(EvanBacon): I have a feeling this shape will change with new iOS versions (tested against iOS 15).
-export interface AppleConnectedDevice {
-  /** @example `00008101-001964A22629003A` */
-  udid: string;
-  /** @example `Evan's phone` */
-  name: string;
-  /** @example `iPhone13,4` */
-  model: string;
-  /** @example `device` */
-  deviceType: "device" | "catalyst";
-  /** @example `USB` */
-  connectionType: "USB" | "Network";
-  /** @example `15.4.1` */
-  osVersion: string;
-  osType: "iOS";
-}
-//
 /** @returns a list of connected Apple devices. */
 export async function getConnectedDevicesAsync(): Promise<
   AppleConnectedDevice[]

--- a/packages/eas-shared/src/run/ios/device.ts
+++ b/packages/eas-shared/src/run/ios/device.ts
@@ -1,5 +1,4 @@
 import { getConnectedDevicesAsync } from "./appleDevice/AppleDevice";
-export { type AppleConnectedDevice } from "./appleDevice/AppleDevice";
 
 const AppleDevice = {
   getConnectedDevicesAsync,

--- a/packages/eas-shared/src/run/ios/simulator.ts
+++ b/packages/eas-shared/src/run/ios/simulator.ts
@@ -3,6 +3,7 @@ import spawnAsync from "@expo/spawn-async";
 import fs from "fs-extra";
 import path from "path";
 import semver from "semver";
+import { IosSimulator } from "common-types/devices";
 
 import * as CoreSimulator from "./CoreSimulator";
 import { simctlAsync } from "./simctl";
@@ -15,19 +16,6 @@ import { delayAsync } from "../../utils/delayAsync";
 import { sleepAsync } from "../../utils/promise";
 import * as Versions from "../../versions";
 
-export interface IosSimulator {
-  runtime: string;
-  osVersion: string;
-  windowName: string;
-  osType: "iOS";
-  state: "Booted" | "Shutdown";
-  isAvailable: boolean;
-  name: string;
-  udid: string;
-  lastBootedAt?: number;
-  deviceType: "simulator";
-}
-
 const EXPO_GO_BUNDLE_IDENTIFIER = "host.exp.Exponent";
 const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 
@@ -38,7 +26,7 @@ export async function selectSimulatorAsync(): Promise<IosSimulator> {
     return bootedSimulator;
   }
 
-  const simulators = await getAvaliableIosSimulatorsListAsync();
+  const simulators = await getAvailableIosSimulatorsListAsync();
 
   Log.newLine();
   const { selectedSimulator } = await promptAsync({
@@ -57,7 +45,7 @@ export async function selectSimulatorAsync(): Promise<IosSimulator> {
 export async function getFirstBootedIosSimulatorAsync(): Promise<
   IosSimulator | undefined
 > {
-  const bootedSimulators = await getAvaliableIosSimulatorsListAsync("booted");
+  const bootedSimulators = await getAvailableIosSimulatorsListAsync("booted");
 
   if (bootedSimulators.length > 0) {
     return bootedSimulators[0];
@@ -65,7 +53,7 @@ export async function getFirstBootedIosSimulatorAsync(): Promise<
   return undefined;
 }
 
-export async function getAvaliableIosSimulatorsListAsync(
+export async function getAvailableIosSimulatorsListAsync(
   query?: string
 ): Promise<IosSimulator[]> {
   const { stdout } = query

--- a/packages/eas-shared/tsconfig.json
+++ b/packages/eas-shared/tsconfig.json
@@ -17,7 +17,11 @@
       "../../ts-declarations",
       "src/ts-declarations",
       "./node_modules/@types"
-    ]
+    ],
+    "paths": {
+      "common-types/*": ["../../common-types/src/*"]
+    }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "references": [{ "path": "../../common-types/tsconfig.json" }]
 }


### PR DESCRIPTION
# Why

To ensure that the communication between the menu-bar and CLI is accurate we should share common types between projects 

# How

Move device types to a new `common-types` folder at the root level of the repo and decouple `AndroidDevice` in `AndroidConnectedDevice` and `AndroidEmulator` 

# Test Plan

Run menu-bar and cli and ensure TS and lint tests are green
