### PR TITLE
[menu-bar] Fix opening local APK files

### DIFF
--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.h
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.h
@@ -13,5 +13,6 @@
 
 @property(nonatomic, readonly) RCTBridge *bridge;
 @property(nonatomic, strong, readonly) NSPopover *popover;
+- (void)openPopover;
 
 @end

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/FilePicker.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/FilePicker.m
@@ -15,7 +15,7 @@ RCT_EXPORT_METHOD(pickFileWithFilenameExtension:(NSArray<NSString *> *)filenameE
     [NSApp activateIgnoringOtherApps:YES];
     NSOpenPanel *panel = [NSOpenPanel openPanel];
     if(prompt){
-      [panel setPrompt:prompt]; 
+      [panel setPrompt:prompt];
     }
     [panel setAllowsMultipleSelection:NO];
     [panel setCanChooseDirectories:YES];
@@ -27,16 +27,21 @@ RCT_EXPORT_METHOD(pickFileWithFilenameExtension:(NSArray<NSString *> *)filenameE
       for (NSString *extension in filenameExtensions) {
         NSArray *utTypes = [UTType typesWithTag:extension tagClass:UTTagClassFilenameExtension conformingToType:nil];
         [allowedTypes addObjectsFromArray:utTypes];
+
+        UTType *utType = [UTType typeWithFilenameExtension:extension];
+        if (utType && ![allowedTypes doesContain:utType]) {
+          [allowedTypes addObject:utType];
+        }
       }
       [panel setAllowedContentTypes:allowedTypes];
     }
-    
+
     if ([panel runModal] == NSModalResponseOK){
       resolve(panel.URL.path);
     } else {
       reject(@"FILE_PICKER_ERROR", @"NSModalResponseCancel", nil);
     }
-    
+
   });
 }
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
@@ -214,18 +214,18 @@ RCT_EXPORT_METHOD(showMultiOptionAlert:(NSString *)title
     [alert setInformativeText:message];
     [alert addButtonWithTitle:@"OK"];
     [alert addButtonWithTitle:@"Cancel"];
-    
+
     NSPopUpButton *popUpButton = [[NSPopUpButton alloc] initWithFrame:NSMakeRect(0, 0, 250, 24) pullsDown:NO];
     [popUpButton addItemsWithTitles:options];
-    
+
     [alert setAccessoryView:popUpButton];
-    
+
     NSInteger response = [alert runModal];
     if (response == NSAlertFirstButtonReturn) {
       resolve(@([popUpButton indexOfSelectedItem]));
     } else {
       reject(@"MULTI_OPTION_ALERT", @"Selection was canceled.", nil);
-    } 
+    }
   });
 }
 
@@ -247,5 +247,11 @@ RCT_EXPORT_METHOD(setEnvVars:(NSDictionary *)envVars)
   [userDefaults synchronize];
 }
 
+RCT_EXPORT_METHOD(openPopover)
+{
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [((AppDelegate *)[NSApp delegate]) openPopover];
+  });
+}
 
 @end

--- a/apps/menu-bar/src/modules/MenuBarModule.ts
+++ b/apps/menu-bar/src/modules/MenuBarModule.ts
@@ -10,6 +10,7 @@ type MenuBarModuleType = NativeModule & {
   setLoginItemEnabled: (enabled: boolean) => Promise<void>;
   setEnvVars: (envVars: { [key: string]: string }) => void;
   showMultiOptionAlert: (title: string, message: string, options: string[]) => Promise<number>;
+  openPopover(): void;
 };
 
 type MenuBarModuleConstants = {
@@ -62,4 +63,5 @@ export default {
     listener.remove();
     return result;
   },
+  openPopover: () => MenuBarModule.openPopover(),
 };

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -204,6 +204,7 @@ function Core(props: Props) {
 
   const openFilePicker = async () => {
     const appPath = await FilePicker.getAppAsync();
+    MenuBarModule.openPopover();
     await installAppFromURI(appPath);
   };
 


### PR DESCRIPTION
# Why

The `pickFileWithFilenameExtension` change introduced by https://github.com/expo/orbit/pull/69 ended up breaking support for apk files

# How

Use both `UTType typesWithTag` and  `UTType typeWithFilenameExtension` methods to find `UTType`s

# Test Plan
 

https://github.com/expo/orbit/assets/11707729/f6b6bfe9-20bb-482b-aca8-4393b994825d


