### PR TITLE
[menu-bar] Remove experimental features option from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add ability to show/hide different types of simulators, and add experimental TV support. ([#77](https://github.com/expo/orbit/pull/77) by [@douglowder](https://github.com/douglowder), [#84](https://github.com/expo/orbit/pull/84), [#90](https://github.com/expo/orbit/pull/90) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add ability to show/hide different types of simulators, and add experimental TV support. ([#77](https://github.com/expo/orbit/pull/77) by [@douglowder](https://github.com/douglowder), [#84](https://github.com/expo/orbit/pull/84), [#90](https://github.com/expo/orbit/pull/90), [#91](https://github.com/expo/orbit/pull/91) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add support for opening tarballs with multiple apps. ([#73](https://github.com/expo/orbit/pull/73) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve feedback to the user when an error occurs. ([#64](https://github.com/expo/orbit/pull/64) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve UI feedback when opening a snack project. ([#88](https://github.com/expo/orbit/pull/88) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/src/hooks/useListDevices.ts
+++ b/apps/menu-bar/src/hooks/useListDevices.ts
@@ -22,8 +22,7 @@ export const useListDevices = () => {
     try {
       const devicesList = await listDevicesAsync({ platform: 'all' });
       const showIos = userPreferences.showIosSimulators;
-      const showTvos =
-        userPreferences.showExperimentalFeatures && userPreferences.showTvosSimulators;
+      const showTvos = userPreferences.showTvosSimulators;
       const showAndroid = userPreferences.showAndroidEmulators;
       if (!showIos) {
         devicesList.ios.devices = devicesList.ios.devices.filter(

--- a/apps/menu-bar/src/modules/Storage.ts
+++ b/apps/menu-bar/src/modules/Storage.ts
@@ -6,7 +6,6 @@ export type UserPreferences = {
   launchOnLogin: boolean;
   emulatorWithoutAudio: boolean;
   customSdkPath?: string;
-  showExperimentalFeatures: boolean;
   showIosSimulators: boolean;
   showTvosSimulators: boolean;
   showAndroidEmulators: boolean;
@@ -15,7 +14,6 @@ export type UserPreferences = {
 export const defaultUserPreferences: UserPreferences = {
   launchOnLogin: false,
   emulatorWithoutAudio: false,
-  showExperimentalFeatures: false,
   showIosSimulators: true,
   showTvosSimulators: false,
   showAndroidEmulators: true,

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -26,10 +26,10 @@ import { getCurrentUserDisplayName } from '../utils/helpers';
 import { addOpacity } from '../utils/theme';
 import { useCurrentTheme } from '../utils/useExpoTheme';
 
-const osList: { label: string; key: keyof UserPreferences; experimental?: boolean }[] = [
+const osList: { label: string; key: keyof UserPreferences }[] = [
   { label: 'Android', key: 'showAndroidEmulators' },
   { label: 'iOS', key: 'showIosSimulators' },
-  { label: 'tvOS', key: 'showTvosSimulators', experimental: true },
+  { label: 'tvOS (experimental)', key: 'showTvosSimulators' },
 ];
 
 const Settings = () => {
@@ -82,14 +82,6 @@ const Settings = () => {
   const onPressSetAutomaticallyChecksForUpdates = async (value: boolean) => {
     setAutomaticallyChecksForUpdates(value);
     SparkleModule.setAutomaticallyChecksForUpdates(value);
-  };
-
-  const onPressSetShowExperimentalFeatures = async (value: boolean) => {
-    setUserPreferences((prev) => {
-      const newPreferences = { ...prev, showExperimentalFeatures: value };
-      saveUserPreferences(newPreferences);
-      return newPreferences;
-    });
   };
 
   const onPressEmulatorWithoutAudio = async (value: boolean) => {
@@ -229,13 +221,6 @@ const Settings = () => {
             label="Run Android emulator without audio"
           />
         </Row>
-        <Row mb="3.5" align="center">
-          <Checkbox
-            value={userPreferences.showExperimentalFeatures}
-            onValueChange={onPressSetShowExperimentalFeatures}
-            label="Show experimental features"
-          />
-        </Row>
         <View mb="3.5">
           <Row mb="2" align="center">
             <Checkbox
@@ -277,25 +262,21 @@ const Settings = () => {
             }}
             border="light"
             px="2">
-            {osList
-              .filter(
-                ({ experimental }) => !experimental || userPreferences.showExperimentalFeatures
-              )
-              .map(({ label, key }, index, list) => (
-                <Fragment key={key}>
-                  <Row align="center" justify="between">
-                    <Text size="small" weight="normal">
-                      {label}
-                    </Text>
-                    <Switch
-                      value={Boolean(userPreferences[key])}
-                      onValueChange={(value) => toggleOS(key, value)}
-                      style={styles.switch}
-                    />
-                  </Row>
-                  {list.length - 1 !== index ? <Divider /> : null}
-                </Fragment>
-              ))}
+            {osList.map(({ label, key }, index, list) => (
+              <Fragment key={key}>
+                <Row align="center" justify="between">
+                  <Text size="small" weight="normal">
+                    {label}
+                  </Text>
+                  <Switch
+                    value={Boolean(userPreferences[key])}
+                    onValueChange={(value) => toggleOS(key, value)}
+                    style={styles.switch}
+                  />
+                </Row>
+                {list.length - 1 !== index ? <Divider /> : null}
+              </Fragment>
+            ))}
           </View>
         </View>
       </View>


### PR DESCRIPTION
# Why

Instead of having a dedicated check check box for just one experimental feature, we can just show "experimental" next to the the tvOS label

# How

Remove the experimental features option from Settings

# Test Plan

Run menu-bar locally