### PR TITLE
Move prettier config to root folder

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  printWidth: 100,
+  tabWidth: 2,
+  singleQuote: true,
+  bracketSameLine: true,
+  trailingComma: "es5",
+}

--- a/apps/cli/src/commands/BootDevice.ts
+++ b/apps/cli/src/commands/BootDevice.ts
@@ -1,19 +1,15 @@
-import { AndroidEmulator, IosSimulator } from "common-types/build/devices";
-import { Emulator, Simulator } from "eas-shared";
-import { getRunningDevicesAsync } from "eas-shared/build/run/android/adb";
+import { AndroidEmulator, IosSimulator } from 'common-types/build/devices';
+import { Emulator, Simulator } from 'eas-shared';
+import { getRunningDevicesAsync } from 'eas-shared/build/run/android/adb';
 
 type BootDeviceAsyncOptions = {
-  platform: "android" | "ios";
+  platform: 'android' | 'ios';
   id: string;
   noAudio?: boolean;
 };
 
-export async function bootDeviceAsync({
-  platform,
-  id,
-  noAudio,
-}: BootDeviceAsyncOptions) {
-  if (platform === "ios") {
+export async function bootDeviceAsync({ platform, id, noAudio }: BootDeviceAsyncOptions) {
+  if (platform === 'ios') {
     try {
       await Simulator.ensureSimulatorBootedAsync({
         udid: id,
@@ -21,7 +17,7 @@ export async function bootDeviceAsync({
     } catch (error) {
       if (
         error instanceof Error &&
-        error.message.includes("Unable to boot device in current state: Booted")
+        error.message.includes('Unable to boot device in current state: Booted')
       ) {
         return;
       }

--- a/apps/cli/src/commands/CheckTools.ts
+++ b/apps/cli/src/commands/CheckTools.ts
@@ -1,11 +1,11 @@
 import {
   validateAndroidSystemRequirementsAsync,
   validateIOSSystemRequirementsAsync,
-} from "eas-shared";
-import stripAnsi from "strip-ansi";
+} from 'eas-shared';
+import stripAnsi from 'strip-ansi';
 
 type CheckToolsOptions = {
-  platform: "android" | "ios" | "all";
+  platform: 'android' | 'ios' | 'all';
 };
 
 type PlatformToolsResult = {
@@ -13,15 +13,14 @@ type PlatformToolsResult = {
   reason?: string;
 };
 
-export async function checkToolsAsync({ platform = "all" }: CheckToolsOptions) {
-  const result: { android?: PlatformToolsResult; ios?: PlatformToolsResult } =
-    {};
+export async function checkToolsAsync({ platform = 'all' }: CheckToolsOptions) {
+  const result: { android?: PlatformToolsResult; ios?: PlatformToolsResult } = {};
 
-  if (platform === "android" || platform === "all") {
+  if (platform === 'android' || platform === 'all') {
     result.android = await checkAndroidToolsAsync();
   }
 
-  if (platform === "ios" || platform === "all") {
+  if (platform === 'ios' || platform === 'all') {
     result.ios = await checkIosToolsAsync();
   }
 

--- a/apps/cli/src/commands/DownloadBuild.ts
+++ b/apps/cli/src/commands/DownloadBuild.ts
@@ -1,9 +1,9 @@
-import { downloadAndMaybeExtractAppAsync, AppPlatform } from "eas-shared";
+import { downloadAndMaybeExtractAppAsync, AppPlatform } from 'eas-shared';
 
 export async function downloadBuildAsync(buildURL: string) {
   const buildPath = await downloadAndMaybeExtractAppAsync(
     buildURL,
-    buildURL.endsWith("apk") ? AppPlatform.Android : AppPlatform.Ios
+    buildURL.endsWith('apk') ? AppPlatform.Android : AppPlatform.Ios
   );
   return buildPath;
 }

--- a/apps/cli/src/commands/InstallAndLaunchApp.ts
+++ b/apps/cli/src/commands/InstallAndLaunchApp.ts
@@ -1,23 +1,16 @@
-import {
-  Emulator,
-  Simulator,
-  extractAppFromLocalArchiveAsync,
-  AppleDevice,
-} from "eas-shared";
-import { Platform } from "common-types/build/cli-commands";
+import { Emulator, Simulator, extractAppFromLocalArchiveAsync, AppleDevice } from 'eas-shared';
+import { Platform } from 'common-types/build/cli-commands';
 
-import { getPlatformFromURI } from "../utils";
+import { getPlatformFromURI } from '../utils';
 
 type InstallAndLaunchAppAsyncOptions = {
   appPath: string;
   deviceId: string;
 };
 
-export async function installAndLaunchAppAsync(
-  options: InstallAndLaunchAppAsyncOptions
-) {
+export async function installAndLaunchAppAsync(options: InstallAndLaunchAppAsyncOptions) {
   let appPath = options.appPath;
-  if (!appPath.endsWith(".app") && !appPath.endsWith(".apk")) {
+  if (!appPath.endsWith('.app') && !appPath.endsWith('.apk')) {
     appPath = await extractAppFromLocalArchiveAsync(appPath);
   }
   const platform = getPlatformFromURI(appPath);
@@ -29,12 +22,9 @@ export async function installAndLaunchAppAsync(
 
 async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string) {
   if (
-    (await Simulator.getAvailableIosSimulatorsListAsync()).find(
-      ({ udid }) => udid === deviceId
-    )
+    (await Simulator.getAvailableIosSimulatorsListAsync()).find(({ udid }) => udid === deviceId)
   ) {
-    const bundleIdentifier =
-      await Simulator.getAppBundleIdentifierAsync(appPath);
+    const bundleIdentifier = await Simulator.getAppBundleIdentifierAsync(appPath);
     await Simulator.installAppAsync(deviceId, appPath);
     await Simulator.launchAppAsync(deviceId, bundleIdentifier);
     return;
@@ -49,10 +39,7 @@ async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string) {
   });
 }
 
-async function installAndLaunchAndroidAppAsync(
-  appPath: string,
-  deviceId: string
-) {
+async function installAndLaunchAndroidAppAsync(appPath: string, deviceId: string) {
   const runningDevices = await Emulator.getRunningDevicesAsync();
   const device = runningDevices.find(({ name }) => name === deviceId);
   if (!device) {
@@ -60,7 +47,6 @@ async function installAndLaunchAndroidAppAsync(
   }
 
   await Emulator.installAppAsync(device, appPath);
-  const { packageName, activityName } =
-    await Emulator.getAptParametersAsync(appPath);
+  const { packageName, activityName } = await Emulator.getAptParametersAsync(appPath);
   await Emulator.startAppAsync(device, packageName, activityName);
 }

--- a/apps/cli/src/commands/LaunchSnack.ts
+++ b/apps/cli/src/commands/LaunchSnack.ts
@@ -1,7 +1,7 @@
-import { Emulator, Simulator } from "eas-shared";
+import { Emulator, Simulator } from 'eas-shared';
 
 type launchSnackAsyncOptions = {
-  platform: "android" | "ios";
+  platform: 'android' | 'ios';
   deviceId: string;
 };
 
@@ -15,18 +15,14 @@ export async function launchSnackAsync(
   const match = snackURL.match(regex);
   const version = match ? match[1] : undefined;
 
-  if (platform === "android") {
+  if (platform === 'android') {
     launchSnackOnAndroidAsync(snackURL, deviceId, version);
   } else {
     launchSnackOnIOSAsync(snackURL, deviceId, version);
   }
 }
 
-async function launchSnackOnAndroidAsync(
-  snackURL: string,
-  deviceId: string,
-  version?: string
-) {
+async function launchSnackOnAndroidAsync(snackURL: string, deviceId: string, version?: string) {
   const runningEmulators = await Emulator.getRunningDevicesAsync();
   const emulator = runningEmulators.find(({ name }) => name === deviceId);
   if (!emulator?.pid) {
@@ -37,11 +33,7 @@ async function launchSnackOnAndroidAsync(
   await Emulator.openURLAsync({ url: snackURL, pid: emulator.pid });
 }
 
-async function launchSnackOnIOSAsync(
-  snackURL: string,
-  deviceId: string,
-  version?: string
-) {
+async function launchSnackOnIOSAsync(snackURL: string, deviceId: string, version?: string) {
   await Simulator.ensureExpoClientInstalledAsync(deviceId, version);
   await Simulator.openURLAsync({
     url: snackURL,

--- a/apps/cli/src/commands/ListDevices.ts
+++ b/apps/cli/src/commands/ListDevices.ts
@@ -1,7 +1,7 @@
-import { AppleDevice, Emulator, Simulator } from "eas-shared";
-import { DevicesPerPlatform } from "common-types/build/cli-commands/listDevices";
-import { Platform } from "common-types/build/cli-commands";
-import { InternalError } from "common-types";
+import { AppleDevice, Emulator, Simulator } from 'eas-shared';
+import { DevicesPerPlatform } from 'common-types/build/cli-commands/listDevices';
+import { Platform } from 'common-types/build/cli-commands';
+import { InternalError } from 'common-types';
 
 export async function listDevicesAsync<P extends Platform>({
   platform,
@@ -13,7 +13,7 @@ export async function listDevicesAsync<P extends Platform>({
     ios: { devices: [], error: undefined },
   };
 
-  if (platform === "ios" || platform === "all") {
+  if (platform === 'ios' || platform === 'all') {
     try {
       result.ios.devices = result.ios.devices.concat(
         await Simulator.getAvailableIosSimulatorsListAsync()
@@ -21,47 +21,45 @@ export async function listDevicesAsync<P extends Platform>({
 
       const connectedDevices = await AppleDevice.getConnectedDevicesAsync();
       for (let connectedDevice of connectedDevices) {
-        if (
-          !result.ios.devices.some(({ udid }) => udid === connectedDevice.udid)
-        ) {
+        if (!result.ios.devices.some(({ udid }) => udid === connectedDevice.udid)) {
           result.ios.devices.push(connectedDevice);
         }
       }
     } catch (error) {
-      console.warn("Unable to get iOS devices", error);
+      console.warn('Unable to get iOS devices', error);
       if (error instanceof Error) {
         result.ios.error = {
-          code: error instanceof InternalError ? error.code : "UNKNOWN_ERROR",
+          code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
           message: error.message,
         };
       }
     }
   }
 
-  if (platform === Platform.Android || platform === "all") {
+  if (platform === Platform.Android || platform === 'all') {
     try {
       const runningDevices = await Emulator.getRunningDevicesAsync();
 
-      result.android.devices = (
-        await Emulator.getAvailableAndroidEmulatorsAsync()
-      )?.map((emulator) => {
-        const runningEmulator = runningDevices.find(
-          (r) => r.deviceType === "emulator" && r.name === emulator.name
-        );
-        return {
-          ...emulator,
-          state: runningEmulator ? "Booted" : "Shutdown",
-          pid: runningEmulator?.pid,
-        };
-      });
+      result.android.devices = (await Emulator.getAvailableAndroidEmulatorsAsync())?.map(
+        (emulator) => {
+          const runningEmulator = runningDevices.find(
+            (r) => r.deviceType === 'emulator' && r.name === emulator.name
+          );
+          return {
+            ...emulator,
+            state: runningEmulator ? 'Booted' : 'Shutdown',
+            pid: runningEmulator?.pid,
+          };
+        }
+      );
       result.android.devices = result.android.devices.concat(
-        runningDevices.filter((r) => r.deviceType === "device")
+        runningDevices.filter((r) => r.deviceType === 'device')
       );
     } catch (error) {
-      console.warn("Unable to get Android devices", error);
+      console.warn('Unable to get Android devices', error);
       if (error instanceof Error) {
         result.android.error = {
-          code: error instanceof InternalError ? error.code : "UNKNOWN_ERROR",
+          code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
           message: error.message,
         };
       }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,55 +1,55 @@
-import { Command } from "commander";
+import { Command } from 'commander';
 
-import { downloadBuildAsync } from "./commands/DownloadBuild";
-import { listDevicesAsync } from "./commands/ListDevices";
-import { bootDeviceAsync } from "./commands/BootDevice";
-import { installAndLaunchAppAsync } from "./commands/InstallAndLaunchApp";
-import { launchSnackAsync } from "./commands/LaunchSnack";
-import { checkToolsAsync } from "./commands/CheckTools";
-import { returnLoggerMiddleware } from "./utils";
+import { downloadBuildAsync } from './commands/DownloadBuild';
+import { listDevicesAsync } from './commands/ListDevices';
+import { bootDeviceAsync } from './commands/BootDevice';
+import { installAndLaunchAppAsync } from './commands/InstallAndLaunchApp';
+import { launchSnackAsync } from './commands/LaunchSnack';
+import { checkToolsAsync } from './commands/CheckTools';
+import { returnLoggerMiddleware } from './utils';
 
 const program = new Command();
 
 program
-  .name("expo-orbit-cli")
-  .description("The command-line tool used internally by Expo Orbit menu bar");
+  .name('expo-orbit-cli')
+  .description('The command-line tool used internally by Expo Orbit menu bar');
 
 program
-  .command("download-build")
-  .argument("<string>", "Build URL")
+  .command('download-build')
+  .argument('<string>', 'Build URL')
   .action(returnLoggerMiddleware(downloadBuildAsync));
 
 program
-  .command("list-devices")
-  .option("-p, --platform <string>", "Selected platform", "all")
+  .command('list-devices')
+  .option('-p, --platform <string>', 'Selected platform', 'all')
   .action(returnLoggerMiddleware(listDevicesAsync));
 
 program
-  .command("boot-device")
-  .requiredOption("-p, --platform <string>", "Selected platform")
-  .requiredOption("--id  <string>", "UDID or name of the device")
-  .option("--no-audio", "Launch Android emulator without audio")
+  .command('boot-device')
+  .requiredOption('-p, --platform <string>', 'Selected platform')
+  .requiredOption('--id  <string>', 'UDID or name of the device')
+  .option('--no-audio', 'Launch Android emulator without audio')
   .action(returnLoggerMiddleware(bootDeviceAsync));
 
 program
-  .command("install-and-launch")
-  .requiredOption("--app-path  <string>", "Local path of the app")
-  .requiredOption("--device-id  <string>", "UDID or name of the device")
+  .command('install-and-launch')
+  .requiredOption('--app-path  <string>', 'Local path of the app')
+  .requiredOption('--device-id  <string>', 'UDID or name of the device')
   .action(returnLoggerMiddleware(installAndLaunchAppAsync));
 
 program
-  .command("launch-snack")
-  .argument("<string>", "Snack URL")
-  .requiredOption("-p, --platform <string>", "Selected platform")
-  .requiredOption("--device-id  <string>", "UDID or name of the device")
+  .command('launch-snack')
+  .argument('<string>', 'Snack URL')
+  .requiredOption('-p, --platform <string>', 'Selected platform')
+  .requiredOption('--device-id  <string>', 'UDID or name of the device')
   .action(returnLoggerMiddleware(launchSnackAsync));
 
 program
-  .command("check-tools")
-  .option("-p, --platform <string>", "Selected platform")
+  .command('check-tools')
+  .option('-p, --platform <string>', 'Selected platform')
   .action(returnLoggerMiddleware(checkToolsAsync));
 
 if (process.argv.length < 3) {
-  program.help()
+  program.help();
 }
 program.parse();

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -1,19 +1,17 @@
-import { InternalError } from "common-types";
-import { Platform } from "common-types/build/cli-commands";
-import { Env } from "eas-shared";
-import util from "util";
+import { InternalError } from 'common-types';
+import { Platform } from 'common-types/build/cli-commands';
+import { Env } from 'eas-shared';
+import util from 'util';
 
-export function returnLoggerMiddleware(
-  fn: (...args: any[]) => any | Promise<any>
-) {
+export function returnLoggerMiddleware(fn: (...args: any[]) => any | Promise<any>) {
   return async function (...args: any[]) {
     try {
       const result = await fn(...args);
       if (Env.isMenuBar()) {
-        console.log("---- return output ----");
-        if (typeof result === "string") {
+        console.log('---- return output ----');
+        if (typeof result === 'string') {
           console.log(result);
-        } else if (typeof result === "object" && result !== null) {
+        } else if (typeof result === 'object' && result !== null) {
           console.log(JSON.stringify(result));
         } else {
           console.log(
@@ -35,7 +33,7 @@ export function returnLoggerMiddleware(
         })
       );
     } catch (error) {
-      console.log("---- thrown error ----");
+      console.log('---- thrown error ----');
       if (error instanceof InternalError) {
         console.log(
           JSON.stringify({
@@ -62,7 +60,7 @@ export function returnLoggerMiddleware(
 }
 
 export const getPlatformFromURI = (uri: string) => {
-  if (uri.endsWith(".apk")) {
+  if (uri.endsWith('.apk')) {
     return Platform.Android;
   }
 

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -1,13 +1,13 @@
-import { JSONValue } from "@expo/json-file";
+import { JSONValue } from '@expo/json-file';
 
-const ERROR_PREFIX = "Error: ";
+const ERROR_PREFIX = 'Error: ';
 export default class InternalError extends Error {
-  override readonly name = "InternalError";
+  override readonly name = 'InternalError';
   code: InternalErrorCode;
   details?: JSONValue;
 
   constructor(code: InternalErrorCode, message: string, details?: JSONValue) {
-    super("");
+    super('');
 
     // If e.toString() was called to get `message` we don't want it to look
     // like "Error: Error:".
@@ -22,13 +22,13 @@ export default class InternalError extends Error {
 }
 
 export type InternalErrorCode =
-  | "APPLE_DEVICE_LOCKED"
-  | "INVALID_VERSION"
-  | "MULTIPLE_APPS_IN_TARBALL"
-  | "XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED"
-  | "XCODE_LICENSE_NOT_ACCEPTED"
-  | "XCODE_NOT_INSTALLED"
-  | "SIMCTL_NOT_AVAILABLE";
+  | 'APPLE_DEVICE_LOCKED'
+  | 'INVALID_VERSION'
+  | 'MULTIPLE_APPS_IN_TARBALL'
+  | 'XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED'
+  | 'XCODE_LICENSE_NOT_ACCEPTED'
+  | 'XCODE_NOT_INSTALLED'
+  | 'SIMCTL_NOT_AVAILABLE';
 
 export type MultipleAppsInTarballErrorDetails = {
   apps: Array<{

--- a/packages/common-types/src/cli-commands/index.ts
+++ b/packages/common-types/src/cli-commands/index.ts
@@ -1,5 +1,5 @@
 export enum Platform {
-  Android = "android",
-  Ios = "ios",
-  All = "all",
+  Android = 'android',
+  Ios = 'ios',
+  All = 'all',
 }

--- a/packages/common-types/src/cli-commands/listDevices.ts
+++ b/packages/common-types/src/cli-commands/listDevices.ts
@@ -3,8 +3,8 @@ import {
   AndroidEmulator,
   AppleConnectedDevice,
   IosSimulator,
-} from "../devices";
-import { Platform } from "./index";
+} from '../devices';
+import { Platform } from './index';
 
 type Device<P> = P extends Platform.Ios
   ? IosSimulator | AppleConnectedDevice

--- a/packages/common-types/src/devices.ts
+++ b/packages/common-types/src/devices.ts
@@ -6,46 +6,42 @@ export interface AppleConnectedDevice {
   /** @example `iPhone13,4` */
   model: string;
   /** @example `device` */
-  deviceType: "device" | "catalyst";
+  deviceType: 'device' | 'catalyst';
   /** @example `USB` */
-  connectionType: "USB" | "Network";
+  connectionType: 'USB' | 'Network';
   /** @example `15.4.1` */
   osVersion: string;
-  osType: "iOS";
+  osType: 'iOS';
 }
 
 export interface IosSimulator {
   runtime: string;
   osVersion: string;
   windowName: string;
-  osType: "iOS";
-  state: "Booted" | "Shutdown";
+  osType: 'iOS';
+  state: 'Booted' | 'Shutdown';
   isAvailable: boolean;
   name: string;
   udid: string;
   lastBootedAt?: number;
-  deviceType: "simulator";
+  deviceType: 'simulator';
 }
 
 export interface AndroidEmulator {
   pid?: string;
   name: string;
-  osType: "Android";
-  deviceType: "emulator";
-  state: "Booted" | "Shutdown";
+  osType: 'Android';
+  deviceType: 'emulator';
+  state: 'Booted' | 'Shutdown';
 }
 
 export interface AndroidConnectedDevice {
   pid?: string;
   model: string;
   name: string;
-  osType: "Android";
-  deviceType: "device";
-  connectionType?: "USB" | "Network";
+  osType: 'Android';
+  deviceType: 'device';
+  connectionType?: 'USB' | 'Network';
 }
 
-export type Device =
-  | AppleConnectedDevice
-  | IosSimulator
-  | AndroidEmulator
-  | AndroidConnectedDevice;
+export type Device = AppleConnectedDevice | IosSimulator | AndroidEmulator | AndroidConnectedDevice;

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,4 +1,4 @@
-import * as Devices from "./devices";
-import InternalError, { InternalErrorCode } from "./InternalError";
+import * as Devices from './devices';
+import InternalError, { InternalErrorCode } from './InternalError';
 
 export { Devices, InternalError, InternalErrorCode };

--- a/packages/eas-shared/.eslintrc.js
+++ b/packages/eas-shared/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: "universe/node",
+  extends: 'universe/node',
 };

--- a/packages/eas-shared/src/api/APIV2.ts
+++ b/packages/eas-shared/src/api/APIV2.ts
@@ -1,9 +1,9 @@
-import { JSONObject, JSONValue } from "@expo/json-file";
-import axios, { AxiosRequestConfig } from "axios";
-import merge from "lodash/merge";
-import QueryString, { ParsedUrlQueryInput } from "querystring";
+import { JSONObject, JSONValue } from '@expo/json-file';
+import axios, { AxiosRequestConfig } from 'axios';
+import merge from 'lodash/merge';
+import QueryString, { ParsedUrlQueryInput } from 'querystring';
 
-import { Config, ConnectionStatus } from "./internal";
+import { Config, ConnectionStatus } from './internal';
 
 const MAX_CONTENT_LENGTH = 100 /* MB */ * 1024 * 1024;
 const MAX_BODY_LENGTH = 100 /* MB */ * 1024 * 1024;
@@ -16,27 +16,27 @@ function _rootBaseUrl() {
 function _apiBaseUrl() {
   let rootBaseUrl = _rootBaseUrl();
   if (Config.api.port) {
-    rootBaseUrl += ":" + Config.api.port;
+    rootBaseUrl += ':' + Config.api.port;
   }
-  return rootBaseUrl + "/--/api/v2";
+  return rootBaseUrl + '/--/api/v2';
 }
 
 export class ApiV2Error extends Error {
-  override readonly name = "ApiV2Error";
+  override readonly name = 'ApiV2Error';
   code: string;
   details?: JSONValue;
   serverStack?: string;
   metadata?: object;
   readonly _isApiError = true;
 
-  constructor(message: string, code: string = "UNKNOWN") {
+  constructor(message: string, code: string = 'UNKNOWN') {
     super(message);
     this.code = code;
   }
 }
 
 type RequestOptions = {
-  httpMethod: "get" | "post" | "put" | "patch" | "delete";
+  httpMethod: 'get' | 'post' | 'put' | 'patch' | 'delete';
   queryParameters?: QueryParameters;
   body?: JSONObject;
   timeout?: number;
@@ -55,7 +55,7 @@ type APIV2ClientOptions = {
 };
 
 export default class ApiV2Client {
-  static exponentClient: string = "xdl";
+  static exponentClient: string = 'xdl';
   sessionSecret: string | null = null;
   accessToken: string | null = null;
 
@@ -89,7 +89,7 @@ export default class ApiV2Client {
     return this._requestAsync(
       methodName,
       {
-        httpMethod: "get",
+        httpMethod: 'get',
         queryParameters: args,
       },
       extraOptions,
@@ -106,7 +106,7 @@ export default class ApiV2Client {
     return this._requestAsync(
       methodName,
       {
-        httpMethod: "post",
+        httpMethod: 'post',
         body: data,
       },
       extraOptions,
@@ -123,7 +123,7 @@ export default class ApiV2Client {
     return this._requestAsync(
       methodName,
       {
-        httpMethod: "put",
+        httpMethod: 'put',
         body: data,
       },
       extraOptions,
@@ -140,7 +140,7 @@ export default class ApiV2Client {
     return this._requestAsync(
       methodName,
       {
-        httpMethod: "patch",
+        httpMethod: 'patch',
         body: data,
       },
       extraOptions,
@@ -157,7 +157,7 @@ export default class ApiV2Client {
     return this._requestAsync(
       methodName,
       {
-        httpMethod: "delete",
+        httpMethod: 'delete',
         queryParameters: args,
       },
       extraOptions,
@@ -174,20 +174,20 @@ export default class ApiV2Client {
   ) {
     const url = `${_apiBaseUrl()}/${methodName}`;
     let reqOptions: AxiosRequestConfig & {
-      headers: NonNullable<AxiosRequestConfig["headers"]>;
+      headers: NonNullable<AxiosRequestConfig['headers']>;
     } = {
       url,
       method: options.httpMethod,
       headers: {
-        "Exponent-Client": ApiV2Client.exponentClient,
+        'Exponent-Client': ApiV2Client.exponentClient,
       },
     };
 
     // Handle auth method, prioritizing authorization tokens before session secrets
     if (this.accessToken) {
-      reqOptions.headers["Authorization"] = `Bearer ${this.accessToken}`;
+      reqOptions.headers['Authorization'] = `Bearer ${this.accessToken}`;
     } else if (this.sessionSecret) {
-      reqOptions.headers["Expo-Session"] = this.sessionSecret;
+      reqOptions.headers['Expo-Session'] = this.sessionSecret;
     }
 
     // Handle qs
@@ -202,10 +202,7 @@ export default class ApiV2Client {
       reqOptions.data = options.body;
     }
 
-    if (
-      !extraRequestOptions.hasOwnProperty("timeout") &&
-      ConnectionStatus.isOffline()
-    ) {
+    if (!extraRequestOptions.hasOwnProperty('timeout') && ConnectionStatus.isOffline()) {
       reqOptions.timeout = 1;
     }
 

--- a/packages/eas-shared/src/api/internal/Config.ts
+++ b/packages/eas-shared/src/api/internal/Config.ts
@@ -1,6 +1,6 @@
-import getenv from "getenv";
+import getenv from 'getenv';
 
-import * as Env from "../../env";
+import * as Env from '../../env';
 
 interface ApiConfig {
   scheme: string;
@@ -16,28 +16,28 @@ interface XDLConfig {
 function getAPI(): ApiConfig {
   if (Env.isLocal()) {
     return {
-      scheme: "http",
-      host: "localhost",
+      scheme: 'http',
+      host: 'localhost',
       port: 3000,
     };
   } else if (Env.isStaging()) {
     return {
-      scheme: getenv.string("XDL_SCHEME", "https"),
-      host: "staging.exp.host",
-      port: getenv.int("XDL_PORT", 0) || null,
+      scheme: getenv.string('XDL_SCHEME', 'https'),
+      host: 'staging.exp.host',
+      port: getenv.int('XDL_PORT', 0) || null,
     };
   } else {
     return {
-      scheme: getenv.string("XDL_SCHEME", "https"),
-      host: getenv.string("XDL_HOST", "exp.host"),
-      port: getenv.int("XDL_PORT", 0) || null,
+      scheme: getenv.string('XDL_SCHEME', 'https'),
+      host: getenv.string('XDL_HOST', 'exp.host'),
+      port: getenv.int('XDL_PORT', 0) || null,
     };
   }
 }
 
 const config: XDLConfig = {
   api: getAPI(),
-  developerTool: "expo-cli",
+  developerTool: 'expo-cli',
 };
 
 export default config;

--- a/packages/eas-shared/src/api/internal/index.ts
+++ b/packages/eas-shared/src/api/internal/index.ts
@@ -1,2 +1,2 @@
-export { default as Config } from "./Config";
-export * as ConnectionStatus from "./ConnectionStatus";
+export { default as Config } from './Config';
+export * as ConnectionStatus from './ConnectionStatus';

--- a/packages/eas-shared/src/downloadApkAsync.ts
+++ b/packages/eas-shared/src/downloadApkAsync.ts
@@ -1,13 +1,13 @@
-import fs from "fs-extra";
-import path from "path";
+import fs from 'fs-extra';
+import path from 'path';
 
-import UserSettings from "./userSettings";
-import * as Versions from "./versions";
-import { downloadAppAsync } from "./downloadAppAsync";
+import UserSettings from './userSettings';
+import * as Versions from './versions';
+import { downloadAppAsync } from './downloadAppAsync';
 
 function _apkCacheDirectory() {
   const dotExpoHomeDirectory = UserSettings.dotExpoHomeDirectory();
-  const dir = path.join(dotExpoHomeDirectory, "android-apk-cache");
+  const dir = path.join(dotExpoHomeDirectory, 'android-apk-cache');
   fs.mkdirpSync(dir);
   return dir;
 }

--- a/packages/eas-shared/src/downloadAppAsync.ts
+++ b/packages/eas-shared/src/downloadAppAsync.ts
@@ -1,9 +1,9 @@
-import axios, { AxiosRequestConfig, Canceler } from "axios";
-import fs from "fs-extra";
-import path from "path";
+import axios, { AxiosRequestConfig, Canceler } from 'axios';
+import fs from 'fs-extra';
+import path from 'path';
 
-import UserSettings from "./userSettings";
-import { tarExtractAsync } from "./download";
+import UserSettings from './userSettings';
+import { tarExtractAsync } from './download';
 
 const TIMER_DURATION = 30000;
 const TIMEOUT = 3600000;
@@ -32,19 +32,17 @@ async function _downloadAsync(
   const tmpPath = `${outputPath}.download`;
   const config: AxiosRequestConfig = {
     timeout: TIMEOUT,
-    responseType: "stream",
+    responseType: 'stream',
     cancelToken: token,
   };
   const response = await axios(url, config);
   await new Promise<void>((resolve) => {
-    const totalDownloadSize = response.data.headers["content-length"];
+    const totalDownloadSize = response.data.headers['content-length'];
     let downloadProgress = 0;
     response.data
-      .on("data", (chunk: Buffer) => {
+      .on('data', (chunk: Buffer) => {
         downloadProgress += chunk.length;
-        const roundedProgress = Math.floor(
-          (downloadProgress / totalDownloadSize) * 100
-        );
+        const roundedProgress = Math.floor((downloadProgress / totalDownloadSize) * 100);
         if (currentProgress !== roundedProgress) {
           currentProgress = roundedProgress;
           clearTimeout(warningTimer);
@@ -61,7 +59,7 @@ async function _downloadAsync(
           }
         }
       })
-      .on("end", () => {
+      .on('end', () => {
         clearTimeout(warningTimer);
         if (progressFunction && currentProgress !== 100) {
           progressFunction(100);
@@ -82,7 +80,7 @@ export async function downloadAppAsync(
 ): Promise<void> {
   if (extract) {
     const dotExpoHomeDirectory = UserSettings.dotExpoHomeDirectory();
-    const tmpPath = path.join(dotExpoHomeDirectory, "tmp-download-file");
+    const tmpPath = path.join(dotExpoHomeDirectory, 'tmp-download-file');
     await _downloadAsync(url, tmpPath, progressFunction);
     await tarExtractAsync(tmpPath, outputPath);
     fs.removeSync(tmpPath);

--- a/packages/eas-shared/src/env.ts
+++ b/packages/eas-shared/src/env.ts
@@ -1,22 +1,22 @@
-import type { ExpoConfig } from "@expo/config";
-import getenv from "getenv";
+import type { ExpoConfig } from '@expo/config';
+import getenv from 'getenv';
 
-import * as Versions from "./versions";
+import * as Versions from './versions';
 
 export function isDebug(): boolean {
-  return getenv.boolish("EXPO_DEBUG", false);
+  return getenv.boolish('EXPO_DEBUG', false);
 }
 
 export function isStaging(): boolean {
-  return getenv.boolish("EXPO_STAGING", false);
+  return getenv.boolish('EXPO_STAGING', false);
 }
 
 export function isLocal(): boolean {
-  return getenv.boolish("EXPO_LOCAL", false);
+  return getenv.boolish('EXPO_LOCAL', false);
 }
 
 export function isMenuBar(): boolean {
-  return getenv.boolish("EXPO_MENU_BAR", false);
+  return getenv.boolish('EXPO_MENU_BAR', false);
 }
 
 export function getFeatureGateOverrides(): {
@@ -24,8 +24,8 @@ export function getFeatureGateOverrides(): {
   disable: string[];
 } {
   return {
-    enable: getenv.array("EXPO_FG_ENABLE"),
-    disable: getenv.array("EXPO_FG_DISABLE"),
+    enable: getenv.array('EXPO_FG_ENABLE'),
+    disable: getenv.array('EXPO_FG_DISABLE'),
   };
 }
 
@@ -35,7 +35,7 @@ export function isInterstitiaLPageEnabled(): boolean {
 }
 
 export function maySkipManifestValidation(): boolean {
-  return !!getenv.string("EXPO_SKIP_MANIFEST_VALIDATION_TOKEN");
+  return !!getenv.string('EXPO_SKIP_MANIFEST_VALIDATION_TOKEN');
 }
 
 /**
@@ -43,14 +43,11 @@ export function maySkipManifestValidation(): boolean {
  * way), false if we should fall back to spawning it as a subprocess (supported for backwards
  * compatibility with SDK39 and older).
  */
-export function shouldUseDevServer(exp: Pick<ExpoConfig, "sdkVersion">) {
-  return (
-    !Versions.lteSdkVersion(exp, "39.0.0") ||
-    getenv.boolish("EXPO_USE_DEV_SERVER", false)
-  );
+export function shouldUseDevServer(exp: Pick<ExpoConfig, 'sdkVersion'>) {
+  return !Versions.lteSdkVersion(exp, '39.0.0') || getenv.boolish('EXPO_USE_DEV_SERVER', false);
 }
 
 // do not allow E2E to fire events
 export function shouldEnableAnalytics() {
-  return !getenv.boolish("E2E", false) && !getenv.boolish("CI", false);
+  return !getenv.boolish('E2E', false) && !getenv.boolish('CI', false);
 }

--- a/packages/eas-shared/src/fetch.ts
+++ b/packages/eas-shared/src/fetch.ts
@@ -1,24 +1,21 @@
-import fetch, { RequestInfo, RequestInit, Response } from "node-fetch";
-export * from "node-fetch";
+import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
+export * from 'node-fetch';
 
 export class RequestError extends Error {
-  constructor(message: string, public readonly response: Response) {
+  constructor(
+    message: string,
+    public readonly response: Response
+  ) {
     super(message);
   }
 }
 
-export default async function (
-  url: RequestInfo,
-  init?: RequestInit
-): Promise<Response> {
+export default async function (url: RequestInfo, init?: RequestInit): Promise<Response> {
   const response = await fetch(url, {
     ...init,
   });
   if (response.status >= 400) {
-    throw new RequestError(
-      `Request failed: ${response.status} (${response.statusText})`,
-      response
-    );
+    throw new RequestError(`Request failed: ${response.status} (${response.statusText})`, response);
   }
   return response;
 }

--- a/packages/eas-shared/src/index.ts
+++ b/packages/eas-shared/src/index.ts
@@ -2,14 +2,14 @@ import {
   downloadAndMaybeExtractAppAsync,
   AppPlatform,
   extractAppFromLocalArchiveAsync,
-} from "./download";
-import { runAppOnIosSimulatorAsync, runAppOnAndroidEmulatorAsync } from "./run";
-import * as Emulator from "./run/android/emulator";
-import { assertExecutablesExistAsync as validateAndroidSystemRequirementsAsync } from "./run/android/systemRequirements";
-import AppleDevice from "./run/ios/device";
-import * as Simulator from "./run/ios/simulator";
-import { validateSystemRequirementsAsync as validateIOSSystemRequirementsAsync } from "./run/ios/systemRequirements";
-import * as Env from "./env";
+} from './download';
+import { runAppOnIosSimulatorAsync, runAppOnAndroidEmulatorAsync } from './run';
+import * as Emulator from './run/android/emulator';
+import { assertExecutablesExistAsync as validateAndroidSystemRequirementsAsync } from './run/android/systemRequirements';
+import AppleDevice from './run/ios/device';
+import * as Simulator from './run/ios/simulator';
+import { validateSystemRequirementsAsync as validateIOSSystemRequirementsAsync } from './run/ios/systemRequirements';
+import * as Env from './env';
 
 export {
   AppPlatform,

--- a/packages/eas-shared/src/log.ts
+++ b/packages/eas-shared/src/log.ts
@@ -1,11 +1,11 @@
-import chalk from "chalk";
-import { boolish } from "getenv";
-import logSymbols from "log-symbols";
+import chalk from 'chalk';
+import { boolish } from 'getenv';
+import logSymbols from 'log-symbols';
 
 type Color = (...text: string[]) => string;
 
 export default class Log {
-  public static readonly isDebug = boolish("EXPO_DEBUG", false);
+  public static readonly isDebug = boolish('EXPO_DEBUG', false);
 
   public static log(...args: any[]): void {
     Log.consoleLog(...args);
@@ -40,7 +40,7 @@ export default class Log {
   }
 
   public static warnDeprecatedFlag(flag: string, message: string): void {
-    Log.warn(`› ${chalk.bold("--" + flag)} flag is deprecated. ${message}`);
+    Log.warn(`› ${chalk.bold('--' + flag)} flag is deprecated. ${message}`);
   }
 
   public static fail(message: string): void {
@@ -67,10 +67,7 @@ export default class Log {
       Log.isLastLineNewLine = true;
     } else {
       const lastArg = args[args.length - 1];
-      if (
-        typeof lastArg === "string" &&
-        (lastArg === "" || lastArg.match(/[\r\n]$/))
-      ) {
+      if (typeof lastArg === 'string' && (lastArg === '' || lastArg.match(/[\r\n]$/))) {
         Log.isLastLineNewLine = true;
       } else {
         Log.isLastLineNewLine = false;
@@ -89,7 +86,7 @@ export function error(...message: string[]): void {
 
 /** Print an error and provide additional info (the stack trace) in debug mode. */
 export function exception(e: Error): void {
-  error(chalk.red(e.toString()) + ("\n" + chalk.gray(e.stack)));
+  error(chalk.red(e.toString()) + ('\n' + chalk.gray(e.stack)));
 }
 
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */

--- a/packages/eas-shared/src/paths.ts
+++ b/packages/eas-shared/src/paths.ts
@@ -1,4 +1,4 @@
-import envPaths from "env-paths";
+import envPaths from 'env-paths';
 
 // Paths for storing things like data, config, cache, etc.
 // Should use the correct OS-specific paths (e.g. XDG base directory on Linux)
@@ -8,7 +8,7 @@ const {
   cache: CACHE_PATH,
   log: LOG_PATH,
   temp: TEMP_PATH,
-} = envPaths("expo-orbit");
+} = envPaths('expo-orbit');
 
 export const getDataDirectory = (): string => DATA_PATH;
 export const getConfigDirectory = (): string => CONFIG_PATH;

--- a/packages/eas-shared/src/progress.ts
+++ b/packages/eas-shared/src/progress.ts
@@ -1,7 +1,7 @@
-import chalk from "chalk";
+import chalk from 'chalk';
 
-import { Ora, ora } from "./ora";
-import { endTimer, formatMilliseconds, startTimer } from "./timer";
+import { Ora, ora } from './ora';
+import { endTimer, formatMilliseconds, startTimer } from './timer';
 
 export type Progress = {
   total: number;
@@ -34,7 +34,7 @@ export function createProgressTracker({
   const getMessage = (v: number, total: number): string => {
     const ratio = Math.min(Math.max(v, 0), 1);
     const percent = Math.floor(ratio * 100);
-    return typeof message === "string"
+    return typeof message === 'string'
       ? `${message} ${percent.toFixed(0)}%`
       : message(ratio, total);
   };
@@ -73,7 +73,7 @@ export function createProgressTracker({
       if (error) {
         bar.fail();
       } else if (isComplete) {
-        if (typeof completedMessage === "string") {
+        if (typeof completedMessage === 'string') {
           bar.succeed(`${completedMessage} ${chalk.dim(prettyTime)}`);
         } else {
           bar.succeed(completedMessage(prettyTime));

--- a/packages/eas-shared/src/run/android/emulator.ts
+++ b/packages/eas-shared/src/run/android/emulator.ts
@@ -1,40 +1,33 @@
-import spawnAsync, { SpawnResult } from "@expo/spawn-async";
-import * as osascript from "@expo/osascript";
-import assert from "assert";
-import chalk from "chalk";
-import os from "os";
-import path from "path";
-import { execFileSync } from "child_process";
-import semver from "semver";
-import {
-  AndroidConnectedDevice,
-  AndroidEmulator,
-} from "common-types/build/devices";
+import spawnAsync, { SpawnResult } from '@expo/spawn-async';
+import * as osascript from '@expo/osascript';
+import assert from 'assert';
+import chalk from 'chalk';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import semver from 'semver';
+import { AndroidConnectedDevice, AndroidEmulator } from 'common-types/build/devices';
 
-import * as Versions from "../../versions";
-import Log from "../../log";
-import {
-  adbAsync,
-  isEmulatorBootedAsync,
-  waitForEmulatorToBeBootedAsync,
-} from "./adb";
-import { getAndroidSdkRootAsync } from "./sdk";
-import { downloadApkAsync } from "../../downloadApkAsync";
+import * as Versions from '../../versions';
+import Log from '../../log';
+import { adbAsync, isEmulatorBootedAsync, waitForEmulatorToBeBootedAsync } from './adb';
+import { getAndroidSdkRootAsync } from './sdk';
+import { downloadApkAsync } from '../../downloadApkAsync';
 
-const BEGINNING_OF_ADB_ERROR_MESSAGE = "error: ";
+const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
 const INSTALL_WARNING_TIMEOUT = 60 * 1000;
-const EXPO_GO_BUNDLE_IDENTIFIER = "host.exp.exponent";
+const EXPO_GO_BUNDLE_IDENTIFIER = 'host.exp.exponent';
 export const EMULATOR_MAX_WAIT_TIMEOUT_MS = 60 * 1000 * 3;
-export { getRunningDevicesAsync } from "./adb";
-export { getAptParametersAsync } from "./aapt";
+export { getRunningDevicesAsync } from './adb';
+export { getAptParametersAsync } from './aapt';
 
 export async function getEmulatorExecutableAsync(): Promise<string> {
   const sdkRoot = await getAndroidSdkRootAsync();
   if (sdkRoot) {
-    return path.join(sdkRoot, "emulator", "emulator");
+    return path.join(sdkRoot, 'emulator', 'emulator');
   }
 
-  return "emulator";
+  return 'emulator';
 }
 
 async function emulatorAsync(...options: string[]): Promise<SpawnResult> {
@@ -50,18 +43,18 @@ async function emulatorAsync(...options: string[]): Promise<SpawnResult> {
 }
 
 export async function getAvailableAndroidEmulatorsAsync(): Promise<
-  Omit<AndroidEmulator, "state">[]
+  Omit<AndroidEmulator, 'state'>[]
 > {
   try {
-    const { stdout } = await emulatorAsync("-list-avds");
+    const { stdout } = await emulatorAsync('-list-avds');
 
     return stdout
       .split(os.EOL)
       .filter(Boolean)
       .map((name) => ({
         name,
-        osType: "Android",
-        deviceType: "emulator",
+        osType: 'Android',
+        deviceType: 'emulator',
       }));
   } catch {
     return [];
@@ -88,12 +81,12 @@ export async function bootEmulatorAsync(
   const emulatorExecutable = await getEmulatorExecutableAsync();
   const spawnArgs = [`@${emulator.name}`];
   if (noAudio) {
-    spawnArgs.push("-no-audio");
+    spawnArgs.push('-no-audio');
   }
 
   // Start a process to open an emulator
   const emulatorProcess = spawnAsync(emulatorExecutable, spawnArgs, {
-    stdio: "ignore",
+    stdio: 'ignore',
     detached: true,
   });
 
@@ -119,16 +112,16 @@ export async function installAppAsync(
   apkFilePath: string
 ): Promise<void> {
   Log.newLine();
-  Log.log("Installing your app...");
+  Log.log('Installing your app...');
 
   assert(emulator.pid);
   await activateEmulatorWindowAsync({
     pid: emulator.pid,
-    deviceType: "emulator",
+    deviceType: 'emulator',
   });
-  await adbAsync("-s", emulator.pid, "install", "-r", "-d", apkFilePath);
+  await adbAsync('-s', emulator.pid, 'install', '-r', '-d', apkFilePath);
 
-  Log.succeed("Successfully installed your app!");
+  Log.succeed('Successfully installed your app!');
 }
 
 export async function startAppAsync(
@@ -137,37 +130,35 @@ export async function startAppAsync(
   activityName: string
 ): Promise<void> {
   Log.newLine();
-  Log.log("Starting your app...");
+  Log.log('Starting your app...');
 
   assert(emulator.pid);
   await adbAsync(
-    "-s",
+    '-s',
     emulator.pid,
-    "shell",
-    "am",
-    "start",
-    "-a",
-    "android.intent.action.MAIN",
-    "-f",
-    "0x20000000", // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
-    "-n",
+    'shell',
+    'am',
+    'start',
+    '-a',
+    'android.intent.action.MAIN',
+    '-f',
+    '0x20000000', // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
+    '-n',
     `${packageName}/${activityName}`
   );
 
-  Log.succeed("Successfully started your app!");
+  Log.succeed('Successfully started your app!');
 }
 
 // Expo installed
-async function isExpoClientInstalledOnEmulatorAsync(
-  pid: string
-): Promise<boolean> {
+async function isExpoClientInstalledOnEmulatorAsync(pid: string): Promise<boolean> {
   const packages = await adbAsync(
-    "-s",
+    '-s',
     pid,
-    "shell",
-    "pm",
-    "list",
-    "packages",
+    'shell',
+    'pm',
+    'list',
+    'packages',
     EXPO_GO_BUNDLE_IDENTIFIER
   );
 
@@ -184,18 +175,16 @@ async function isExpoClientInstalledOnEmulatorAsync(
 export async function getAdbOutputAsync(args: string[]): Promise<string> {
   try {
     const result = await adbAsync(...args);
-    return result.output.join("\n");
+    return result.output.join('\n');
   } catch (e: any) {
     // User pressed ctrl+c to cancel the process...
-    if (e.signal === "SIGINT") {
+    if (e.signal === 'SIGINT') {
       e.isAbortError = true;
     }
     // TODO: Support heap corruption for adb 29 (process exits with code -1073740940) (windows and linux)
     let errorMessage = (e.stderr || e.stdout || e.message).trim();
     if (errorMessage.startsWith(BEGINNING_OF_ADB_ERROR_MESSAGE)) {
-      errorMessage = errorMessage.substring(
-        BEGINNING_OF_ADB_ERROR_MESSAGE.length
-      );
+      errorMessage = errorMessage.substring(BEGINNING_OF_ADB_ERROR_MESSAGE.length);
     }
     e.message = errorMessage;
     throw e;
@@ -203,7 +192,7 @@ export async function getAdbOutputAsync(args: string[]): Promise<string> {
 }
 
 export async function openURLAsync({ pid, url }: { pid: string; url: string }) {
-  await activateEmulatorWindowAsync({ pid, deviceType: "emulator" });
+  await activateEmulatorWindowAsync({ pid, deviceType: 'emulator' });
 
   try {
     // NOTE(brentvatne): temporary workaround! launch Expo Go first, then
@@ -212,26 +201,26 @@ export async function openURLAsync({ pid, url }: { pid: string; url: string }) {
     // adb shell monkey -p host.exp.exponent -c android.intent.category.LAUNCHER 1
     // Note: this is not needed in Expo Development Client, it only applies to Expo Go
     await adbAsync(
-      "-s",
+      '-s',
       pid,
-      "shell",
-      "monkey",
-      "-p",
+      'shell',
+      'monkey',
+      '-p',
       EXPO_GO_BUNDLE_IDENTIFIER,
-      "-c",
-      "android.intent.category.LAUNCHER",
-      "1"
+      '-c',
+      'android.intent.category.LAUNCHER',
+      '1'
     );
 
     const openProject = await adbAsync(
-      "-s",
+      '-s',
       pid,
-      "shell",
-      "am",
-      "start",
-      "-a",
-      "android.intent.action.VIEW",
-      "-d",
+      'shell',
+      'am',
+      'start',
+      '-a',
+      'android.intent.action.VIEW',
+      '-d',
       url
     );
     return openProject;
@@ -241,22 +230,22 @@ export async function openURLAsync({ pid, url }: { pid: string; url: string }) {
 }
 
 function getUnixPID(port: number | string) {
-  return execFileSync("lsof", [`-i:${port}`, "-P", "-t", "-sTCP:LISTEN"], {
-    encoding: "utf8",
-    stdio: ["pipe", "pipe", "ignore"],
+  return execFileSync('lsof', [`-i:${port}`, '-P', '-t', '-sTCP:LISTEN'], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
   })
-    .split("\n")[0]
+    .split('\n')[0]
     .trim();
 }
 
 export async function activateEmulatorWindowAsync(
-  device: Pick<AndroidEmulator, "deviceType" | "pid">
+  device: Pick<AndroidEmulator, 'deviceType' | 'pid'>
 ) {
   if (
     // only mac is supported for now.
-    process.platform !== "darwin" ||
+    process.platform !== 'darwin' ||
     // can only focus emulators
-    device.deviceType !== "emulator"
+    device.deviceType !== 'emulator'
   ) {
     return;
   }
@@ -296,14 +285,7 @@ async function getClientForSDK(sdkVersionString?: string) {
 }
 
 async function expoVersionOnEmulatorAsync(pid: string): Promise<string | null> {
-  const info = await adbAsync(
-    "-s",
-    pid,
-    "shell",
-    "dumpsys",
-    "package",
-    EXPO_GO_BUNDLE_IDENTIFIER
-  );
+  const info = await adbAsync('-s', pid, 'shell', 'dumpsys', 'package', EXPO_GO_BUNDLE_IDENTIFIER);
 
   const regex = /versionName=([0-9.]+)/;
   const regexMatch = regex.exec(info.stdout);
@@ -314,14 +296,10 @@ async function expoVersionOnEmulatorAsync(pid: string): Promise<string | null> {
   return regexMatch[1];
 }
 
-async function doesExpoClientNeedUpdatedAsync(
-  pid: string,
-  sdkVersion?: string
-): Promise<boolean> {
+async function doesExpoClientNeedUpdatedAsync(pid: string, sdkVersion?: string): Promise<boolean> {
   const versions = await Versions.versionsAsync();
   const clientForSdk = await getClientForSDK(sdkVersion);
-  const latestVersionForSdk =
-    clientForSdk?.version ?? versions.androidClientVersion;
+  const latestVersionForSdk = clientForSdk?.version ?? versions.androidClientVersion;
 
   const installedVersion = await expoVersionOnEmulatorAsync(pid);
   if (installedVersion && semver.lt(installedVersion, latestVersionForSdk)) {
@@ -346,23 +324,19 @@ export async function installExpoOnEmulatorAsync({
     }
     return setTimeout(() => {
       console.log(
-        "This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.dev/tools"
+        'This download is taking longer than expected. You can also try downloading the clients from the website at https://expo.dev/tools'
       );
     }, INSTALL_WARNING_TIMEOUT);
   };
 
-  console.log("Downloading the Expo Go app");
+  console.log('Downloading the Expo Go app');
   warningTimer = setWarningTimer();
 
   const path = await downloadApkAsync(url, (progress) => {
     console.log(`Downloading: ${progress.toFixed(2)}%`);
   });
 
-  console.log(
-    version
-      ? `Installing Expo Go ${version} on ${pid}`
-      : `Installing Expo Go on ${pid}`
-  );
+  console.log(version ? `Installing Expo Go ${version} on ${pid}` : `Installing Expo Go on ${pid}`);
   warningTimer = setWarningTimer();
 
   const result = await installAppAsync({ pid } as AndroidEmulator, path);
@@ -371,10 +345,7 @@ export async function installExpoOnEmulatorAsync({
   return result;
 }
 
-export async function ensureExpoClientInstalledAsync(
-  pid: string,
-  sdkVersion?: string
-) {
+export async function ensureExpoClientInstalledAsync(pid: string, sdkVersion?: string) {
   let isInstalled = await isExpoClientInstalledOnEmulatorAsync(pid);
   if (isInstalled && (await doesExpoClientNeedUpdatedAsync(pid, sdkVersion))) {
     isInstalled = false;

--- a/packages/eas-shared/src/run/index.ts
+++ b/packages/eas-shared/src/run/index.ts
@@ -1,10 +1,10 @@
-import { AndroidEmulator, IosSimulator } from "common-types/build/devices";
+import { AndroidEmulator, IosSimulator } from 'common-types/build/devices';
 
-import * as Emulator from "./android/emulator";
-import * as Simulator from "./ios/simulator";
-import { validateSystemRequirementsAsync } from "./ios/systemRequirements";
-import { assertExecutablesExistAsync } from "./android/systemRequirements";
-import { getAptParametersAsync } from "./android/aapt";
+import * as Emulator from './android/emulator';
+import * as Simulator from './ios/simulator';
+import { validateSystemRequirementsAsync } from './ios/systemRequirements';
+import { assertExecutablesExistAsync } from './android/systemRequirements';
+import { getAptParametersAsync } from './android/aapt';
 
 export async function runAppOnIosSimulatorAsync(
   appPath: string,

--- a/packages/eas-shared/src/run/ios/CoreSimulator.ts
+++ b/packages/eas-shared/src/run/ios/CoreSimulator.ts
@@ -1,14 +1,14 @@
-import fs from "fs";
-import { boolish } from "getenv";
-import { sync as globSync } from "fast-glob";
-import os from "os";
-import path from "path";
+import fs from 'fs';
+import { boolish } from 'getenv';
+import { sync as globSync } from 'fast-glob';
+import os from 'os';
+import path from 'path';
 
-import { SimulatorDevice } from "./SimControl";
-import { parseBinaryPlistAsync } from "../../utils/parseBinaryPlistAsync";
+import { SimulatorDevice } from './SimControl';
+import { parseBinaryPlistAsync } from '../../utils/parseBinaryPlistAsync';
 
 // Enable this to test the JS version of simctl
-const EXPO_USE_CORE_SIM = boolish("EXPO_USE_CORE_SIM", false);
+const EXPO_USE_CORE_SIM = boolish('EXPO_USE_CORE_SIM', false);
 
 export function isEnabled() {
   return EXPO_USE_CORE_SIM;
@@ -22,7 +22,7 @@ enum DeviceState {
 export class CoreSimulatorError extends Error {
   constructor(
     public override message: string,
-    public code?: "MALFORMED_BINARY" | "INVALID_UDID"
+    public code?: 'MALFORMED_BINARY' | 'INVALID_UDID'
   ) {
     super(message);
   }
@@ -34,7 +34,7 @@ export class CoreSimulatorError extends Error {
  * @returns /Users/evanbacon/Library/Developer/CoreSimulator/Devices
  */
 function getDevicesDirectory(): string {
-  return path.join(os.homedir(), "/Library/Developer/CoreSimulator/Devices/");
+  return path.join(os.homedir(), '/Library/Developer/CoreSimulator/Devices/');
 }
 
 /**
@@ -51,21 +51,21 @@ async function getDirectoryForDeviceAsync(udid: string): Promise<string> {
     const possibleUdids = await getDirectoriesAsync(getDevicesDirectory());
     let errorMessage = `Invalid iOS Simulator device UDID: ${udid}.`;
     if (possibleUdids.length) {
-      errorMessage += ` Expected one of: ${possibleUdids.join(", ")}`;
+      errorMessage += ` Expected one of: ${possibleUdids.join(', ')}`;
     }
-    throw new CoreSimulatorError(errorMessage, "INVALID_UDID");
+    throw new CoreSimulatorError(errorMessage, 'INVALID_UDID');
   }
   return deviceFolder;
 }
 
 async function resolveUdidAsync(udid: string): Promise<string> {
-  if (udid === "booted") {
+  if (udid === 'booted') {
     const bootedDevice = await getBootedDeviceAsync();
     if (!bootedDevice) {
-      throw new CoreSimulatorError("No devices are booted.", "INVALID_UDID");
+      throw new CoreSimulatorError('No devices are booted.', 'INVALID_UDID');
     }
     udid = bootedDevice.UDID;
-    console.log("Resolved booted device: " + udid);
+    console.log('Resolved booted device: ' + udid);
   }
   return udid;
 }
@@ -77,7 +77,7 @@ export async function listDevicesAsync(): Promise<SimulatorDevice[]> {
   return (
     await Promise.all(
       devices.map(async (device): Promise<SimulatorDevice | null> => {
-        const plistPath = path.join(devicesDirectory, device, "device.plist");
+        const plistPath = path.join(devicesDirectory, device, 'device.plist');
         if (!fs.existsSync(plistPath)) return null;
         // The plist is stored in binary format
         const data = await parseBinaryPlistAsync(plistPath);
@@ -90,43 +90,38 @@ export async function listDevicesAsync(): Promise<SimulatorDevice[]> {
 export async function getDeviceInfoAsync({
   udid,
 }: { udid?: string } = {}): Promise<SimulatorDevice> {
-  if (!udid || udid === "booted") {
+  if (!udid || udid === 'booted') {
     const bootedDevice = await getBootedDeviceAsync();
     if (!bootedDevice) {
-      throw new CoreSimulatorError("No devices are booted.", "INVALID_UDID");
+      throw new CoreSimulatorError('No devices are booted.', 'INVALID_UDID');
     }
     const deviceDirectory = await getDirectoryForDeviceAsync(bootedDevice.UDID);
     return devicePlistToSimulatorDevice(deviceDirectory, bootedDevice);
   }
 
   const deviceDirectory = await getDirectoryForDeviceAsync(udid);
-  const plistPath = path.join(deviceDirectory, "device.plist");
+  const plistPath = path.join(deviceDirectory, 'device.plist');
   // The plist is stored in binary format
   const data = await parseBinaryPlistAsync(plistPath);
   return devicePlistToSimulatorDevice(deviceDirectory, data);
 }
 
-export function devicePlistToSimulatorDevice(
-  deviceDirectory: string,
-  data: any
-): SimulatorDevice {
-  const runtimeSuffix = data.runtime
-    .split("com.apple.CoreSimulator.SimRuntime.")
-    .pop()!;
+export function devicePlistToSimulatorDevice(deviceDirectory: string, data: any): SimulatorDevice {
+  const runtimeSuffix = data.runtime.split('com.apple.CoreSimulator.SimRuntime.').pop()!;
   // Create an array [tvOS, 13, 4]
-  const [osType, ...osVersionComponents] = runtimeSuffix.split("-");
+  const [osType, ...osVersionComponents] = runtimeSuffix.split('-');
   // Join the end components [13, 4] -> '13.4'
-  const osVersion = osVersionComponents.join(".");
+  const osVersion = osVersionComponents.join('.');
   return {
     ...data,
     /**
      * '/Users/name/Library/Developer/CoreSimulator/Devices/00E55DC0-0364-49DF-9EC6-77BE587137D4/data'
      */
-    dataPath: path.join(deviceDirectory, "data"),
+    dataPath: path.join(deviceDirectory, 'data'),
     /**
      * '/Users/name/Library/Logs/CoreSimulator/00E55DC0-0364-49DF-9EC6-77BE587137D4'
      */
-    logPath: path.join(os.homedir(), "Library/Logs/CoreSimulator", data.UDID),
+    logPath: path.join(os.homedir(), 'Library/Logs/CoreSimulator', data.UDID),
     /**
      * '00E55DC0-0364-49DF-9EC6-77BE587137D4'
      */
@@ -140,7 +135,7 @@ export function devicePlistToSimulatorDevice(
      * 'com.apple.CoreSimulator.SimDeviceType.Apple-TV-1080p'
      */
     deviceTypeIdentifier: data.deviceType,
-    state: data.state === DeviceState.BOOTED ? "Booted" : "Shutdown",
+    state: data.state === DeviceState.BOOTED ? 'Booted' : 'Shutdown',
     /**
      * 'Apple TV'
      */
@@ -149,7 +144,7 @@ export function devicePlistToSimulatorDevice(
     /**
      * 'iOS'
      */
-    osType: osType as SimulatorDevice["osType"],
+    osType: osType as SimulatorDevice['osType'],
     /**
      * '13.4'
      */
@@ -180,7 +175,7 @@ export async function getBootedDeviceAsync(): Promise<{ UDID: string } | null> {
       await Promise.all(
         devices.map(async (device) => {
           if (complete) return;
-          const plistPath = path.join(devicesDirectory, device, "device.plist");
+          const plistPath = path.join(devicesDirectory, device, 'device.plist');
           // The plist is stored in binary format
           const data = await parseBinaryPlistAsync(plistPath);
           // Compare state stored under `state` to 3 (booted)
@@ -222,7 +217,7 @@ export async function getContainerPathAsync({
   // TODO: Maybe shallow glob for `.com.apple.mobile_container_manager.metadata.plist` to find apps faster
   const appsFolder = path.join(
     await getDirectoryForDeviceAsync(udid),
-    "data/Containers/Bundle/Application"
+    'data/Containers/Bundle/Application'
   );
 
   // Get all apps for a device
@@ -239,7 +234,7 @@ export async function getContainerPathAsync({
           const appFolder = path.join(appsFolder, app);
           const plistPath = path.join(
             appFolder,
-            ".com.apple.mobile_container_manager.metadata.plist"
+            '.com.apple.mobile_container_manager.metadata.plist'
           );
           // The plist is stored in binary format
           const data = await parseBinaryPlistAsync(plistPath);
@@ -250,7 +245,7 @@ export async function getContainerPathAsync({
             if (!binaryPath) {
               throw new CoreSimulatorError(
                 `Found matching app container at "${appFolder}" but binary (*.app file) is missing.`,
-                "MALFORMED_BINARY"
+                'MALFORMED_BINARY'
               );
             }
             complete = true;
@@ -271,7 +266,7 @@ export async function getContainerPathAsync({
 
 function findBinaryFileInDirectory(folder: string) {
   // Find .app file in the app folder
-  const binaryPath = globSync("*.app", {
+  const binaryPath = globSync('*.app', {
     absolute: true,
     cwd: folder,
   })[0];
@@ -280,11 +275,7 @@ function findBinaryFileInDirectory(folder: string) {
 }
 
 async function getDirectoriesAsync(directory: string) {
-  return (
-    await fs.promises
-      .readdir(directory, { withFileTypes: true })
-      .catch(() => [])
-  )
+  return (await fs.promises.readdir(directory, { withFileTypes: true }).catch(() => []))
     .filter((device) => device.isDirectory())
     .map((device) => device.name);
 }

--- a/packages/eas-shared/src/run/ios/SimControl.ts
+++ b/packages/eas-shared/src/run/ios/SimControl.ts
@@ -1,7 +1,7 @@
-type DeviceState = "Shutdown" | "Booted";
+type DeviceState = 'Shutdown' | 'Booted';
 
 export type SimulatorDevice = {
-  availabilityError: "runtime profile not found";
+  availabilityError: 'runtime profile not found';
   /**
    * '/Users/name/Library/Developer/CoreSimulator/Devices/00E55DC0-0364-49DF-9EC6-77BE587137D4/data'
    */
@@ -50,11 +50,11 @@ export type XCTraceDevice = {
    */
   name: string;
 
-  deviceType: "device" | "catalyst";
+  deviceType: 'device' | 'catalyst';
   /**
    * '13.4'
    */
   osVersion: string;
 };
 
-type OSType = "iOS" | "tvOS" | "watchOS" | "macOS";
+type OSType = 'iOS' | 'tvOS' | 'watchOS' | 'macOS';

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -1,50 +1,43 @@
-import fs from "fs";
-import path from "path";
-import { AppleConnectedDevice } from "common-types/build/devices";
-import debug from "debug";
+import fs from 'fs';
+import path from 'path';
+import { AppleConnectedDevice } from 'common-types/build/devices';
+import debug from 'debug';
 
-import { ClientManager } from "./ClientManager";
-import { XcodeDeveloperDiskImagePrerequisite } from "./XcodeDeveloperDiskImagePrerequisite";
-import {
-  IPLookupResult,
-  OnInstallProgressCallback,
-} from "./client/InstallationProxyClient";
-import { LockdowndClient } from "./client/LockdowndClient";
-import { UsbmuxdClient } from "./client/UsbmuxdClient";
-import { AFC_STATUS, AFCError } from "./protocol/AFCProtocol";
-import { delayAsync } from "../../../utils/delayAsync";
-import { CommandError } from "../../../utils/errors";
-import { parseBinaryPlistAsync } from "../../../utils/parseBinaryPlistAsync";
-import { installExitHooks } from "../../../utils/exit";
-import { xcrunAsync } from "../xcrun";
+import { ClientManager } from './ClientManager';
+import { XcodeDeveloperDiskImagePrerequisite } from './XcodeDeveloperDiskImagePrerequisite';
+import { IPLookupResult, OnInstallProgressCallback } from './client/InstallationProxyClient';
+import { LockdowndClient } from './client/LockdowndClient';
+import { UsbmuxdClient } from './client/UsbmuxdClient';
+import { AFC_STATUS, AFCError } from './protocol/AFCProtocol';
+import { delayAsync } from '../../../utils/delayAsync';
+import { CommandError } from '../../../utils/errors';
+import { parseBinaryPlistAsync } from '../../../utils/parseBinaryPlistAsync';
+import { installExitHooks } from '../../../utils/exit';
+import { xcrunAsync } from '../xcrun';
 
 /** @returns a list of connected Apple devices. */
-export async function getConnectedDevicesAsync(): Promise<
-  AppleConnectedDevice[]
-> {
+export async function getConnectedDevicesAsync(): Promise<AppleConnectedDevice[]> {
   const client = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
   const devices = await client.getDevices();
   client.socket.end();
 
   return Promise.all(
     devices.map(async (device): Promise<AppleConnectedDevice> => {
-      const socket = await new UsbmuxdClient(
-        UsbmuxdClient.connectUsbmuxdSocket()
-      ).connect(device, 62078);
+      const socket = await new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket()).connect(
+        device,
+        62078
+      );
       const deviceValues = await new LockdowndClient(socket).getAllValues();
       socket.end();
       // TODO: Add support for osType (ipad, watchos, etc)
       return {
-        name:
-          deviceValues.DeviceName ??
-          deviceValues.ProductType ??
-          "unknown iOS device",
+        name: deviceValues.DeviceName ?? deviceValues.ProductType ?? 'unknown iOS device',
         model: deviceValues.ProductType,
         osVersion: deviceValues.ProductVersion,
-        deviceType: "device",
+        deviceType: 'device',
         connectionType: device.Properties.ConnectionType,
         udid: device.Properties.SerialNumber,
-        osType: "iOS",
+        osType: 'iOS',
       };
     })
   );
@@ -78,7 +71,7 @@ export async function runOnDevice({
     await mountDeveloperDiskImage(clientManager);
 
     const packageName = path.basename(appPath);
-    const destPackagePath = path.join("PublicStaging", packageName);
+    const destPackagePath = path.join('PublicStaging', packageName);
 
     await uploadApp(clientManager, {
       appBinaryPath: appPath,
@@ -91,17 +84,17 @@ export async function runOnDevice({
       bundleId,
       {
         // https://github.com/ios-control/ios-deploy/blob/0f2ffb1e564aa67a2dfca7cdf13de47ce489d835/src/ios-deploy/ios-deploy.m#L2491-L2508
-        ApplicationsType: "Any",
+        ApplicationsType: 'Any',
 
         CFBundleIdentifier: bundleId,
-        CloseOnInvalidate: "1",
-        InvalidateOnDetach: "1",
-        IsUserInitiated: "1",
+        CloseOnInvalidate: '1',
+        InvalidateOnDetach: '1',
+        IsUserInitiated: '1',
         // Disable checking for wifi devices, this is nominally faster.
-        PreferWifi: "0",
+        PreferWifi: '0',
         // Only info I could find on these:
         // https://github.com/wwxxyx/Quectel_BG96/blob/310876f90fc1093a59e45e381160eddcc31697d0/Apple_Homekit/homekit_certification_tools/ATS%206/ATS%206/ATS.app/Contents/Frameworks/CaptureKit.framework/Versions/A/Resources/MobileDevice/MobileInstallation.h#L112-L121
-        PackageType: "Developer",
+        PackageType: 'Developer',
         ShadowParentKey: deltaPath,
         // SkipUninstall: '1'
       },
@@ -133,14 +126,12 @@ export async function runOnDevice({
         const result = await debugServerClient.continue();
         // TODO: I have no idea what this packet means yet (successful close?)
         // if not a close (ie, most likely due to halt from onBeforeExit), then kill the app
-        if (result !== "W00") {
+        if (result !== 'W00') {
           await debugServerClient.kill();
         }
       }
     } else {
-      console.log(
-        `App "${bundleId}" installed but couldn't be launched. Open on device manually.`
-      );
+      console.log(`App "${bundleId}" installed but couldn't be launched. Open on device manually.`);
     }
   } finally {
     clientManager.end();
@@ -154,40 +145,26 @@ async function mountDeveloperDiskImage(clientManager: ClientManager) {
   if (!(await imageMounter.lookupImage()).ImageSignature) {
     // verify DeveloperDiskImage exists (TODO: how does this work on Windows/Linux?)
     // TODO: if windows/linux, download?
-    const version = await (
-      await clientManager.getLockdowndClient()
-    ).getValue("ProductVersion");
-    const developerDiskImagePath =
-      await XcodeDeveloperDiskImagePrerequisite.instance.assertAsync({
-        version,
-      });
-    const developerDiskImageSig = fs.readFileSync(
-      `${developerDiskImagePath}.signature`
-    );
-    await imageMounter.uploadImage(
-      developerDiskImagePath,
-      developerDiskImageSig
-    );
-    await imageMounter.mountImage(
-      developerDiskImagePath,
-      developerDiskImageSig
-    );
+    const version = await (await clientManager.getLockdowndClient()).getValue('ProductVersion');
+    const developerDiskImagePath = await XcodeDeveloperDiskImagePrerequisite.instance.assertAsync({
+      version,
+    });
+    const developerDiskImageSig = fs.readFileSync(`${developerDiskImagePath}.signature`);
+    await imageMounter.uploadImage(developerDiskImagePath, developerDiskImageSig);
+    await imageMounter.mountImage(developerDiskImagePath, developerDiskImageSig);
   }
 }
 
 async function uploadApp(
   clientManager: ClientManager,
-  {
-    appBinaryPath,
-    destinationPath,
-  }: { appBinaryPath: string; destinationPath: string }
+  { appBinaryPath, destinationPath }: { appBinaryPath: string; destinationPath: string }
 ) {
   const afcClient = await clientManager.getAFCClient();
   try {
-    await afcClient.getFileInfo("PublicStaging");
+    await afcClient.getFileInfo('PublicStaging');
   } catch (err: any) {
     if (err instanceof AFCError && err.status === AFC_STATUS.OBJECT_NOT_FOUND) {
-      await afcClient.makeDirectory("PublicStaging");
+      await afcClient.makeDirectory('PublicStaging');
     } else {
       throw err;
     }
@@ -207,23 +184,21 @@ async function launchAppWithUsbmux(
     await debugServerClient.launchApp(appInfo.Path, appInfo.CFBundleExecutable);
 
     const result = await debugServerClient.checkLaunchSuccess();
-    if (result === "OK") {
+    if (result === 'OK') {
       if (detach) {
         // https://github.com/libimobiledevice/libimobiledevice/blob/25059d4c7d75e03aab516af2929d7c6e6d4c17de/tools/idevicedebug.c#L455-L464
-        const res = await debugServerClient.sendCommand("D", []);
-        console.log("Disconnect from debug server request:", res);
-        if (res !== "OK") {
+        const res = await debugServerClient.sendCommand('D', []);
+        console.log('Disconnect from debug server request:', res);
+        if (res !== 'OK') {
           console.warn(
-            "Something went wrong while attempting to disconnect from iOS debug server, you may need to reopen the app manually."
+            'Something went wrong while attempting to disconnect from iOS debug server, you may need to reopen the app manually.'
           );
         }
       }
 
       return debugServerClient;
-    } else if (result === "EBusy" || result === "ENotFound") {
-      console.log(
-        "Device busy or app not found, trying to launch again in .5s..."
-      );
+    } else if (result === 'EBusy' || result === 'ENotFound') {
+      console.log('Device busy or app not found, trying to launch again in .5s...');
       tries++;
       debugServerClient.socket.end();
       await delayAsync(500);
@@ -231,19 +206,11 @@ async function launchAppWithUsbmux(
       throw new CommandError(`There was an error launching app: ${result}`);
     }
   }
-  throw new CommandError("Unable to launch app, number of tries exceeded");
+  throw new CommandError('Unable to launch app, number of tries exceeded');
 }
 
 async function launchAppWithDeviceCtl(deviceId: string, bundleId: string) {
-  await xcrunAsync([
-    "devicectl",
-    "device",
-    "process",
-    "launch",
-    "--device",
-    deviceId,
-    bundleId,
-  ]);
+  await xcrunAsync(['devicectl', 'device', 'process', 'launch', '--device', deviceId, bundleId]);
 }
 
 /**
@@ -263,9 +230,7 @@ async function launchApp(
   try {
     return await launchAppWithUsbmux(clientManager, { appInfo, detach });
   } catch (error) {
-    debug(
-      `Failed to launch app with Usbmuxd, falling back to xcrun... ${error}`
-    );
+    debug(`Failed to launch app with Usbmuxd, falling back to xcrun... ${error}`);
 
     // Get the device UDID and close the connection, to allow `xcrun devicectl` to connect
     const deviceId = clientManager.device.Properties.SerialNumber;
@@ -276,11 +241,8 @@ async function launchApp(
   }
 }
 
-export async function getBundleIdentifierForBinaryAsync(
-  binaryPath: string
-): Promise<string> {
-  const builtInfoPlistPath = path.join(binaryPath, "Info.plist");
-  const { CFBundleIdentifier } =
-    await parseBinaryPlistAsync(builtInfoPlistPath);
+export async function getBundleIdentifierForBinaryAsync(binaryPath: string): Promise<string> {
+  const builtInfoPlistPath = path.join(binaryPath, 'Info.plist');
+  const { CFBundleIdentifier } = await parseBinaryPlistAsync(builtInfoPlistPath);
   return CFBundleIdentifier;
 }

--- a/packages/eas-shared/src/run/ios/appleDevice/Prerequisite.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/Prerequisite.ts
@@ -1,10 +1,10 @@
-import { CommandError, UnimplementedError } from "../../../utils/errors";
-import { memoize } from "../../../utils/fn";
+import { CommandError, UnimplementedError } from '../../../utils/errors';
+import { memoize } from '../../../utils/fn';
 
 /** An error that is memoized and asserted whenever a Prerequisite.assertAsync is subsequently called. */
 export class PrerequisiteCommandError extends CommandError {
-  constructor(code: string, message: string = "") {
-    super(message ? "VALIDATE_" + code : code, message);
+  constructor(code: string, message: string = '') {
+    super(message ? 'VALIDATE_' + code : code, message);
   }
 }
 
@@ -46,10 +46,7 @@ export class Prerequisite<T = void, TProps = void> {
 }
 
 /** A prerequisite that is project specific. */
-export class ProjectPrerequisite<T = void, TProps = void> extends Prerequisite<
-  T,
-  TProps
-> {
+export class ProjectPrerequisite<T = void, TProps = void> extends Prerequisite<T, TProps> {
   constructor(protected projectRoot: string) {
     super();
   }

--- a/packages/eas-shared/src/run/ios/appleDevice/XcodeDeveloperDiskImagePrerequisite.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/XcodeDeveloperDiskImagePrerequisite.ts
@@ -1,43 +1,31 @@
-import spawnAsync from "@expo/spawn-async";
-import fs from "fs/promises";
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs/promises';
 
-import { Prerequisite, PrerequisiteCommandError } from "./Prerequisite";
+import { Prerequisite, PrerequisiteCommandError } from './Prerequisite';
 
-const ERROR_CODE = "XCODE_DEVELOPER_DISK_IMAGE";
+const ERROR_CODE = 'XCODE_DEVELOPER_DISK_IMAGE';
 async function getXcodePathAsync(): Promise<string> {
   try {
-    const { stdout } = await spawnAsync("xcode-select", ["-p"]);
+    const { stdout } = await spawnAsync('xcode-select', ['-p']);
     if (stdout) {
       return stdout.trim();
     }
   } catch (error: any) {
     console.log(`Could not find Xcode path: %O`, error);
   }
-  throw new PrerequisiteCommandError(ERROR_CODE, "Unable to locate Xcode.");
+  throw new PrerequisiteCommandError(ERROR_CODE, 'Unable to locate Xcode.');
 }
 
-export class XcodeDeveloperDiskImagePrerequisite extends Prerequisite<
-  string,
-  { version: string }
-> {
+export class XcodeDeveloperDiskImagePrerequisite extends Prerequisite<string, { version: string }> {
   static instance = new XcodeDeveloperDiskImagePrerequisite();
 
-  override async assertImplementation({
-    version,
-  }: {
-    version: string;
-  }): Promise<string> {
+  override async assertImplementation({ version }: { version: string }): Promise<string> {
     const xcodePath = await getXcodePathAsync();
     // Like "11.2 (15C107)"
-    const versions = await fs.readdir(
-      `${xcodePath}/Platforms/iPhoneOS.platform/DeviceSupport/`
-    );
+    const versions = await fs.readdir(`${xcodePath}/Platforms/iPhoneOS.platform/DeviceSupport/`);
     const prefix = version.match(/\d+\.\d+/);
     if (prefix === null) {
-      throw new PrerequisiteCommandError(
-        ERROR_CODE,
-        `Invalid iOS version: ${version}`
-      );
+      throw new PrerequisiteCommandError(ERROR_CODE, `Invalid iOS version: ${version}`);
     }
     for (const directory of versions) {
       if (directory.includes(prefix[0])) {

--- a/packages/eas-shared/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/AFCClient.ts
@@ -5,14 +5,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import Debug from "debug";
-import * as fs from "fs";
-import { Socket } from "net";
-import * as path from "path";
-import { promisify } from "util";
+import Debug from 'debug';
+import * as fs from 'fs';
+import { Socket } from 'net';
+import * as path from 'path';
+import { promisify } from 'util';
 
-import { ServiceClient } from "./ServiceClient";
-import { CommandError } from "../../../../utils/errors";
+import { ServiceClient } from './ServiceClient';
+import { CommandError } from '../../../../utils/errors';
 import {
   AFC_FILE_OPEN_FLAGS,
   AFC_OPS,
@@ -20,9 +20,9 @@ import {
   AFCError,
   AFCProtocolClient,
   AFCResponse,
-} from "../protocol/AFCProtocol";
+} from '../protocol/AFCProtocol';
 
-const debug = Debug("expo:apple-device:client:afc");
+const debug = Debug('expo:apple-device:client:afc');
 const MAX_OPEN_FILES = 240;
 
 export class AFCClient extends ServiceClient<AFCProtocolClient> {
@@ -40,12 +40,12 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
     debug(`getFileInfo:response: %O`, response);
 
     const strings: string[] = [];
-    let currentString = "";
+    let currentString = '';
     const tokens = response.data;
     tokens.forEach((token) => {
       if (token === 0) {
         strings.push(currentString);
-        currentString = "";
+        currentString = '';
       } else {
         currentString += String.fromCharCode(token);
       }
@@ -54,11 +54,7 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
   }
 
   async writeFile(fd: Buffer, data: Buffer): Promise<AFCResponse> {
-    debug(
-      `writeFile: ${Array.prototype.toString.call(fd)} data size: ${
-        data.length
-      }`
-    );
+    debug(`writeFile: ${Array.prototype.toString.call(fd)} data size: ${data.length}`);
 
     const response = await this.protocolClient.sendMessage({
       operation: AFC_OPS.FILE_WRITE,
@@ -91,7 +87,7 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
     }
 
     throw new CommandError(
-      "APPLE_DEVICE_AFC",
+      'APPLE_DEVICE_AFC',
       `There was an unknown error opening file ${path}, response: ${Array.prototype.toString.call(
         response.data
       )}`
@@ -154,14 +150,9 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
       const promises: Promise<void>[] = [];
       for (const file of fs.readdirSync(dirPath)) {
         const filePath = path.join(dirPath, file);
-        const remotePath = path.join(
-          destPath,
-          path.relative(srcPath, filePath)
-        );
+        const remotePath = path.join(destPath, path.relative(srcPath, filePath));
         if (fs.lstatSync(filePath).isDirectory()) {
-          promises.push(
-            _this.makeDirectory(remotePath).then(() => uploadDir(filePath))
-          );
+          promises.push(_this.makeDirectory(remotePath).then(() => uploadDir(filePath)));
         } else {
           // Create promise to add to promises array
           // this way it can be resolved once a pending upload has finished
@@ -190,9 +181,7 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
                 // Couldn't get fd for whatever reason, try again
                 // # of retries is arbitrary and can be adjusted
                 if (err.status === AFC_STATUS.NO_RESOURCES && tries < 10) {
-                  debug(
-                    `Received NO_RESOURCES from AFC, retrying ${filePath} upload. ${tries}`
-                  );
+                  debug(`Received NO_RESOURCES from AFC, retrying ${filePath} upload. ${tries}`);
                   uploadFile(tries++);
                 } else {
                   numOpenFiles--;

--- a/packages/eas-shared/src/run/ios/appleDevice/client/DebugserverClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/DebugserverClient.ts
@@ -5,14 +5,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import Debug from "debug";
-import { Socket } from "net";
-import * as path from "path";
+import Debug from 'debug';
+import { Socket } from 'net';
+import * as path from 'path';
 
-import { ServiceClient } from "./ServiceClient";
-import { GDBProtocolClient } from "../protocol/GDBProtocol";
+import { ServiceClient } from './ServiceClient';
+import { GDBProtocolClient } from '../protocol/GDBProtocol';
 
-const debug = Debug("expo:apple-device:client:debugserver");
+const debug = Debug('expo:apple-device:client:debugserver');
 
 export class DebugserverClient extends ServiceClient<GDBProtocolClient> {
   constructor(socket: Socket) {
@@ -20,49 +20,46 @@ export class DebugserverClient extends ServiceClient<GDBProtocolClient> {
   }
 
   async setMaxPacketSize(size: number) {
-    return this.sendCommand("QSetMaxPacketSize:", [size.toString()]);
+    return this.sendCommand('QSetMaxPacketSize:', [size.toString()]);
   }
 
   async setWorkingDir(workingDir: string) {
-    return this.sendCommand("QSetWorkingDir:", [workingDir]);
+    return this.sendCommand('QSetWorkingDir:', [workingDir]);
   }
 
   async checkLaunchSuccess() {
-    return this.sendCommand("qLaunchSuccess", []);
+    return this.sendCommand('qLaunchSuccess', []);
   }
 
   async attachByName(name: string) {
-    const hexName = Buffer.from(name).toString("hex");
+    const hexName = Buffer.from(name).toString('hex');
     return this.sendCommand(`vAttachName;${hexName}`, []);
   }
 
   async continue() {
-    return this.sendCommand("c", []);
+    return this.sendCommand('c', []);
   }
 
   halt() {
     // ^C
-    debug("Sending ^C to debugserver");
-    return this.protocolClient.socket.write("\u0003");
+    debug('Sending ^C to debugserver');
+    return this.protocolClient.socket.write('\u0003');
   }
 
   async kill() {
     debug(`kill`);
-    const msg: any = { cmd: "k", args: [] };
-    return this.protocolClient.sendMessage(
-      msg,
-      (resp: string, resolve: any) => {
-        debug(`kill:response: ${resp}`);
-        this.protocolClient.socket.write("+");
-        const parts = resp.split(";");
-        for (const part of parts) {
-          if (part.includes("description")) {
-            // description:{hex encoded message like: "Terminated with signal 9"}
-            resolve(Buffer.from(part.split(":")[1], "hex").toString("ascii"));
-          }
+    const msg: any = { cmd: 'k', args: [] };
+    return this.protocolClient.sendMessage(msg, (resp: string, resolve: any) => {
+      debug(`kill:response: ${resp}`);
+      this.protocolClient.socket.write('+');
+      const parts = resp.split(';');
+      for (const part of parts) {
+        if (part.includes('description')) {
+          // description:{hex encoded message like: "Terminated with signal 9"}
+          resolve(Buffer.from(part.split(':')[1], 'hex').toString('ascii'));
         }
       }
-    );
+    });
   }
 
   // TODO support app args
@@ -70,7 +67,7 @@ export class DebugserverClient extends ServiceClient<GDBProtocolClient> {
   // A arglen,argnum,arg,
   async launchApp(appPath: string, executableName: string) {
     const fullPath = path.join(appPath, executableName);
-    const hexAppPath = Buffer.from(fullPath).toString("hex");
+    const hexAppPath = Buffer.from(fullPath).toString('hex');
     const appCommand = `A${hexAppPath.length},0,${hexAppPath}`;
     return this.sendCommand(appCommand, []);
   }
@@ -80,7 +77,7 @@ export class DebugserverClient extends ServiceClient<GDBProtocolClient> {
     debug(`Sending command: ${cmd}, args: ${args}`);
     const resp = await this.protocolClient.sendMessage(msg);
     // we need to ACK as well
-    this.protocolClient.socket.write("+");
+    this.protocolClient.socket.write('+');
     return resp;
   }
 }

--- a/packages/eas-shared/src/run/ios/appleDevice/client/InstallationProxyClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/InstallationProxyClient.ts
@@ -5,17 +5,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import Debug from "debug";
-import { Socket } from "net";
+import Debug from 'debug';
+import { Socket } from 'net';
 
-import { ResponseError, ServiceClient } from "./ServiceClient";
-import { LockdownProtocolClient } from "../protocol/LockdownProtocol";
-import type {
-  LockdownCommand,
-  LockdownResponse,
-} from "../protocol/LockdownProtocol";
+import { ResponseError, ServiceClient } from './ServiceClient';
+import { LockdownProtocolClient } from '../protocol/LockdownProtocol';
+import type { LockdownCommand, LockdownResponse } from '../protocol/LockdownProtocol';
 
-const debug = Debug("expo:apple-device:client:installation_proxy");
+const debug = Debug('expo:apple-device:client:installation_proxy');
 
 export type OnInstallProgressCallback = (props: {
   status: string;
@@ -25,33 +22,33 @@ export type OnInstallProgressCallback = (props: {
 }) => void;
 
 interface IPOptions {
-  ApplicationsType?: "Any";
-  PackageType?: "Developer";
+  ApplicationsType?: 'Any';
+  PackageType?: 'Developer';
   CFBundleIdentifier?: string;
 
   ReturnAttributes?: (
-    | "CFBundleIdentifier"
-    | "ApplicationDSID"
-    | "ApplicationType"
-    | "CFBundleExecutable"
-    | "CFBundleDisplayName"
-    | "CFBundleIconFile"
-    | "CFBundleName"
-    | "CFBundleShortVersionString"
-    | "CFBundleSupportedPlatforms"
-    | "CFBundleURLTypes"
-    | "CodeInfoIdentifier"
-    | "Container"
-    | "Entitlements"
-    | "HasSettingsBundle"
-    | "IsUpgradeable"
-    | "MinimumOSVersion"
-    | "Path"
-    | "SignerIdentity"
-    | "UIDeviceFamily"
-    | "UIFileSharingEnabled"
-    | "UIStatusBarHidden"
-    | "UISupportedInterfaceOrientations"
+    | 'CFBundleIdentifier'
+    | 'ApplicationDSID'
+    | 'ApplicationType'
+    | 'CFBundleExecutable'
+    | 'CFBundleDisplayName'
+    | 'CFBundleIconFile'
+    | 'CFBundleName'
+    | 'CFBundleShortVersionString'
+    | 'CFBundleSupportedPlatforms'
+    | 'CFBundleURLTypes'
+    | 'CodeInfoIdentifier'
+    | 'Container'
+    | 'Entitlements'
+    | 'HasSettingsBundle'
+    | 'IsUpgradeable'
+    | 'MinimumOSVersion'
+    | 'Path'
+    | 'SignerIdentity'
+    | 'UIDeviceFamily'
+    | 'UIFileSharingEnabled'
+    | 'UIStatusBarHidden'
+    | 'UISupportedInterfaceOrientations'
   )[];
   BundleIDs?: string[];
   [key: string]: undefined | string | string[];
@@ -66,7 +63,7 @@ interface IPInstallCFBundleIdentifierResponseItem {
 }
 
 interface IPInstallCompleteResponseItem extends LockdownResponse {
-  Status: "Complete";
+  Status: 'Complete';
 }
 /*
  *  [{ "PercentComplete": 5, "Status": "CreatingStagingDirectory" }]
@@ -76,8 +73,7 @@ interface IPInstallCompleteResponseItem extends LockdownResponse {
  *  [{ "Status": "Complete" }]
  */
 type IPInstallPercentCompleteResponse = IPInstallPercentCompleteResponseItem[];
-type IPInstallCFBundleIdentifierResponse =
-  IPInstallCFBundleIdentifierResponseItem[];
+type IPInstallCFBundleIdentifierResponse = IPInstallCFBundleIdentifierResponseItem[];
 type IPInstallCompleteResponse = IPInstallCompleteResponseItem[];
 
 interface IPMessage extends LockdownCommand {
@@ -110,9 +106,7 @@ function isIPLookupResponse(resp: any): resp is IPLookupResponse {
   return resp.length && resp[0].LookupResult !== undefined;
 }
 
-function isIPInstallPercentCompleteResponse(
-  resp: any
-): resp is IPInstallPercentCompleteResponse {
+function isIPInstallPercentCompleteResponse(resp: any): resp is IPInstallPercentCompleteResponse {
   return resp.length && resp[0].PercentComplete !== undefined;
 }
 
@@ -122,15 +116,11 @@ function isIPInstallCFBundleIdentifierResponse(
   return resp.length && resp[0].CFBundleIdentifier !== undefined;
 }
 
-function isIPInstallCompleteResponse(
-  resp: any
-): resp is IPInstallCompleteResponse {
-  return resp.length && resp[0].Status === "Complete";
+function isIPInstallCompleteResponse(resp: any): resp is IPInstallCompleteResponse {
+  return resp.length && resp[0].Status === 'Complete';
 }
 
-export class InstallationProxyClient extends ServiceClient<
-  LockdownProtocolClient<IPMessage>
-> {
+export class InstallationProxyClient extends ServiceClient<LockdownProtocolClient<IPMessage>> {
   constructor(public override socket: Socket) {
     super(socket, new LockdownProtocolClient(socket));
   }
@@ -138,19 +128,14 @@ export class InstallationProxyClient extends ServiceClient<
   async lookupApp(
     bundleIds: string[],
     options: IPOptions = {
-      ReturnAttributes: [
-        "Path",
-        "Container",
-        "CFBundleExecutable",
-        "CFBundleIdentifier",
-      ],
-      ApplicationsType: "Any",
+      ReturnAttributes: ['Path', 'Container', 'CFBundleExecutable', 'CFBundleIdentifier'],
+      ApplicationsType: 'Any',
     }
   ) {
     debug(`lookupApp, options: ${JSON.stringify(options)}`);
 
     let resp = await this.protocolClient.sendMessage({
-      Command: "Lookup",
+      Command: 'Lookup',
       ClientOptions: {
         BundleIDs: bundleIds,
         ...options,
@@ -168,8 +153,8 @@ export class InstallationProxyClient extends ServiceClient<
     packagePath: string,
     bundleId: string,
     options: IPOptions = {
-      ApplicationsType: "Any",
-      PackageType: "Developer",
+      ApplicationsType: 'Any',
+      PackageType: 'Developer',
     },
     onProgress: OnInstallProgressCallback
   ) {
@@ -177,7 +162,7 @@ export class InstallationProxyClient extends ServiceClient<
 
     return this.protocolClient.sendMessage(
       {
-        Command: "Install",
+        Command: 'Install',
         PackagePath: packagePath,
         ClientOptions: {
           CFBundleIdentifier: bundleId,
@@ -200,16 +185,13 @@ export class InstallationProxyClient extends ServiceClient<
             progress: resp[0].PercentComplete,
             status: resp[0].Status,
           });
-          debug(
-            `Installation status: ${resp[0].Status}, %${resp[0].PercentComplete}`
-          );
+          debug(`Installation status: ${resp[0].Status}, %${resp[0].PercentComplete}`);
         } else if (isIPInstallCFBundleIdentifierResponse(resp)) {
           debug(`Installed app: ${resp[0].CFBundleIdentifier}`);
         } else {
           reject(
             new ResponseError(
-              "There was an error installing app: " +
-                require("util").inspect(resp),
+              'There was an error installing app: ' + require('util').inspect(resp),
               resp
             )
           );

--- a/packages/eas-shared/src/run/ios/appleDevice/client/LockdowndClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/LockdowndClient.ts
@@ -5,15 +5,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import Debug from "debug";
-import { Socket } from "net";
-import * as tls from "tls";
+import Debug from 'debug';
+import { Socket } from 'net';
+import * as tls from 'tls';
 
-import { ResponseError, ServiceClient } from "./ServiceClient";
-import { UsbmuxdPairRecord } from "./UsbmuxdClient";
-import { LockdownProtocolClient } from "../protocol/LockdownProtocol";
+import { ResponseError, ServiceClient } from './ServiceClient';
+import { UsbmuxdPairRecord } from './UsbmuxdClient';
+import { LockdownProtocolClient } from '../protocol/LockdownProtocol';
 
-const debug = Debug("expo:apple-device:client:lockdownd");
+const debug = Debug('expo:apple-device:client:lockdownd');
 
 export interface DeviceValues {
   BasebandCertId: number;
@@ -27,7 +27,7 @@ export interface DeviceValues {
   BoardId: number;
   BuildVersion: string;
   ChipID: number;
-  ConnectionType: "USB" | "Network";
+  ConnectionType: 'USB' | 'Network';
   DeviceClass: string;
   DeviceColor: string;
   DeviceName: string;
@@ -48,67 +48,51 @@ export interface DeviceValues {
 }
 
 interface LockdowndServiceResponse {
-  Request: "StartService";
+  Request: 'StartService';
   Service: string;
   Port: number;
   EnableServiceSSL?: boolean; // Only on iOS 13+
 }
 
 interface LockdowndSessionResponse {
-  Request: "StartSession";
+  Request: 'StartSession';
   EnableSessionSSL: boolean;
 }
 
 interface LockdowndAllValuesResponse {
-  Request: "GetValue";
+  Request: 'GetValue';
   Value: DeviceValues;
 }
 
 interface LockdowndValueResponse {
-  Request: "GetValue";
+  Request: 'GetValue';
   Key: string;
   Value: string;
 }
 
 interface LockdowndQueryTypeResponse {
-  Request: "QueryType";
+  Request: 'QueryType';
   Type: string;
 }
 
-function isLockdowndServiceResponse(
-  resp: any
-): resp is LockdowndServiceResponse {
-  return (
-    resp.Request === "StartService" &&
-    resp.Service !== undefined &&
-    resp.Port !== undefined
-  );
+function isLockdowndServiceResponse(resp: any): resp is LockdowndServiceResponse {
+  return resp.Request === 'StartService' && resp.Service !== undefined && resp.Port !== undefined;
 }
 
-function isLockdowndSessionResponse(
-  resp: any
-): resp is LockdowndSessionResponse {
-  return resp.Request === "StartSession";
+function isLockdowndSessionResponse(resp: any): resp is LockdowndSessionResponse {
+  return resp.Request === 'StartSession';
 }
 
-function isLockdowndAllValuesResponse(
-  resp: any
-): resp is LockdowndAllValuesResponse {
-  return resp.Request === "GetValue" && resp.Value !== undefined;
+function isLockdowndAllValuesResponse(resp: any): resp is LockdowndAllValuesResponse {
+  return resp.Request === 'GetValue' && resp.Value !== undefined;
 }
 
 function isLockdowndValueResponse(resp: any): resp is LockdowndValueResponse {
-  return (
-    resp.Request === "GetValue" &&
-    resp.Key !== undefined &&
-    typeof resp.Value === "string"
-  );
+  return resp.Request === 'GetValue' && resp.Key !== undefined && typeof resp.Value === 'string';
 }
 
-function isLockdowndQueryTypeResponse(
-  resp: any
-): resp is LockdowndQueryTypeResponse {
-  return resp.Request === "QueryType" && resp.Type !== undefined;
+function isLockdowndQueryTypeResponse(resp: any): resp is LockdowndQueryTypeResponse {
+  return resp.Request === 'QueryType' && resp.Type !== undefined;
 }
 
 export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
@@ -120,7 +104,7 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
     debug(`startService: ${name}`);
 
     const resp = await this.protocolClient.sendMessage({
-      Request: "StartService",
+      Request: 'StartService',
       Service: name,
     });
 
@@ -135,44 +119,41 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
     debug(`startSession: ${pairRecord}`);
 
     const resp = await this.protocolClient.sendMessage({
-      Request: "StartSession",
+      Request: 'StartSession',
       HostID: pairRecord.HostID,
       SystemBUID: pairRecord.SystemBUID,
     });
 
     if (isLockdowndSessionResponse(resp)) {
       if (resp.EnableSessionSSL) {
-        this.protocolClient.socket = new tls.TLSSocket(
-          this.protocolClient.socket,
-          {
-            secureContext: tls.createSecureContext({
-              // Avoid using `secureProtocol` fixing the socket to a single TLS version.
-              // Newer Node versions might not support older TLS versions.
-              // By using the default `minVersion` and `maxVersion` options,
-              // The socket will automatically use the appropriate TLS version.
-              // See: https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
-              cert: pairRecord.RootCertificate,
-              key: pairRecord.RootPrivateKey,
-            }),
-          }
-        );
+        this.protocolClient.socket = new tls.TLSSocket(this.protocolClient.socket, {
+          secureContext: tls.createSecureContext({
+            // Avoid using `secureProtocol` fixing the socket to a single TLS version.
+            // Newer Node versions might not support older TLS versions.
+            // By using the default `minVersion` and `maxVersion` options,
+            // The socket will automatically use the appropriate TLS version.
+            // See: https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions
+            cert: pairRecord.RootCertificate,
+            key: pairRecord.RootPrivateKey,
+          }),
+        });
         debug(`Socket upgraded to TLS connection`);
       }
       // TODO: save sessionID for StopSession?
     } else {
-      throw new ResponseError("Error starting session", resp);
+      throw new ResponseError('Error starting session', resp);
     }
   }
 
   async getAllValues() {
     debug(`getAllValues`);
 
-    const resp = await this.protocolClient.sendMessage({ Request: "GetValue" });
+    const resp = await this.protocolClient.sendMessage({ Request: 'GetValue' });
 
     if (isLockdowndAllValuesResponse(resp)) {
       return resp.Value;
     } else {
-      throw new ResponseError("Error getting lockdown value", resp);
+      throw new ResponseError('Error getting lockdown value', resp);
     }
   }
 
@@ -180,33 +161,33 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
     debug(`getValue: ${val}`);
 
     const resp = await this.protocolClient.sendMessage({
-      Request: "GetValue",
+      Request: 'GetValue',
       Key: val,
     });
 
     if (isLockdowndValueResponse(resp)) {
       return resp.Value;
     } else {
-      throw new ResponseError("Error getting lockdown value", resp);
+      throw new ResponseError('Error getting lockdown value', resp);
     }
   }
 
   async queryType() {
-    debug("queryType");
+    debug('queryType');
 
     const resp = await this.protocolClient.sendMessage({
-      Request: "QueryType",
+      Request: 'QueryType',
     });
 
     if (isLockdowndQueryTypeResponse(resp)) {
       return resp.Type;
     } else {
-      throw new ResponseError("Error getting lockdown query type", resp);
+      throw new ResponseError('Error getting lockdown query type', resp);
     }
   }
 
   async doHandshake(pairRecord: UsbmuxdPairRecord) {
-    debug("doHandshake");
+    debug('doHandshake');
 
     // if (await this.lockdownQueryType() !== 'com.apple.mobile.lockdown') {
     //   throw new CommandError('Invalid type received from lockdown handshake');

--- a/packages/eas-shared/src/run/ios/appleDevice/client/MobileImageMounterClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/MobileImageMounterClient.ts
@@ -5,21 +5,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import Debug from "debug";
-import * as fs from "fs";
-import { Socket } from "net";
+import Debug from 'debug';
+import * as fs from 'fs';
+import { Socket } from 'net';
 
-import { ResponseError, ServiceClient } from "./ServiceClient";
-import type {
-  LockdownCommand,
-  LockdownResponse,
-} from "../protocol/LockdownProtocol";
-import {
-  isLockdownResponse,
-  LockdownProtocolClient,
-} from "../protocol/LockdownProtocol";
+import { ResponseError, ServiceClient } from './ServiceClient';
+import type { LockdownCommand, LockdownResponse } from '../protocol/LockdownProtocol';
+import { isLockdownResponse, LockdownProtocolClient } from '../protocol/LockdownProtocol';
 
-const debug = Debug("expo:apple-device:client:mobile_image_mounter");
+const debug = Debug('expo:apple-device:client:mobile_image_mounter');
 
 export type MIMMountResponse = LockdownResponse;
 
@@ -32,28 +26,22 @@ export interface MIMLookupResponse extends LockdownResponse {
 }
 
 export interface MIMUploadCompleteResponse extends LockdownResponse {
-  Status: "Complete";
+  Status: 'Complete';
 }
 
 export interface MIMUploadReceiveBytesResponse extends LockdownResponse {
-  Status: "ReceiveBytesAck";
+  Status: 'ReceiveBytesAck';
 }
 
-function isMIMUploadCompleteResponse(
-  resp: any
-): resp is MIMUploadCompleteResponse {
-  return resp.Status === "Complete";
+function isMIMUploadCompleteResponse(resp: any): resp is MIMUploadCompleteResponse {
+  return resp.Status === 'Complete';
 }
 
-function isMIMUploadReceiveBytesResponse(
-  resp: any
-): resp is MIMUploadReceiveBytesResponse {
-  return resp.Status === "ReceiveBytesAck";
+function isMIMUploadReceiveBytesResponse(resp: any): resp is MIMUploadReceiveBytesResponse {
+  return resp.Status === 'ReceiveBytesAck';
 }
 
-export class MobileImageMounterClient extends ServiceClient<
-  LockdownProtocolClient<MIMMessage>
-> {
+export class MobileImageMounterClient extends ServiceClient<LockdownProtocolClient<MIMMessage>> {
   constructor(socket: Socket) {
     super(socket, new LockdownProtocolClient(socket));
   }
@@ -62,17 +50,14 @@ export class MobileImageMounterClient extends ServiceClient<
     debug(`mountImage: ${imagePath}`);
 
     const resp = await this.protocolClient.sendMessage({
-      Command: "MountImage",
+      Command: 'MountImage',
       ImagePath: imagePath,
       ImageSignature: imageSig,
-      ImageType: "Developer",
+      ImageType: 'Developer',
     });
 
-    if (!isLockdownResponse(resp) || resp.Status !== "Complete") {
-      throw new ResponseError(
-        `There was an error mounting ${imagePath} on device`,
-        resp
-      );
+    if (!isLockdownResponse(resp) || resp.Status !== 'Complete') {
+      throw new ResponseError(`There was an error mounting ${imagePath} on device`, resp);
     }
   }
 
@@ -82,24 +67,21 @@ export class MobileImageMounterClient extends ServiceClient<
     const imageSize = fs.statSync(imagePath).size;
     return this.protocolClient.sendMessage(
       {
-        Command: "ReceiveBytes",
+        Command: 'ReceiveBytes',
         ImageSize: imageSize,
         ImageSignature: imageSig,
-        ImageType: "Developer",
+        ImageType: 'Developer',
       },
       (resp: any, resolve, reject) => {
         if (isMIMUploadReceiveBytesResponse(resp)) {
           const imageStream = fs.createReadStream(imagePath);
           imageStream.pipe(this.protocolClient.socket, { end: false });
-          imageStream.on("error", (err) => reject(err));
+          imageStream.on('error', (err) => reject(err));
         } else if (isMIMUploadCompleteResponse(resp)) {
           resolve();
         } else {
           reject(
-            new ResponseError(
-              `There was an error uploading image ${imagePath} to the device`,
-              resp
-            )
+            new ResponseError(`There was an error uploading image ${imagePath} to the device`, resp)
           );
         }
       }
@@ -107,11 +89,11 @@ export class MobileImageMounterClient extends ServiceClient<
   }
 
   async lookupImage() {
-    debug("lookupImage");
+    debug('lookupImage');
 
     return this.protocolClient.sendMessage<MIMLookupResponse>({
-      Command: "LookupImage",
-      ImageType: "Developer",
+      Command: 'LookupImage',
+      ImageType: 'Developer',
     });
   }
 }

--- a/packages/eas-shared/src/run/ios/appleDevice/client/ServiceClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/ServiceClient.ts
@@ -5,17 +5,23 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Socket } from "net";
+import { Socket } from 'net';
 
-import { CommandError } from "../../../../utils/errors";
-import { ProtocolClient } from "../protocol/AbstractProtocol";
+import { CommandError } from '../../../../utils/errors';
+import { ProtocolClient } from '../protocol/AbstractProtocol';
 
 export abstract class ServiceClient<T extends ProtocolClient> {
-  constructor(public socket: Socket, protected protocolClient: T) {}
+  constructor(
+    public socket: Socket,
+    protected protocolClient: T
+  ) {}
 }
 
 export class ResponseError extends CommandError {
-  constructor(msg: string, public response: any) {
+  constructor(
+    msg: string,
+    public response: any
+  ) {
     super(msg);
   }
 }

--- a/packages/eas-shared/src/run/ios/appleDevice/installOnDeviceAsync.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/installOnDeviceAsync.ts
@@ -1,18 +1,18 @@
-import chalk from "chalk";
-import { Ora } from "ora";
-import os from "os";
-import path from "path";
+import chalk from 'chalk';
+import { Ora } from 'ora';
+import os from 'os';
+import path from 'path';
 
-import * as AppleDevice from "./AppleDevice";
-import { ora } from "../../../ora";
-import { ensureDirectory } from "../../../utils/dir";
-import { InternalError } from "common-types";
+import * as AppleDevice from './AppleDevice';
+import { ora } from '../../../ora';
+import { ensureDirectory } from '../../../utils/dir';
+import { InternalError } from 'common-types';
 
 /** Get the app_delta folder for faster subsequent rebuilds on devices. */
 export function getAppDeltaDirectory(bundleId: string): string {
   // TODO: Maybe use .expo folder instead for debugging
   // TODO: Reuse existing folder from xcode?
-  const deltaFolder = path.join(os.tmpdir(), "ios", "app-delta", bundleId);
+  const deltaFolder = path.join(os.tmpdir(), 'ios', 'app-delta', bundleId);
   ensureDirectory(deltaFolder);
   return deltaFolder;
 }
@@ -60,11 +60,11 @@ export async function installOnDeviceAsync(props: {
     if (indicator) {
       indicator.fail();
     }
-    if (error.code === "APPLE_DEVICE_LOCKED") {
+    if (error.code === 'APPLE_DEVICE_LOCKED') {
       // Get the app name from the binary path.
-      const appName = path.basename(bundle).split(".")[0] ?? "app";
+      const appName = path.basename(bundle).split('.')[0] ?? 'app';
       throw new InternalError(
-        "APPLE_DEVICE_LOCKED",
+        'APPLE_DEVICE_LOCKED',
         `Unable to launch ${appName} because the device is locked. Please launch the app manually.`
       );
     }

--- a/packages/eas-shared/src/run/ios/appleDevice/protocol/LockdownProtocol.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/protocol/LockdownProtocol.ts
@@ -6,19 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import plist from "@expo/plist";
-import Debug from "debug";
-import { Socket } from "net";
+import plist from '@expo/plist';
+import Debug from 'debug';
+import { Socket } from 'net';
 
-import type { ProtocolWriter } from "./AbstractProtocol";
-import {
-  PlistProtocolReader,
-  ProtocolClient,
-  ProtocolReaderFactory,
-} from "./AbstractProtocol";
-import { CommandError } from "../../../../utils/errors";
+import type { ProtocolWriter } from './AbstractProtocol';
+import { PlistProtocolReader, ProtocolClient, ProtocolReaderFactory } from './AbstractProtocol';
+import { CommandError } from '../../../../utils/errors';
 
-const debug = Debug("expo:apple-device:protocol:lockdown");
+const debug = Debug('expo:apple-device:protocol:lockdown');
 export const LOCKDOWN_HEADER_SIZE = 4;
 
 export interface LockdownCommand {
@@ -43,28 +39,22 @@ export interface LockdownRequest {
 }
 
 function isDefined(val: any) {
-  return typeof val !== "undefined";
+  return typeof val !== 'undefined';
 }
 
 export function isLockdownResponse(resp: any): resp is LockdownResponse {
   return isDefined(resp.Status);
 }
 
-export function isLockdownErrorResponse(
-  resp: any
-): resp is LockdownErrorResponse {
+export function isLockdownErrorResponse(resp: any): resp is LockdownErrorResponse {
   return isDefined(resp.Error);
 }
 
 export class LockdownProtocolClient<
-  MessageType extends LockdownRequest | LockdownCommand = LockdownRequest
+  MessageType extends LockdownRequest | LockdownCommand = LockdownRequest,
 > extends ProtocolClient<MessageType> {
   constructor(socket: Socket) {
-    super(
-      socket,
-      new ProtocolReaderFactory(LockdownProtocolReader),
-      new LockdownProtocolWriter()
-    );
+    super(socket, new ProtocolReaderFactory(LockdownProtocolReader), new LockdownProtocolWriter());
   }
 }
 
@@ -81,23 +71,20 @@ export class LockdownProtocolReader extends PlistProtocolReader {
     const resp = super.parseBody(data);
     debug(`Response: ${JSON.stringify(resp)}`);
     if (isLockdownErrorResponse(resp)) {
-      if (resp.Error === "DeviceLocked") {
-        throw new CommandError(
-          "APPLE_DEVICE_LOCKED",
-          "Device is currently locked."
-        );
+      if (resp.Error === 'DeviceLocked') {
+        throw new CommandError('APPLE_DEVICE_LOCKED', 'Device is currently locked.');
       }
 
-      if (resp.Error === "InvalidService") {
+      if (resp.Error === 'InvalidService') {
         let errorMessage = `${resp.Error}: ${resp.Service} (request: ${resp.Request})`;
-        if (resp.Service === "com.apple.debugserver") {
+        if (resp.Service === 'com.apple.debugserver') {
           errorMessage +=
-            "\nTry reconnecting your device. You can also debug service logs with `export DEBUG=expo:xdl:ios:*`";
+            '\nTry reconnecting your device. You can also debug service logs with `export DEBUG=expo:xdl:ios:*`';
         }
-        throw new CommandError("APPLE_DEVICE_LOCKDOWN", errorMessage);
+        throw new CommandError('APPLE_DEVICE_LOCKDOWN', errorMessage);
       }
 
-      throw new CommandError("APPLE_DEVICE_LOCKDOWN", resp.Error);
+      throw new CommandError('APPLE_DEVICE_LOCKDOWN', resp.Error);
     }
     return resp;
   }

--- a/packages/eas-shared/src/run/ios/appleDevice/protocol/UsbmuxProtocol.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/protocol/UsbmuxProtocol.ts
@@ -6,18 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import plist from "@expo/plist";
-import Debug from "debug";
-import { Socket } from "net";
+import plist from '@expo/plist';
+import Debug from 'debug';
+import { Socket } from 'net';
 
-import type { ProtocolWriter } from "./AbstractProtocol";
-import {
-  PlistProtocolReader,
-  ProtocolClient,
-  ProtocolReaderFactory,
-} from "./AbstractProtocol";
+import type { ProtocolWriter } from './AbstractProtocol';
+import { PlistProtocolReader, ProtocolClient, ProtocolReaderFactory } from './AbstractProtocol';
 
-const debug = Debug("expo:apple-device:protocol:usbmux");
+const debug = Debug('expo:apple-device:protocol:usbmux');
 
 export const USBMUXD_HEADER_SIZE = 16;
 
@@ -28,11 +24,7 @@ export interface UsbmuxMessage {
 
 export class UsbmuxProtocolClient extends ProtocolClient<UsbmuxMessage> {
   constructor(socket: Socket) {
-    super(
-      socket,
-      new ProtocolReaderFactory(UsbmuxProtocolReader),
-      new UsbmuxProtocolWriter()
-    );
+    super(socket, new ProtocolReaderFactory(UsbmuxProtocolReader), new UsbmuxProtocolWriter());
   }
 }
 
@@ -60,10 +52,10 @@ export class UsbmuxProtocolWriter implements ProtocolWriter {
     debug(`socket write: ${JSON.stringify(msg)}`);
     const { messageType, extraFields } = msg;
     const plistMessage = plist.build({
-      BundleID: "dev.expo.native-run", // TODO
-      ClientVersionString: "usbmux.js", // TODO
+      BundleID: 'dev.expo.native-run', // TODO
+      ClientVersionString: 'usbmux.js', // TODO
       MessageType: messageType,
-      ProgName: "native-run", // TODO
+      ProgName: 'native-run', // TODO
       kLibUSBMuxVersion: 3,
       ...extraFields,
     });

--- a/packages/eas-shared/src/run/ios/device.ts
+++ b/packages/eas-shared/src/run/ios/device.ts
@@ -1,11 +1,8 @@
 import {
   getConnectedDevicesAsync,
   getBundleIdentifierForBinaryAsync,
-} from "./appleDevice/AppleDevice";
-import {
-  getAppDeltaDirectory,
-  installOnDeviceAsync,
-} from "./appleDevice/installOnDeviceAsync";
+} from './appleDevice/AppleDevice';
+import { getAppDeltaDirectory, installOnDeviceAsync } from './appleDevice/installOnDeviceAsync';
 
 const AppleDevice = {
   getConnectedDevicesAsync,

--- a/packages/eas-shared/src/run/ios/systemRequirements.ts
+++ b/packages/eas-shared/src/run/ios/systemRequirements.ts
@@ -1,17 +1,17 @@
-import spawnAsync from "@expo/spawn-async";
-import chalk from "chalk";
-import semver from "semver";
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import semver from 'semver';
 
-import Log from "../../log";
-import { getSimulatorAppIdAsync } from "./simulator";
-import * as xcode from "./xcode";
-import { isXcrunInstalledAsync } from "./xcrun";
-import { InternalError } from "common-types";
+import Log from '../../log';
+import { getSimulatorAppIdAsync } from './simulator';
+import * as xcode from './xcode';
+import { isXcrunInstalledAsync } from './xcrun';
+import { InternalError } from 'common-types';
 
 function assertPlatform(): void {
-  if (process.platform !== "darwin") {
-    Log.error("iOS simulator apps can only be run on macOS devices.");
-    throw Error("iOS simulator apps can only be run on macOS devices.");
+  if (process.platform !== 'darwin') {
+    Log.error('iOS simulator apps can only be run on macOS devices.');
+    throw Error('iOS simulator apps can only be run on macOS devices.');
   }
 }
 
@@ -19,14 +19,12 @@ async function assertCorrectXcodeVersionInstalledAsync(): Promise<void> {
   const xcodeVersion = await xcode.getXcodeVersionAsync();
 
   if (!xcodeVersion) {
-    throw new InternalError("XCODE_NOT_INSTALLED", "Xcode is not installed.");
+    throw new InternalError('XCODE_NOT_INSTALLED', 'Xcode is not installed.');
   }
 
   if (semver.lt(xcodeVersion, xcode.MIN_XCODE_VERSION)) {
     throw Error(
-      `Xcode version ${chalk.bold(
-        xcodeVersion
-      )} is too old. Please upgrade to version ${chalk.bold(
+      `Xcode version ${chalk.bold(xcodeVersion)} is too old. Please upgrade to version ${chalk.bold(
         xcode.MIN_XCODE_VERSION
       )} or higher.`
     );
@@ -36,8 +34,8 @@ async function assertCorrectXcodeVersionInstalledAsync(): Promise<void> {
 async function ensureXcrunInstalledAsync(): Promise<void> {
   if (!isXcrunInstalledAsync()) {
     throw new InternalError(
-      "XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED",
-      "Please try again once Xcode Command Line Tools are installed"
+      'XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED',
+      'Please try again once Xcode Command Line Tools are installed'
     );
   }
 }
@@ -51,8 +49,8 @@ async function assertSimulatorAppInstalledAsync(): Promise<void> {
   }
 
   if (
-    simulatorAppId !== "com.apple.iphonesimulator" &&
-    simulatorAppId !== "com.apple.CoreSimulator.SimulatorTrampoline"
+    simulatorAppId !== 'com.apple.iphonesimulator' &&
+    simulatorAppId !== 'com.apple.CoreSimulator.SimulatorTrampoline'
   ) {
     throw new Error(
       `Simulator is installed but is identified as '${simulatorAppId}', can't recognize what that is`
@@ -61,11 +59,11 @@ async function assertSimulatorAppInstalledAsync(): Promise<void> {
 
   try {
     // make sure we can run simctl
-    await spawnAsync("xcrun", ["simctl", "help"]);
+    await spawnAsync('xcrun', ['simctl', 'help']);
   } catch (error: any) {
     Log.warn(`Unable to run simctl:\n${error.toString()}`);
     throw new Error(
-      "xcrun is not configured correctly. Ensure `sudo xcode-select --reset` works before running this command again."
+      'xcrun is not configured correctly. Ensure `sudo xcode-select --reset` works before running this command again.'
     );
   }
 }

--- a/packages/eas-shared/src/run/ios/xcrun.ts
+++ b/packages/eas-shared/src/run/ios/xcrun.ts
@@ -1,16 +1,13 @@
-import spawnAsync, { SpawnOptions, SpawnResult } from "@expo/spawn-async";
-import { InternalError } from "common-types";
-import chalk from "chalk";
+import spawnAsync, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
+import { InternalError } from 'common-types';
+import chalk from 'chalk';
 
-import Log from "../../log";
-import { sleepAsync } from "../../utils/promise";
+import Log from '../../log';
+import { sleepAsync } from '../../utils/promise';
 
-export async function xcrunAsync(
-  args: string[],
-  options?: SpawnOptions
-): Promise<SpawnResult> {
+export async function xcrunAsync(args: string[], options?: SpawnOptions): Promise<SpawnResult> {
   try {
-    return await spawnAsync("xcrun", args, options);
+    return await spawnAsync('xcrun', args, options);
   } catch (e) {
     throwXcrunError(e);
   }
@@ -19,26 +16,23 @@ export async function xcrunAsync(
 function throwXcrunError(e: any): never {
   if (isLicenseOutOfDate(e.stdout) || isLicenseOutOfDate(e.stderr)) {
     throw new InternalError(
-      "XCODE_LICENSE_NOT_ACCEPTED",
-      "Xcode license is not accepted. Please run `sudo xcodebuild -license`."
+      'XCODE_LICENSE_NOT_ACCEPTED',
+      'Xcode license is not accepted. Please run `sudo xcodebuild -license`.'
     );
-  } else if (e.stderr?.includes("not a developer tool or in PATH")) {
+  } else if (e.stderr?.includes('not a developer tool or in PATH')) {
     throw new Error(
       `You may need to run ${chalk.bold(
-        "sudo xcode-select -s /Applications/Xcode.app"
+        'sudo xcode-select -s /Applications/Xcode.app'
       )} and try again.`
     );
   } else if (e.stderr?.match(/the device was not, or could not be, unlocked/)) {
-    throw new InternalError(
-      "APPLE_DEVICE_LOCKED",
-      "Device is currently locked."
-    );
+    throw new InternalError('APPLE_DEVICE_LOCKED', 'Device is currently locked.');
   }
 
   if (Array.isArray(e.output)) {
-    e.message += "\n" + e.output.join("\n").trim();
+    e.message += '\n' + e.output.join('\n').trim();
   } else if (e.stderr) {
-    e.message += "\n" + e.stderr;
+    e.message += '\n' + e.stderr;
   }
 
   throw new Error(
@@ -53,12 +47,12 @@ function isLicenseOutOfDate(text: string): boolean {
   }
 
   const lower = text.toLowerCase();
-  return lower.includes("xcode") && lower.includes("license");
+  return lower.includes('xcode') && lower.includes('license');
 }
 
 export async function isXcrunInstalledAsync(): Promise<boolean> {
   try {
-    await spawnAsync("xcrun", ["--version"]);
+    await spawnAsync('xcrun', ['--version']);
     return true;
   } catch {
     return false;
@@ -66,7 +60,7 @@ export async function isXcrunInstalledAsync(): Promise<boolean> {
 }
 
 export async function installXcrunAsync(): Promise<void> {
-  await spawnAsync("xcode-select", ["--install"]);
+  await spawnAsync('xcode-select', ['--install']);
 
   await waitForXcrunInstallToFinishAsync(60 * 1000, 1000);
 }
@@ -76,21 +70,14 @@ async function waitForXcrunInstallToFinishAsync(
   intervalMs: number
 ): Promise<void> {
   Log.newLine();
-  Log.log("Waiting for Xcode Command Line Tools install to finish...");
+  Log.log('Waiting for Xcode Command Line Tools install to finish...');
 
   const startTime = Date.now();
   while (Date.now() - startTime < maxWaitTimeMs) {
     if (await isXcrunInstalledAsync()) {
       return;
     }
-    await sleepAsync(
-      Math.min(
-        intervalMs,
-        Math.max(maxWaitTimeMs - (Date.now() - startTime), 0)
-      )
-    );
+    await sleepAsync(Math.min(intervalMs, Math.max(maxWaitTimeMs - (Date.now() - startTime), 0)));
   }
-  throw new Error(
-    "Timed out waiting for Xcode Command Line Tools install to finish"
-  );
+  throw new Error('Timed out waiting for Xcode Command Line Tools install to finish');
 }

--- a/packages/eas-shared/src/timer.ts
+++ b/packages/eas-shared/src/timer.ts
@@ -1,4 +1,4 @@
-const LABEL = "DEFAULT";
+const LABEL = 'DEFAULT';
 const startTimes: Record<string, number> = {};
 
 export function hasTimer(label: string): number | null {
@@ -36,21 +36,21 @@ export function formatMilliseconds(duration: number): string {
   const msInHour = 1000 * 60 * 60;
   const hours = Math.trunc(duration / msInHour);
   if (hours > 0) {
-    portions.push(hours + "h");
+    portions.push(hours + 'h');
     duration = duration - hours * msInHour;
   }
 
   const msInMinute = 1000 * 60;
   const minutes = Math.trunc(duration / msInMinute);
   if (minutes > 0) {
-    portions.push(minutes + "m");
+    portions.push(minutes + 'm');
     duration = duration - minutes * msInMinute;
   }
 
   const seconds = Math.trunc(duration / 1000);
   if (seconds > 0) {
-    portions.push(seconds + "s");
+    portions.push(seconds + 's');
   }
 
-  return portions.join(" ");
+  return portions.join(' ');
 }

--- a/packages/eas-shared/src/ts-declarations/xcode/index.d.ts
+++ b/packages/eas-shared/src/ts-declarations/xcode/index.d.ts
@@ -14,7 +14,7 @@ interface pbxFile {
   target?: string;
 }
 
-declare module "xcode" {
+declare module 'xcode' {
   /**
    * UUID that is a key to each fragment of PBXProject.
    */
@@ -26,24 +26,24 @@ declare module "xcode" {
   type UUIDComment = string;
 
   type XCObjectType =
-    | "PBXBuildFile"
-    | "PBXFileReference"
-    | "PBXFrameworksBuildPhase"
-    | "PBXGroup"
-    | "PBXNativeTarget"
-    | "PBXProject"
-    | "PBXResourcesBuildPhase"
-    | "PBXShellScriptBuildPhase"
-    | "PBXSourcesBuildPhase"
-    | "PBXVariantGroup"
-    | "PBXTargetDependency"
-    | "XCBuildConfiguration"
-    | "XCConfigurationList";
+    | 'PBXBuildFile'
+    | 'PBXFileReference'
+    | 'PBXFrameworksBuildPhase'
+    | 'PBXGroup'
+    | 'PBXNativeTarget'
+    | 'PBXProject'
+    | 'PBXResourcesBuildPhase'
+    | 'PBXShellScriptBuildPhase'
+    | 'PBXSourcesBuildPhase'
+    | 'PBXVariantGroup'
+    | 'PBXTargetDependency'
+    | 'XCBuildConfiguration'
+    | 'XCConfigurationList';
 
   type PBXFile = pbxFile;
 
   interface PBXProject {
-    isa: "PBXProject";
+    isa: 'PBXProject';
     attributes: {
       LastUpgradeCheck: number;
       TargetAttributes: Record<
@@ -74,7 +74,7 @@ declare module "xcode" {
   }
 
   interface PBXNativeTarget {
-    isa: "PBXNativeTarget";
+    isa: 'PBXNativeTarget';
     buildConfigurationList: UUID;
     buildConfigurationList_comment: string;
     buildPhases: {
@@ -94,30 +94,30 @@ declare module "xcode" {
   }
 
   interface PBXBuildFile {
-    isa: "PBXBuildFile";
+    isa: 'PBXBuildFile';
     fileRef: UUID;
     // "AppDelegate.m"
     fileRef_comment: string;
   }
 
   interface PBXTargetDependency {
-    isa: "PBXTargetDependency";
+    isa: 'PBXTargetDependency';
     target: UUID;
     targetProxy: UUID;
   }
 
   interface XCConfigurationList {
-    isa: "XCConfigurationList";
+    isa: 'XCConfigurationList';
     buildConfigurations: {
       value: UUID;
-      comment: string | "Release" | "Debug";
+      comment: string | 'Release' | 'Debug';
     }[];
     defaultConfigurationIsVisible: number;
     defaultConfigurationName: string;
   }
 
   interface XCBuildConfiguration {
-    isa: "XCBuildConfiguration";
+    isa: 'XCBuildConfiguration';
     baseConfigurationReference: UUID;
     baseConfigurationReference_comment: string;
     buildSettings: Record<string, string | undefined | number | unknown[]> & {
@@ -157,21 +157,21 @@ declare module "xcode" {
   }
 
   type ProductType =
-    | "com.apple.product-type.application"
-    | "com.apple.product-type.app-extension"
-    | "com.apple.product-type.bundle"
-    | "com.apple.product-type.tool"
-    | "com.apple.product-type.library.dynamic"
-    | "com.apple.product-type.framework"
-    | "com.apple.product-type.library.static"
-    | "com.apple.product-type.bundle.unit-test"
-    | "com.apple.product-type.application.watchapp"
-    | "com.apple.product-type.application.watchapp2"
-    | "com.apple.product-type.watchkit-extension"
-    | "com.apple.product-type.watchkit2-extension";
+    | 'com.apple.product-type.application'
+    | 'com.apple.product-type.app-extension'
+    | 'com.apple.product-type.bundle'
+    | 'com.apple.product-type.tool'
+    | 'com.apple.product-type.library.dynamic'
+    | 'com.apple.product-type.framework'
+    | 'com.apple.product-type.library.static'
+    | 'com.apple.product-type.bundle.unit-test'
+    | 'com.apple.product-type.application.watchapp'
+    | 'com.apple.product-type.application.watchapp2'
+    | 'com.apple.product-type.watchkit-extension'
+    | 'com.apple.product-type.watchkit2-extension';
 
   interface PBXGroup {
-    isa: "PBXGroup";
+    isa: 'PBXGroup';
     children: {
       value: UUID;
       comment?: string;
@@ -328,17 +328,13 @@ declare module "xcode" {
      * Retrieves main part describing PBXProjects that are available in `.pbxproj` file.
      */
     pbxProjectSection(): Record<UUID, PBXProject> & Record<UUIDComment, string>;
-    pbxBuildFileSection(): Record<UUID, PBXBuildFile> &
-      Record<UUIDComment, string>;
+    pbxBuildFileSection(): Record<UUID, PBXBuildFile> & Record<UUIDComment, string>;
     pbxXCBuildConfigurationSection(): Record<UUID, XCBuildConfiguration> &
       Record<UUIDComment, string>;
-    pbxFileReferenceSection(): Record<UUID, PBXFile> &
-      Record<UUIDComment, string>;
-    pbxNativeTargetSection(): Record<UUID, PBXNativeTarget> &
-      Record<UUIDComment, string>;
+    pbxFileReferenceSection(): Record<UUID, PBXFile> & Record<UUIDComment, string>;
+    pbxNativeTargetSection(): Record<UUID, PBXNativeTarget> & Record<UUIDComment, string>;
     xcVersionGroupSection(): unknown;
-    pbxXCConfigurationList(): Record<UUID, XCConfigurationList> &
-      Record<UUIDComment, string>;
+    pbxXCConfigurationList(): Record<UUID, XCConfigurationList> & Record<UUIDComment, string>;
     pbxGroupByName(name: string): PBXGroup | undefined;
     /**
      * @param targetName in most cases it's the name of the application
@@ -399,28 +395,14 @@ declare module "xcode" {
     /**
      * Retrieves PBXNativeTarget by the type
      */
-    getTarget(
-      productType: ProductType
-    ): { uuid: UUID; target: PBXNativeTarget } | null;
-    addToPbxGroupType(
-      file: unknown,
-      groupKey: unknown,
-      groupType: unknown
-    ): void;
+    getTarget(productType: ProductType): { uuid: UUID; target: PBXNativeTarget } | null;
+    addToPbxGroupType(file: unknown, groupKey: unknown, groupType: unknown): void;
     addToPbxVariantGroup(file: unknown, groupKey: unknown): void;
     addToPbxGroup(file: PBXFile, groupKey: UUID): void;
-    pbxCreateGroupWithType(
-      name: unknown,
-      pathName: unknown,
-      groupType: unknown
-    ): unknown;
+    pbxCreateGroupWithType(name: unknown, pathName: unknown, groupType: unknown): unknown;
     pbxCreateVariantGroup(name: unknown): unknown;
     pbxCreateGroup(name: string, pathName: string): UUID;
-    removeFromPbxGroupAndType(
-      file: unknown,
-      groupKey: unknown,
-      groupType: unknown
-    ): void;
+    removeFromPbxGroupAndType(file: unknown, groupKey: unknown, groupType: unknown): void;
     removeFromPbxGroup(file: unknown, groupKey: unknown): void;
     removeFromPbxVariantGroup(file: unknown, groupKey: unknown): void;
     getPBXGroupByKeyAndType(key: unknown, groupType: unknown): unknown;
@@ -433,10 +415,7 @@ declare module "xcode" {
     /**
      * @param criteria Params that should be used to locate desired PBXGroup.
      */
-    findPBXGroupKey(criteria: {
-      name?: string;
-      path?: string;
-    }): UUID | undefined;
+    findPBXGroupKey(criteria: { name?: string; path?: string }): UUID | undefined;
     findPBXVariantGroupKey(criteria: unknown): string;
     addLocalizationVariantGroup(name: unknown): {
       uuid: unknown;
@@ -473,11 +452,7 @@ declare module "xcode" {
     removeFile(path: unknown, group: unknown, opt: unknown): unknown;
     getBuildProperty(prop: unknown, build: unknown): unknown;
     getBuildConfigByName(name: unknown): object;
-    addDataModelDocument(
-      filePath: unknown,
-      group: unknown,
-      opt: unknown
-    ): unknown;
+    addDataModelDocument(filePath: unknown, group: unknown, opt: unknown): unknown;
     addTargetAttribute(prop: unknown, value: unknown, target: unknown): void;
     removeTargetAttribute(prop: unknown, target: unknown): void;
   }
@@ -485,7 +460,7 @@ declare module "xcode" {
   export function project(projectPath: string): XcodeProject;
 }
 
-declare module "xcode/lib/pbxFile" {
+declare module 'xcode/lib/pbxFile' {
   export default class PBXFile implements pbxFile {
     constructor(file: string);
     basename: string;

--- a/packages/eas-shared/src/userSettings.ts
+++ b/packages/eas-shared/src/userSettings.ts
@@ -1,10 +1,10 @@
-import JsonFile from "@expo/json-file";
-import fs from "fs-extra";
-import os from "os";
-import path from "path";
-import { v4 as uuidv4 } from "uuid";
+import JsonFile from '@expo/json-file';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 
-import * as Env from "./env";
+import * as Env from './env';
 
 export type UserSettingsData = {
   developmentCodeSigningId?: string;
@@ -26,7 +26,7 @@ export type UserData = {
   sessionSecret?: string;
 };
 
-const SETTINGS_FILE_NAME = "state.json";
+const SETTINGS_FILE_NAME = 'state.json';
 
 function userSettingsFile(): string {
   return path.join(dotExpoHomeDirectory(), SETTINGS_FILE_NAME);
@@ -47,11 +47,11 @@ function dotExpoHomeDirectory() {
     const home = os.homedir();
 
     if (Env.isStaging()) {
-      dirPath = path.join(home, ".expo-staging");
+      dirPath = path.join(home, '.expo-staging');
     } else if (Env.isLocal()) {
-      dirPath = path.join(home, ".expo-local");
+      dirPath = path.join(home, '.expo-local');
     } else {
-      dirPath = path.join(home, ".expo");
+      dirPath = path.join(home, '.expo');
     }
   }
   if (!mkdirped) {
@@ -64,11 +64,11 @@ function dotExpoHomeDirectory() {
 // returns an anonymous, unique identifier for a user on the current computer
 async function getAnonymousIdentifierAsync(): Promise<string> {
   const settings = await userSettingsJsonFile();
-  let id = await settings.getAsync("uuid", null);
+  let id = await settings.getAsync('uuid', null);
 
   if (!id) {
     id = uuidv4();
-    await settings.setAsync("uuid", id);
+    await settings.setAsync('uuid', id);
   }
 
   return id;

--- a/packages/eas-shared/src/utils/delayAsync.ts
+++ b/packages/eas-shared/src/utils/delayAsync.ts
@@ -1,3 +1,3 @@
 export function delayAsync(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/eas-shared/src/utils/dir.ts
+++ b/packages/eas-shared/src/utils/dir.ts
@@ -1,4 +1,4 @@
-import fs from "fs-extra";
+import fs from 'fs-extra';
 
 export function directoryExistsSync(file: string): boolean {
   try {
@@ -9,20 +9,16 @@ export function directoryExistsSync(file: string): boolean {
 }
 
 export async function directoryExistsAsync(file: string): Promise<boolean> {
-  return (
-    (await fs.promises.stat(file).catch(() => null))?.isDirectory() ?? false
-  );
+  return (await fs.promises.stat(file).catch(() => null))?.isDirectory() ?? false;
 }
 
 export async function fileExistsAsync(file: string): Promise<boolean> {
   return (await fs.promises.stat(file).catch(() => null))?.isFile() ?? false;
 }
 
-export const ensureDirectoryAsync = (path: string) =>
-  fs.promises.mkdir(path, { recursive: true });
+export const ensureDirectoryAsync = (path: string) => fs.promises.mkdir(path, { recursive: true });
 
-export const ensureDirectory = (path: string) =>
-  fs.mkdirSync(path, { recursive: true });
+export const ensureDirectory = (path: string) => fs.mkdirSync(path, { recursive: true });
 
 export const copySync = fs.copySync;
 

--- a/packages/eas-shared/src/utils/errors.ts
+++ b/packages/eas-shared/src/utils/errors.ts
@@ -1,19 +1,22 @@
-import { AssertionError } from "assert";
-import chalk from "chalk";
+import { AssertionError } from 'assert';
+import chalk from 'chalk';
 
-import { exit } from "../log";
+import { exit } from '../log';
 
-const ERROR_PREFIX = "Error: ";
+const ERROR_PREFIX = 'Error: ';
 
 /**
  * General error, formatted as a message in red text when caught by expo-cli (no stack trace is printed). Should be used in favor of `log.error()` in most cases.
  */
 export class CommandError extends Error {
-  override name = "CommandError";
+  override name = 'CommandError';
   readonly isCommandError = true;
 
-  constructor(public code: string, message: string = "") {
-    super("");
+  constructor(
+    public code: string,
+    message: string = ''
+  ) {
+    super('');
     // If e.toString() was called to get `message` we don't want it to look
     // like "Error: Error:".
     if (message.startsWith(ERROR_PREFIX)) {
@@ -26,7 +29,7 @@ export class CommandError extends Error {
 
 export class AbortCommandError extends CommandError {
   constructor() {
-    super("ABORTED", "Interactive prompt was cancelled.");
+    super('ABORTED', 'Interactive prompt was cancelled.');
   }
 }
 
@@ -36,12 +39,10 @@ export class AbortCommandError extends CommandError {
 export class SilentError extends CommandError {
   constructor(messageOrError?: string | Error) {
     const message =
-      (typeof messageOrError === "string"
-        ? messageOrError
-        : messageOrError?.message) ??
-      "This error should fail silently in the CLI";
-    super("SILENT", message);
-    if (typeof messageOrError !== "string") {
+      (typeof messageOrError === 'string' ? messageOrError : messageOrError?.message) ??
+      'This error should fail silently in the CLI';
+    super('SILENT', message);
+    if (typeof messageOrError !== 'string') {
       // forward the props of the incoming error for tests or processes outside of expo-cli that use expo cli internals.
       this.stack = messageOrError?.stack ?? this.stack;
       this.name = messageOrError?.name ?? this.name;
@@ -56,14 +57,14 @@ export function logCmdError(error: Error) {
   } else if (
     error instanceof CommandError ||
     error instanceof AssertionError ||
-    error.name === "ApiV2Error" ||
-    error.name === "ConfigError"
+    error.name === 'ApiV2Error' ||
+    error.name === 'ConfigError'
   ) {
     // Print the stack trace in debug mode only.
     exit(error);
   }
 
-  const errorDetails = error.stack ? "\n" + chalk.gray(error.stack) : "";
+  const errorDetails = error.stack ? '\n' + chalk.gray(error.stack) : '';
 
   exit(chalk.red(error.toString()) + errorDetails);
 }
@@ -71,7 +72,7 @@ export function logCmdError(error: Error) {
 /** This should never be thrown in production. */
 export class UnimplementedError extends Error {
   constructor() {
-    super("Unimplemented");
-    this.name = "UnimplementedError";
+    super('Unimplemented');
+    this.name = 'UnimplementedError';
   }
 }

--- a/packages/eas-shared/src/utils/exit.ts
+++ b/packages/eas-shared/src/utils/exit.ts
@@ -1,15 +1,10 @@
-import { guardAsync } from "./fn";
+import { guardAsync } from './fn';
 
-const debug = require("debug")("expo:utils:exit") as typeof console.log;
+const debug = require('debug')('expo:utils:exit') as typeof console.log;
 
 type AsyncExitHook = (signal: NodeJS.Signals) => void | Promise<void>;
 
-const PRE_EXIT_SIGNALS: NodeJS.Signals[] = [
-  "SIGHUP",
-  "SIGINT",
-  "SIGTERM",
-  "SIGBREAK",
-];
+const PRE_EXIT_SIGNALS: NodeJS.Signals[] = ['SIGHUP', 'SIGINT', 'SIGTERM', 'SIGBREAK'];
 
 // We create a queue since Node.js throws an error if we try to append too many listeners:
 // (node:4405) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit

--- a/packages/eas-shared/src/utils/parseBinaryPlistAsync.ts
+++ b/packages/eas-shared/src/utils/parseBinaryPlistAsync.ts
@@ -1,6 +1,6 @@
-import plist from "@expo/plist";
-import binaryPlist from "bplist-parser";
-import fs from "fs";
+import plist from '@expo/plist';
+import binaryPlist from 'bplist-parser';
+import fs from 'fs';
 
 const CHAR_CHEVRON_OPEN = 60;
 const CHAR_B_LOWER = 98;
@@ -21,8 +21,6 @@ export function parsePlistBuffer(contents: Buffer) {
     if (Array.isArray(info)) return info[0];
     return info;
   } else {
-    throw new Error(
-      `Cannot parse plist of type byte (0x${contents[0].toString(16)})`
-    );
+    throw new Error(`Cannot parse plist of type byte (0x${contents[0].toString(16)})`);
   }
 }

--- a/packages/eas-shared/src/utils/promise.ts
+++ b/packages/eas-shared/src/utils/promise.ts
@@ -5,5 +5,5 @@
  * @returns A promise that resolves after the provided number of milliseconds.
  */
 export async function sleepAsync(ms: number): Promise<void> {
-  return new Promise(res => setTimeout(res, ms));
+  return new Promise((res) => setTimeout(res, ms));
 }

--- a/packages/eas-shared/src/versions.ts
+++ b/packages/eas-shared/src/versions.ts
@@ -1,12 +1,12 @@
-import type { ExpoConfig } from "@expo/config";
-import getenv from "getenv";
-import pickBy from "lodash/pickBy";
-import path from "path";
-import semver from "semver";
+import type { ExpoConfig } from '@expo/config';
+import getenv from 'getenv';
+import pickBy from 'lodash/pickBy';
+import path from 'path';
+import semver from 'semver';
 
-import ApiV2Client from "./api/APIV2";
-import * as FsCache from "./tools/FsCache";
-import { InternalError } from "common-types";
+import ApiV2Client from './api/APIV2';
+import * as FsCache from './tools/FsCache';
+import { InternalError } from 'common-types';
 
 export type SDKVersion = {
   androidExpoViewUrl?: string;
@@ -41,19 +41,17 @@ type Versions = {
   turtleSdkVersions: TurtleSDKVersionsOld;
 };
 
-export async function versionsAsync(options?: {
-  skipCache?: boolean;
-}): Promise<Versions> {
+export async function versionsAsync(options?: { skipCache?: boolean }): Promise<Versions> {
   const api = new ApiV2Client();
   const versionCache = new FsCache.Cacher(
-    () => api.getAsync("versions/latest"),
-    "versions.json",
+    () => api.getAsync('versions/latest'),
+    'versions.json',
     0,
-    path.join(__dirname, "../caches/versions.json")
+    path.join(__dirname, '../caches/versions.json')
   );
 
   // Clear cache when opting in to beta because things can change quickly in beta
-  if (getenv.boolish("EXPO_BETA", false) || options?.skipCache) {
+  if (getenv.boolish('EXPO_BETA', false) || options?.skipCache) {
     versionCache.clearAsync();
   }
 
@@ -72,20 +70,19 @@ export async function releasedSdkVersionsAsync(): Promise<SDKVersions> {
   const sdkVersions = await sdkVersionsAsync();
   return pickBy(
     sdkVersions,
-    (data: SDKVersion) =>
-      !!data.releaseNoteUrl || (getenv.boolish("EXPO_BETA", false) && data.beta)
+    (data: SDKVersion) => !!data.releaseNoteUrl || (getenv.boolish('EXPO_BETA', false) && data.beta)
   );
 }
 
 export function gteSdkVersion(
-  expJson: Pick<ExpoConfig, "sdkVersion">,
+  expJson: Pick<ExpoConfig, 'sdkVersion'>,
   sdkVersion: string
 ): boolean {
   if (!expJson.sdkVersion) {
     return false;
   }
 
-  if (expJson.sdkVersion === "UNVERSIONED") {
+  if (expJson.sdkVersion === 'UNVERSIONED') {
     return true;
   }
 
@@ -93,21 +90,21 @@ export function gteSdkVersion(
     return semver.gte(expJson.sdkVersion, sdkVersion);
   } catch {
     throw new InternalError(
-      "INVALID_VERSION",
+      'INVALID_VERSION',
       `${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`
     );
   }
 }
 
 export function lteSdkVersion(
-  expJson: Pick<ExpoConfig, "sdkVersion">,
+  expJson: Pick<ExpoConfig, 'sdkVersion'>,
   sdkVersion: string
 ): boolean {
   if (!expJson.sdkVersion) {
     return false;
   }
 
-  if (expJson.sdkVersion === "UNVERSIONED") {
+  if (expJson.sdkVersion === 'UNVERSIONED') {
     return false;
   }
 
@@ -115,14 +112,14 @@ export function lteSdkVersion(
     return semver.lte(expJson.sdkVersion, sdkVersion);
   } catch {
     throw new InternalError(
-      "INVALID_VERSION",
+      'INVALID_VERSION',
       `${expJson.sdkVersion} is not a valid version. Must be in the form of x.y.z`
     );
   }
 }
 
 export function parseSdkVersionFromTag(tag: string): string {
-  if (tag.startsWith("sdk-")) {
+  if (tag.startsWith('sdk-')) {
     return tag.substring(4);
   }
 
@@ -136,11 +133,11 @@ export async function newestReleasedSdkVersionAsync(): Promise<{
   version: string;
   data: SDKVersion | null;
 }> {
-  const betaOptInEnabled = getenv.boolish("EXPO_BETA", false);
+  const betaOptInEnabled = getenv.boolish('EXPO_BETA', false);
   const sdkVersions = await sdkVersionsAsync();
 
   let result = null;
-  let highestMajorVersion = "0.0.0";
+  let highestMajorVersion = '0.0.0';
 
   for (const [version, data] of Object.entries(sdkVersions)) {
     const hasReleaseNotes = !!data.releaseNoteUrl;
@@ -162,13 +159,8 @@ export async function newestReleasedSdkVersionAsync(): Promise<{
 
 export async function oldestSupportedMajorVersionAsync(): Promise<number> {
   const sdkVersions = await sdkVersionsAsync();
-  const supportedVersions = pickBy(
-    sdkVersions,
-    (v: SDKVersion) => !v.isDeprecated
-  );
-  const versionNumbers = Object.keys(supportedVersions).map((version) =>
-    semver.major(version)
-  );
+  const supportedVersions = pickBy(sdkVersions, (v: SDKVersion) => !v.isDeprecated);
+  const versionNumbers = Object.keys(supportedVersions).map((version) => semver.major(version));
   return Math.min(...versionNumbers);
 }
 
@@ -176,24 +168,23 @@ export async function canTurtleBuildSdkVersion(
   sdkVersion: string,
   platform: keyof TurtleSDKVersions
 ): Promise<boolean> {
-  if (sdkVersion === "UNVERSIONED") {
+  if (sdkVersion === 'UNVERSIONED') {
     return true;
   }
 
   if (semver.valid(sdkVersion) == null) {
     throw new InternalError(
-      "INVALID_VERSION",
+      'INVALID_VERSION',
       `"${sdkVersion}" is not a valid version. Must be in the form of x.y.z`
     );
   }
 
   const supportedVersions = await getSdkVersionsSupportedByTurtle();
-  const supportedVersionsForPlatform: string[] =
-    supportedVersions[platform] ?? [];
+  const supportedVersionsForPlatform: string[] = supportedVersions[platform] ?? [];
   return supportedVersionsForPlatform.indexOf(sdkVersion) !== -1;
 }
 
 async function getSdkVersionsSupportedByTurtle(): Promise<TurtleSDKVersions> {
   const api = new ApiV2Client();
-  return await api.getAsync("standalone-build/supportedSDKVersions");
+  return await api.getAsync('standalone-build/supportedSDKVersions');
 }

--- a/packages/eas-shared/tsconfig.json
+++ b/packages/eas-shared/tsconfig.json
@@ -13,11 +13,7 @@
     "target": "ES2019",
     "outDir": "build",
     "rootDir": "src",
-    "typeRoots": [
-      "../../ts-declarations",
-      "src/ts-declarations",
-      "./node_modules/@types"
-    ]
+    "typeRoots": ["../../ts-declarations", "src/ts-declarations", "./node_modules/@types"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
# Why

We should unify out linting so all packages/apps use the same patterns  

# How

Move prettier config to the root folder and run `npx prettier **/*.ts* --write`

# Test Plan

N / A
