### PR TITLE
[menu-bar][cli] Add support for iOS internal distribution apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added Projects section to the menu bar. ([#46](https://github.com/expo/orbit/pull/46), [#59](https://github.com/expo/orbit/pull/59) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added support for login to Expo. ([#41](https://github.com/expo/orbit/pull/41), [#43](https://github.com/expo/orbit/pull/43), [#44](https://github.com/expo/orbit/pull/44), [#45](https://github.com/expo/orbit/pull/45), [#62](https://github.com/expo/orbit/pull/62), [#67](https://github.com/expo/orbit/pull/67) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Focus simulator/emulator window when launching an app. ([#75](https://github.com/expo/orbit/pull/75) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for running iOS internal distribution apps on real devices. ([#79](https://github.com/expo/orbit/pull/79) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/cli/src/commands/InstallAndLaunchApp.ts
+++ b/apps/cli/src/commands/InstallAndLaunchApp.ts
@@ -2,6 +2,7 @@ import {
   Emulator,
   Simulator,
   extractAppFromLocalArchiveAsync,
+  AppleDevice,
 } from "eas-shared";
 import { Platform } from "common-types/build/cli-commands";
 
@@ -27,9 +28,25 @@ export async function installAndLaunchAppAsync(
 }
 
 async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string) {
-  const bundleIdentifier = await Simulator.getAppBundleIdentifierAsync(appPath);
-  await Simulator.installAppAsync(deviceId, appPath);
-  await Simulator.launchAppAsync(deviceId, bundleIdentifier);
+  if (
+    (await Simulator.getAvailableIosSimulatorsListAsync()).find(
+      ({ udid }) => udid === deviceId
+    )
+  ) {
+    const bundleIdentifier =
+      await Simulator.getAppBundleIdentifierAsync(appPath);
+    await Simulator.installAppAsync(deviceId, appPath);
+    await Simulator.launchAppAsync(deviceId, bundleIdentifier);
+    return;
+  }
+
+  const appId = await AppleDevice.getBundleIdentifierForBinaryAsync(appPath);
+  await AppleDevice.installOnDeviceAsync({
+    bundleIdentifier: appId,
+    bundle: appPath,
+    appDeltaDirectory: AppleDevice.getAppDeltaDirectory(appId),
+    udid: deviceId,
+  });
 }
 
 async function installAndLaunchAndroidAppAsync(

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -167,22 +167,26 @@ function Core(props: Props) {
         try {
           await installAndLaunchAppAsync({ appPath: localFilePath, deviceId });
         } catch (error) {
-          if (
-            error instanceof InternalError &&
-            error.code === 'MULTIPLE_APPS_IN_TARBALL' &&
-            error.details
-          ) {
-            const { apps } = error.details as MultipleAppsInTarballErrorDetails;
-            const selectedAppNameIndex = await MenuBarModule.showMultiOptionAlert(
-              'Multiple apps where detected in the tarball',
-              'Select which app to run:',
-              apps.map((app) => app.name)
-            );
+          if (error instanceof InternalError) {
+            if (error.code === 'MULTIPLE_APPS_IN_TARBALL' && error.details) {
+              const { apps } = error.details as MultipleAppsInTarballErrorDetails;
+              const selectedAppNameIndex = await MenuBarModule.showMultiOptionAlert(
+                'Multiple apps where detected in the tarball',
+                'Select which app to run:',
+                apps.map((app) => app.name)
+              );
 
-            await installAndLaunchAppAsync({
-              appPath: apps[selectedAppNameIndex].path,
-              deviceId,
-            });
+              await installAndLaunchAppAsync({
+                appPath: apps[selectedAppNameIndex].path,
+                deviceId,
+              });
+            }
+            if (error.code === 'APPLE_DEVICE_LOCKED') {
+              Alert.alert(
+                'Please unlock your device and open the app manually',
+                'We were unable to launch your app because the device is currently locked.'
+              );
+            }
           } else {
             throw error;
           }

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -22,6 +22,7 @@ export default class InternalError extends Error {
 }
 
 export type InternalErrorCode =
+  | "APPLE_DEVICE_LOCKED"
   | "INVALID_VERSION"
   | "MULTIPLE_APPS_IN_TARBALL"
   | "XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED"

--- a/packages/eas-shared/src/run/ios/appleDevice/installOnDeviceAsync.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/installOnDeviceAsync.ts
@@ -6,7 +6,7 @@ import path from "path";
 import * as AppleDevice from "./AppleDevice";
 import { ora } from "../../../ora";
 import { ensureDirectory } from "../../../utils/dir";
-import { CommandError } from "../../../utils/errors";
+import { InternalError } from "common-types";
 
 /** Get the app_delta folder for faster subsequent rebuilds on devices. */
 export function getAppDeltaDirectory(bundleId: string): string {
@@ -26,10 +26,8 @@ export async function installOnDeviceAsync(props: {
   bundleIdentifier: string;
   appDeltaDirectory: string;
   udid: string;
-  deviceName: string;
 }): Promise<void> {
-  const { bundle, bundleIdentifier, appDeltaDirectory, udid, deviceName } =
-    props;
+  const { bundle, bundleIdentifier, appDeltaDirectory, udid } = props;
   let indicator: Ora | undefined;
 
   try {
@@ -65,8 +63,9 @@ export async function installOnDeviceAsync(props: {
     if (error.code === "APPLE_DEVICE_LOCKED") {
       // Get the app name from the binary path.
       const appName = path.basename(bundle).split(".")[0] ?? "app";
-      throw new CommandError(
-        `Cannot launch ${appName} on ${deviceName} because the device is locked.`
+      throw new InternalError(
+        "APPLE_DEVICE_LOCKED",
+        `Unable to launch ${appName} because the device is locked. Please launch the app manually.`
       );
     }
     throw error;

--- a/packages/eas-shared/src/run/ios/device.ts
+++ b/packages/eas-shared/src/run/ios/device.ts
@@ -1,7 +1,17 @@
-import { getConnectedDevicesAsync } from "./appleDevice/AppleDevice";
+import {
+  getConnectedDevicesAsync,
+  getBundleIdentifierForBinaryAsync,
+} from "./appleDevice/AppleDevice";
+import {
+  getAppDeltaDirectory,
+  installOnDeviceAsync,
+} from "./appleDevice/installOnDeviceAsync";
 
 const AppleDevice = {
   getConnectedDevicesAsync,
+  getAppDeltaDirectory,
+  installOnDeviceAsync,
+  getBundleIdentifierForBinaryAsync,
 };
 
 export default AppleDevice;

--- a/packages/eas-shared/src/run/ios/xcrun.ts
+++ b/packages/eas-shared/src/run/ios/xcrun.ts
@@ -28,6 +28,11 @@ function throwXcrunError(e: any): never {
         "sudo xcode-select -s /Applications/Xcode.app"
       )} and try again.`
     );
+  } else if (e.stderr?.match(/the device was not, or could not be, unlocked/)) {
+    throw new InternalError(
+      "APPLE_DEVICE_LOCKED",
+      "Device is currently locked."
+    );
   }
 
   if (Array.isArray(e.output)) {


### PR DESCRIPTION
# Why

We should allow users to install iOS apps signed with ad hoc or enterprise provisioning profiles

# How

Add support for iOS internal distribution apps

# Test Plan

Run menu-bar locally and install an iOS app signed using an ad-hoc provisioning profile
