### PR TITLE
[menu-bar] Fix user default preferences storage migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add ability to show/hide different types of simulators, and add experimental TV support. ([#77](https://github.com/expo/orbit/pull/77) by [@douglowder](https://github.com/douglowder), [#84](https://github.com/expo/orbit/pull/84) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add ability to show/hide different types of simulators, and add experimental TV support. ([#77](https://github.com/expo/orbit/pull/77) by [@douglowder](https://github.com/douglowder), [#84](https://github.com/expo/orbit/pull/84), [#90](https://github.com/expo/orbit/pull/90) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add support for opening tarballs with multiple apps. ([#73](https://github.com/expo/orbit/pull/73) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve feedback to the user when an error occurs. ([#64](https://github.com/expo/orbit/pull/64) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve UI feedback when opening a snack project. ([#88](https://github.com/expo/orbit/pull/88) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/src/modules/Storage.ts
+++ b/apps/menu-bar/src/modules/Storage.ts
@@ -23,8 +23,8 @@ export const defaultUserPreferences: UserPreferences = {
 
 export const getUserPreferences = () => {
   const stringValue = storage.getString(userPreferencesStorageKey);
-  const value = (stringValue ? JSON.parse(stringValue) : defaultUserPreferences) as UserPreferences;
-  return value;
+  const value = (stringValue ? JSON.parse(stringValue) : {}) as UserPreferences;
+  return { ...defaultUserPreferences, ...value };
 };
 
 export const saveUserPreferences = (preferences: UserPreferences) => {


### PR DESCRIPTION
# Why

When migrating from  v0.1.3 to latest default user preferences are not applied, causing the user to see no simulators/emulators in the menu bar 

![image](https://github.com/expo/orbit/assets/11707729/f93a0dd0-0a49-4bad-8531-f9469c025638)


# How

Update `getUserPreferences` to merge the retrieved object from mmkv with the default preferences, this ensures that in case we add new keys to `UserPreferences` `getUserPreferences` will always return the whole object with the default values

# Test Plan

1. Reset local storage
2. install Orbit v0.1.3 
3. Open the Settings Window and change some configuration (e.g. `Run Android emulator without audio`)
4. Install orbit from main
5. Check if ios and android platforms are enabled 