### PR TITLE
Changes for TV support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add ability to show/hide different types of simulators, and add experimental TV support. ([#77](https://github.com/expo/orbit/pull/77) by [@douglowder](https://github.com/douglowder))
 - Add support for opening tarballs with multiple apps. ([#73](https://github.com/expo/orbit/pull/73) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve feedback to the user when an error occurs. ([#64](https://github.com/expo/orbit/pull/64) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added drag and drop support for installing apps. ([#57](https://github.com/expo/orbit/pull/57) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/.prettierrc.js
+++ b/apps/menu-bar/.prettierrc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  printWidth: 100,
-  tabWidth: 2,
-  singleQuote: true,
-  bracketSameLine: true,
-  trailingComma: "es5",
-}

--- a/apps/menu-bar/src/modules/Storage.ts
+++ b/apps/menu-bar/src/modules/Storage.ts
@@ -4,14 +4,28 @@ import { MMKV } from 'react-native-mmkv';
 const userPreferencesStorageKey = 'user-preferences';
 
 export type UserPreferences = {
-  launchOnLogin?: boolean;
-  emulatorWithoutAudio?: boolean;
+  launchOnLogin: boolean;
+  emulatorWithoutAudio: boolean;
   customSdkPath?: string;
+  showExperimentalFeatures: boolean;
+  showIosSimulators: boolean;
+  showTvosSimulators: boolean;
+  showAndroidEmulators: boolean;
+};
+
+export const defaultUserPreferences: UserPreferences = {
+  launchOnLogin: false,
+  emulatorWithoutAudio: false,
+  showExperimentalFeatures: false,
+  showIosSimulators: true,
+  showTvosSimulators: false,
+  showAndroidEmulators: true,
 };
 
 export const getUserPreferences = async () => {
-  const value = await AsyncStorage.getItem(userPreferencesStorageKey);
-  return JSON.parse(value ?? '{}') as UserPreferences;
+  const stringValue = await AsyncStorage.getItem(userPreferencesStorageKey);
+  const value = (stringValue ? JSON.parse(stringValue) : defaultUserPreferences) as UserPreferences;
+  return value;
 };
 
 export const saveUserPreferences = async (preferences: UserPreferences) => {

--- a/apps/menu-bar/src/utils/device.ts
+++ b/apps/menu-bar/src/utils/device.ts
@@ -18,11 +18,14 @@ export type BaseDevice = {
 );
 
 export function getDeviceOS(device: Device): 'android' | 'ios' {
+  if (device.osType === 'tvOS') {
+    return 'ios';
+  }
   return device.osType.toLowerCase() as 'android' | 'ios';
 }
 
 export function getDeviceId(device: Device): string {
-  return device.osType === 'iOS' ? device.udid : device.name;
+  return device.osType === 'iOS' || device.osType === 'tvOS' ? device.udid : device.name;
 }
 
 export function getSectionsFromDeviceList(

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -14,6 +14,7 @@ import MenuBarModule from '../modules/MenuBarModule';
 import SparkleModule from '../modules/SparkleModule';
 import {
   UserPreferences,
+  defaultUserPreferences,
   getUserPreferences,
   saveUserPreferences,
   storage,
@@ -30,7 +31,7 @@ const Settings = () => {
     Boolean(storage.getString('sessionSecret'))
   );
 
-  const [userPreferences, setUserPreferences] = useState<UserPreferences>({});
+  const [userPreferences, setUserPreferences] = useState<UserPreferences>(defaultUserPreferences);
   const [customSdkPathEnabled, setCustomSdkPathEnabled] = useState(false);
   const [automaticallyChecksForUpdates, setAutomaticallyChecksForUpdates] = useState(false);
 
@@ -76,6 +77,14 @@ const Settings = () => {
   const onPressSetAutomaticallyChecksForUpdates = async (value: boolean) => {
     setAutomaticallyChecksForUpdates(value);
     SparkleModule.setAutomaticallyChecksForUpdates(value);
+  };
+
+  const onPressSetShowExperimentalFeatures = async (value: boolean) => {
+    setUserPreferences((prev) => {
+      const newPreferences = { ...prev, showExperimentalFeatures: value };
+      saveUserPreferences(newPreferences);
+      return newPreferences;
+    });
   };
 
   const onPressEmulatorWithoutAudio = async (value: boolean) => {
@@ -167,6 +176,13 @@ const Settings = () => {
                 color="primary"
               />
               <Button title="Log In" onPress={() => handleAuthentication('login')} />
+              {__DEV__ ? (
+                <TouchableOpacity
+                  onPress={() => WindowsNavigator.open('DebugMenu')}
+                  style={[styles.debugButton, getStylesForColor('primary', theme)?.touchableStyle]}>
+                  <SystemIconView systemIconName="ladybug" />
+                </TouchableOpacity>
+              ) : null}
             </Row>
           )}
         </View>
@@ -205,6 +221,13 @@ const Settings = () => {
             value={customSdkPathEnabled}
             onValueChange={toggleCustomSdkPath}
             label="Custom Android SDK root location"
+          />
+        </Row>
+        <Row mb="2" align="center">
+          <Checkbox
+            value={userPreferences.showExperimentalFeatures}
+            onValueChange={onPressSetShowExperimentalFeatures}
+            label="Show experimental features (requires restart)"
           />
         </Row>
         <PathInput

--- a/packages/common-types/src/devices.ts
+++ b/packages/common-types/src/devices.ts
@@ -18,7 +18,7 @@ export interface IosSimulator {
   runtime: string;
   osVersion: string;
   windowName: string;
-  osType: 'iOS';
+  osType: 'iOS' | 'tvOS';
   state: 'Booted' | 'Shutdown';
   isAvailable: boolean;
   name: string;

--- a/packages/eas-shared/src/run/ios/simulator.ts
+++ b/packages/eas-shared/src/run/ios/simulator.ts
@@ -46,7 +46,7 @@ export async function getAvailableIosSimulatorsListAsync(query?: string): Promis
     // Create an array [tvOS, 13, 4]
     const [osType, ...osVersionComponents] = runtimeSuffix.split('-');
 
-    if (osType === 'iOS') {
+    if (osType === 'iOS' || osType === 'tvOS') {
       // Join the end components [13, 4] -> '13.4'
       const osVersion = osVersionComponents.join('.');
       const sims = info.devices[runtime];
@@ -56,8 +56,8 @@ export async function getAvailableIosSimulatorsListAsync(query?: string): Promis
             ...device,
             runtime,
             osVersion,
-            windowName: `${device.name} (${osVersion})`,
-            osType: 'iOS' as const,
+            windowName: `${device.osType} ${device.name} (${osVersion})`,
+            osType,
             state: device.state as 'Booted' | 'Shutdown',
             deviceType: 'simulator',
             lastBootedAt: device.lastBootedAt ? new Date(device.lastBootedAt).getTime() : undefined,


### PR DESCRIPTION
# Why

- Allow Orbit user to only show certain simulators/emulators (e.g. only iOS or only Android)
- Allow Orbit user to run Apple TV builds on Apple TV simulators (new experimental feature) 

# How

- New user pref "Show experimental features" (false by default)
- New user prefs to hide/show different simulator types
- Checkbox in settings UI for the experimental features
- New row in menu bar UI to switch between different simulator lists
- Awareness of `osType=tvOS` in `common-types` and `eas-shared`
- Other changes:
  - Boolean user preferences are now always defined -- defaults in `Storage.ts`
  - Allow showing debug menu even if we are not logged in

# Test Plan

- Tested on desktop