### PR TITLE
[menu-bar] Refactor SystemIconView to work when switching themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix some build and running issues. ([#69](https://github.com/expo/orbit/pull/69) by [@douglowder](https://github.com/douglowder))
 - Fix build using Xcode 15. ([#74](https://github.com/expo/orbit/pull/74) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix listing iOS connected devices. ([#78](https://github.com/expo/orbit/pull/78) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix SystemIconView not reacting to Appearance changes. ([#85](https://github.com/expo/orbit/pull/85) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/SystemIconViewManager.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/SystemIconViewManager.m
@@ -1,37 +1,36 @@
 // SystemIconViewManager.m
 #import "SystemIconViewManager.h"
-
-#import "RCTImageView+Private.h"
-
-@interface SystemIconView : RCTImageView
-
-
-@end
-
-@implementation SystemIconView
-
-
-- (void)setSystemIconName:(NSString *)systemIconName
-{
-  NSImage *systemIcon = [NSImage imageWithSystemSymbolName:systemIconName accessibilityDescription:nil];
  
-  NSImageSymbolConfiguration *config = [NSImageSymbolConfiguration configurationWithPaletteColors:@[[NSColor textColor]]];
-  systemIcon = [systemIcon imageWithSymbolConfiguration:config];
-
-  [super updateWithImage:systemIcon];
-}
-
-
-@end
 
 @implementation SystemIconViewManager
 
 RCT_EXPORT_MODULE()
 
-RCT_EXPORT_VIEW_PROPERTY(systemIconName, NSString)
+RCT_CUSTOM_VIEW_PROPERTY(tintColor, NSColor, NSImageView)
+{
+  view.contentTintColor = [RCTConvert NSColor:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(systemIconName, NSString, NSImageView)
+{
+    NSString *symbolName = [RCTConvert NSString:json];
+    NSImage *systemImage = [NSImage imageWithSystemSymbolName:symbolName accessibilityDescription:nil];
+    [systemImage setTemplate:YES];
+
+    if (systemImage) {
+        view.image = systemImage;
+    } else {
+        NSLog(@"System symbol '%@' not found.", symbolName);
+    }
+}
+
 
 - (NSView *)view
 {
-  return [[SystemIconView alloc] initWithBridge:self.bridge];}
+    NSImageView *imageView = [[NSImageView alloc] init];
+    [imageView setImageScaling:NSImageScaleProportionallyUpOrDown];
+    return imageView;
+}
+
 
 @end

--- a/apps/menu-bar/src/components/SystemIconView.tsx
+++ b/apps/menu-bar/src/components/SystemIconView.tsx
@@ -1,16 +1,18 @@
-import { requireNativeComponent, ImageProps } from 'react-native';
+import { requireNativeComponent, StyleSheet, ImageProps } from 'react-native';
 
 type Props = Omit<ImageProps, 'source'> & { systemIconName: string };
 
 const SystemIconViewInternal = requireNativeComponent<Props>('SystemIconView');
 
 const SystemIconView = (props: Props) => {
-  return <SystemIconViewInternal {...props} style={[defaultStyle, props?.style]} />;
+  return <SystemIconViewInternal {...props} style={[styles.icon, props?.style]} />;
 };
 
-const defaultStyle = {
-  height: 18,
-  width: 18,
-};
+const styles = StyleSheet.create({
+  icon: {
+    height: 18,
+    width: 18,
+  },
+});
 
 export default SystemIconView;


### PR DESCRIPTION
# Why

Closes ENG-10386

# How

Refactor SystemIconView to no longer inherit from RCTImageView and use NSImageView directly. This way we can easily set the image as a template and change the view contentTintColor

# Test Plan
 

https://github.com/expo/orbit/assets/11707729/6d8b23e6-59b1-4b04-9694-c459509b0076


