### PR TITLE
Add support for opening snack projects on real iOS devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added support for login to Expo. ([#41](https://github.com/expo/orbit/pull/41), [#43](https://github.com/expo/orbit/pull/43), [#44](https://github.com/expo/orbit/pull/44), [#45](https://github.com/expo/orbit/pull/45), [#62](https://github.com/expo/orbit/pull/62), [#67](https://github.com/expo/orbit/pull/67), [#89](https://github.com/expo/orbit/pull/89) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Focus simulator/emulator window when launching an app. ([#75](https://github.com/expo/orbit/pull/75) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add support for running iOS internal distribution apps on real devices. ([#79](https://github.com/expo/orbit/pull/79) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for opening snack projects on real iOS devices. ([#92](https://github.com/expo/orbit/pull/92) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/cli/src/commands/DownloadBuild.ts
+++ b/apps/cli/src/commands/DownloadBuild.ts
@@ -1,9 +1,6 @@
-import { downloadAndMaybeExtractAppAsync, AppPlatform } from 'eas-shared';
+import { downloadAndMaybeExtractAppAsync } from 'eas-shared';
 
 export async function downloadBuildAsync(buildURL: string) {
-  const buildPath = await downloadAndMaybeExtractAppAsync(
-    buildURL,
-    buildURL.endsWith('apk') ? AppPlatform.Android : AppPlatform.Ios
-  );
+  const buildPath = await downloadAndMaybeExtractAppAsync(buildURL);
   return buildPath;
 }

--- a/apps/menu-bar/src/utils/device.ts
+++ b/apps/menu-bar/src/utils/device.ts
@@ -1,21 +1,13 @@
-import { DevicesPerPlatform } from 'common-types/build/cli-commands/listDevices';
+import { CliCommands } from 'common-types';
 import { Device, IosSimulator, AndroidEmulator } from 'common-types/build/devices';
 import { SectionListData } from 'react-native';
 
-export type BaseDevice = {
-  name: string;
-  osVersion?: string;
-  osType: 'iOS' | 'android';
-  state?: 'Booted' | 'Shutdown';
-} & (
-  | {
-      deviceType: 'device';
-      connectionType?: 'USB' | 'Network';
-    }
-  | {
-      deviceType: 'simulator' | 'emulator';
-    }
-);
+export type DevicesPerPlatform = {
+  [P in Exclude<CliCommands.Platform, CliCommands.Platform.All>]: {
+    devices: Map<string, CliCommands.ListDevices.Device<P>>;
+    error?: { code: string; message: string };
+  };
+};
 
 export function getDeviceOS(device: Device): 'android' | 'ios' {
   if (device.osType === 'tvOS') {
@@ -36,13 +28,13 @@ export function getSectionsFromDeviceList(
 >[] {
   const sections = [
     {
-      data: devicesPerPlatform.ios.devices,
+      data: Array.from(devicesPerPlatform.ios.devices.values()),
       key: 'ios',
       label: 'iOS',
       error: devicesPerPlatform.ios.error,
     },
     {
-      data: devicesPerPlatform.android.devices,
+      data: Array.from(devicesPerPlatform.android.devices.values()),
       key: 'android',
       label: 'Android',
       error: devicesPerPlatform.android.error,

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -23,6 +23,7 @@ export default class InternalError extends Error {
 
 export type InternalErrorCode =
   | 'APPLE_DEVICE_LOCKED'
+  | 'EXPO_GO_NOT_INSTALLED_ON_DEVICE'
   | 'INVALID_VERSION'
   | 'MULTIPLE_APPS_IN_TARBALL'
   | 'XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED'

--- a/packages/common-types/src/cli-commands/index.ts
+++ b/packages/common-types/src/cli-commands/index.ts
@@ -1,5 +1,9 @@
-export enum Platform {
+import * as ListDevices from './listDevices';
+
+declare enum Platform {
   Android = 'android',
   Ios = 'ios',
   All = 'all',
 }
+
+export { Platform, ListDevices };

--- a/packages/common-types/src/cli-commands/listDevices.ts
+++ b/packages/common-types/src/cli-commands/listDevices.ts
@@ -6,7 +6,7 @@ import {
 } from '../devices';
 import { Platform } from './index';
 
-type Device<P> = P extends Platform.Ios
+export type Device<P> = P extends Platform.Ios
   ? IosSimulator | AppleConnectedDevice
   : P extends Platform.Android
   ? AndroidConnectedDevice | AndroidEmulator

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,4 +1,5 @@
 import * as Devices from './devices';
+import * as CliCommands from './cli-commands';
 import InternalError, { InternalErrorCode } from './InternalError';
 
-export { Devices, InternalError, InternalErrorCode };
+export { Devices, CliCommands, InternalError, InternalErrorCode };

--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -119,7 +119,6 @@ async function maybeCacheAppAsync(appPath: string, cachedAppPath?: string): Prom
 
 export async function downloadAndMaybeExtractAppAsync(
   url: string,
-  platform: AppPlatform,
   cachedAppPath?: string
 ): Promise<string> {
   const outputDir = path.join(getTmpDirectory(), uuidv4());
@@ -149,7 +148,7 @@ export async function downloadAndMaybeExtractAppAsync(
     );
     await tarExtractAsync(tmpArchivePath, outputDir);
 
-    const appPath = await getAppPathAsync(outputDir, platform === AppPlatform.Ios ? 'app' : 'apk');
+    const appPath = await getAppPathAsync(outputDir, '(apk|app|ipa)');
 
     return maybeCacheAppAsync(appPath, cachedAppPath);
   }
@@ -161,7 +160,7 @@ export async function extractAppFromLocalArchiveAsync(appArchivePath: string): P
 
   await tarExtractAsync(appArchivePath, outputDir);
 
-  return await getAppPathAsync(outputDir, '(apk|app)');
+  return await getAppPathAsync(outputDir, '(apk|app|ipa)');
 }
 
 async function getAppPathAsync(outputDir: string, applicationExtension: string): Promise<string> {

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -14,6 +14,12 @@ import { CommandError } from '../../../utils/errors';
 import { parseBinaryPlistAsync } from '../../../utils/parseBinaryPlistAsync';
 import { installExitHooks } from '../../../utils/exit';
 import { xcrunAsync } from '../xcrun';
+import {
+  APP_STORE_BUNDLE_IDENTIFIER,
+  EXPO_GO_APP_STORE_URL,
+  EXPO_GO_BUNDLE_IDENTIFIER,
+} from '../constants';
+import { InternalError } from 'common-types';
 
 /** @returns a list of connected Apple devices. */
 export async function getConnectedDevicesAsync(): Promise<AppleConnectedDevice[]> {
@@ -252,7 +258,6 @@ export async function getBundleIdentifierForBinaryAsync(binaryPath: string): Pro
   return CFBundleIdentifier;
 }
 
-// TODO(gabrieldonadel): Figure out a way to open a deeplink using xcrun devicectl
 export async function checkIfAppIsInstalled({
   udid,
   bundleId,
@@ -261,20 +266,14 @@ export async function checkIfAppIsInstalled({
   bundleId: string;
 }): Promise<IPLookupResult[keyof IPLookupResult] | undefined> {
   const clientManager = await ClientManager.create(udid);
-  const client = await clientManager.getUsbmuxdClient();
-  client.connect(clientManager.device, 62078);
 
   try {
+    const client = await clientManager.getUsbmuxdClient();
+    client.connect(clientManager.device, 62078);
     await mountDeveloperDiskImage(clientManager);
     const installer = await clientManager.getInstallationProxyClient();
 
     const { [bundleId]: appInfo } = await installer.lookupApp([bundleId]);
-
-    await launchApp(clientManager, {
-      appInfo,
-      bundleId,
-      detach: false,
-    });
 
     return appInfo;
   } catch (error) {
@@ -282,4 +281,59 @@ export async function checkIfAppIsInstalled({
     clientManager.end();
   }
   return undefined;
+}
+
+export async function isExpoClientInstalledOnDeviceAsync(udid: string): Promise<boolean> {
+  const appInfo = await checkIfAppIsInstalled({
+    udid,
+    bundleId: EXPO_GO_BUNDLE_IDENTIFIER,
+  });
+
+  return Boolean(appInfo);
+}
+
+export async function ensureExpoClientInstalledAsync(udid: string) {
+  let isInstalled = await isExpoClientInstalledOnDeviceAsync(udid);
+
+  if (!isInstalled) {
+    await openExpoGoOnAppStoreAsync(udid);
+    throw new InternalError(
+      'EXPO_GO_NOT_INSTALLED_ON_DEVICE',
+      'Expo Go is not installed on device, please install it from the App Store and try again.'
+    );
+  }
+}
+
+export async function openURLAsync(options: {
+  udid: string;
+  url: string;
+  bundleId: string;
+}): Promise<void> {
+  await xcrunAsync([
+    'devicectl',
+    'device',
+    'process',
+    'launch',
+    '--device',
+    options.udid,
+    '--payload-url',
+    options.url,
+    options.bundleId,
+  ]);
+}
+
+export async function openSnackURLAsync(udid: string, url: string) {
+  return await openURLAsync({
+    bundleId: EXPO_GO_BUNDLE_IDENTIFIER,
+    udid,
+    url,
+  });
+}
+
+export async function openExpoGoOnAppStoreAsync(udid: string) {
+  return await openURLAsync({
+    udid,
+    bundleId: APP_STORE_BUNDLE_IDENTIFIER,
+    url: EXPO_GO_APP_STORE_URL,
+  });
 }

--- a/packages/eas-shared/src/run/ios/appleDevice/ClientManager.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/ClientManager.ts
@@ -30,12 +30,17 @@ export class ClientManager {
 
   static async create(udid?: string) {
     const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
-    const device = await usbmuxClient.getDevice(udid);
-    const pairRecord = await usbmuxClient.readPairRecord(device.Properties.SerialNumber);
-    const lockdownSocket = await usbmuxClient.connect(device, 62078);
-    const lockdownClient = new LockdowndClient(lockdownSocket);
-    await lockdownClient.doHandshake(pairRecord);
-    return new ClientManager(pairRecord, device, lockdownClient);
+    try {
+      const device = await usbmuxClient.getDevice(udid);
+      const pairRecord = await usbmuxClient.readPairRecord(device.Properties.SerialNumber);
+      const lockdownSocket = await usbmuxClient.connect(device, 62078);
+      const lockdownClient = new LockdowndClient(lockdownSocket);
+      await lockdownClient.doHandshake(pairRecord);
+      return new ClientManager(pairRecord, device, lockdownClient);
+    } catch (error) {
+      usbmuxClient.socket.end();
+      throw error;
+    }
   }
 
   async getUsbmuxdClient() {

--- a/packages/eas-shared/src/run/ios/constants.ts
+++ b/packages/eas-shared/src/run/ios/constants.ts
@@ -1,0 +1,4 @@
+export const EXPO_GO_BUNDLE_IDENTIFIER = 'host.exp.Exponent';
+export const APP_STORE_BUNDLE_IDENTIFIER = 'com.apple.AppStore';
+
+export const EXPO_GO_APP_STORE_URL = 'https://apps.apple.com/br/app/expo-go/id982107779';

--- a/packages/eas-shared/src/run/ios/device.ts
+++ b/packages/eas-shared/src/run/ios/device.ts
@@ -1,6 +1,8 @@
 import {
   getConnectedDevicesAsync,
   getBundleIdentifierForBinaryAsync,
+  openSnackURLAsync,
+  ensureExpoClientInstalledAsync,
 } from './appleDevice/AppleDevice';
 import { getAppDeltaDirectory, installOnDeviceAsync } from './appleDevice/installOnDeviceAsync';
 
@@ -9,6 +11,8 @@ const AppleDevice = {
   getAppDeltaDirectory,
   installOnDeviceAsync,
   getBundleIdentifierForBinaryAsync,
+  openSnackURLAsync,
+  ensureExpoClientInstalledAsync,
 };
 
 export default AppleDevice;

--- a/packages/eas-shared/src/run/ios/simulator.ts
+++ b/packages/eas-shared/src/run/ios/simulator.ts
@@ -14,8 +14,8 @@ import UserSettings from '../../userSettings';
 import { delayAsync } from '../../utils/delayAsync';
 import { sleepAsync } from '../../utils/promise';
 import * as Versions from '../../versions';
+import { EXPO_GO_BUNDLE_IDENTIFIER } from './constants';
 
-const EXPO_GO_BUNDLE_IDENTIFIER = 'host.exp.Exponent';
 const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 
 export async function getFirstBootedIosSimulatorAsync(): Promise<IosSimulator | undefined> {


### PR DESCRIPTION
# Why

Users should be able to launch Snack projects on real iOS devices just like on simulators 

# How

Apple does not allow us to directly install Expo Go (without doing proper app distribution) on the user's device but using `devicectl` we can check if the app is installed and if not, open the Expo Go screen inside App Store app on the device.  `devicectl` also allow us to pass URL payloads to real devices in a similar way to `simctl openurl`

# Test Plan

run menu-bar locally and launch snack projects on a real iOS device 
