### PR TITLE
[menu-bar] Upgrade @react-native-clipboard/clipboard to 1.12.1 and patch warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Setup Lerna. ([#72](https://github.com/expo/orbit/pull/72) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Migrate AsyncStorage records to react-native-mmkv. ([#82](https://github.com/expo/orbit/pull/82) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Update Onboarding to rerun checks when focusing the window. ([#93](https://github.com/expo/orbit/pull/93) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Upgrade @react-native-clipboard/clipboard to 1.12.1 and patch warnings. ([#70](https://github.com/expo/orbit/pull/70) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 0.1.3 — 2023-09-21
 

--- a/apps/menu-bar/macos/Podfile.lock
+++ b/apps/menu-bar/macos/Podfile.lock
@@ -433,7 +433,7 @@ PODS:
     - React-perflogger (= 0.72.1)
   - RNCAsyncStorage (1.19.0):
     - React-Core
-  - RNCClipboard (1.11.2):
+  - RNCClipboard (1.12.1):
     - React-Core
   - RNSVG (13.14.0):
     - React-Core
@@ -596,12 +596,12 @@ SPEC CHECKSUMS:
   FBLazyVector: c1b10226447c9e666e3febea613f47a0ea8a7d0b
   FBReactNativeSpec: c88d89502b50ab72e449044bbf4662a9e867dbe9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 6df0a3d6e2750a50609471fd1a01fd2948d405b5
-  hermes-engine: 9df83855a0fd15ef8eb61694652bae636b0c466e
+  glog: 3c476bdc6486bdf33416f24a12624f1d1a3fe0cc
+  hermes-engine: 353c47089f198a442f3dec7ca4acf051eb30a15b
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   MMKV: 9c6c3fa4ddd849f28c7b9a5c9d23aab84f14ee35
   MMKVCore: 9bb7440b170181ac5b81f542ac258103542e693d
-  RCT-Folly: bf7b4921a91932051ebf1c5c2d297154b1fa3c8c
+  RCT-Folly: 11f5241db0b3af773c763b0577f39cce78545730
   RCTRequired: e6862daa1f08a21f5ae0a65370678fde9f6997b0
   RCTTypeSafety: 8b25b7061c08d6a5e2e9fed58553923cc36856ac
   React: e0d2fbb2992d869f81f3b18d5756dd692a200733
@@ -635,13 +635,13 @@ SPEC CHECKSUMS:
   React-utils: d3c1b229649baa9b4ef99a17a92f962a5664e466
   ReactCommon: 4fc7741bd50d6b1a5cc6e702e9f59e08e52206b5
   RNCAsyncStorage: 4b98ac3c64efa4e35c1197cb0c5ca5e9f5d4c666
-  RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
+  RNCClipboard: d77213bfa269013bf4b857b7a9ca37ee062d8ef1
   RNSVG: d00c8f91c3cbf6d476451313a18f04d220d4f396
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Sparkle: 913cef92f73e08d0ae47a36ee20e523913e5f9e2
   Swifter: e71dd674404923d7f03ebb03f3f222d1c570bc8e
   Yoga: b01d8e70b1bc0e88b40040a7d9c50fdadb1054b9
 
-PODFILE CHECKSUM: 3ee64bd16ae5677f1957974b6e7eb9189851163d
+PODFILE CHECKSUM: 7121a3341f970d873213debac8c4be7d3308b430
 
 COCOAPODS: 1.13.0

--- a/apps/menu-bar/package.json
+++ b/apps/menu-bar/package.json
@@ -15,7 +15,7 @@
     "@apollo/client": "^3.8.1",
     "@expo/styleguide-native": "^1.0.1",
     "@react-native-async-storage/async-storage": "^1.19.0",
-    "@react-native-clipboard/clipboard": "^1.11.2",
+    "@react-native-clipboard/clipboard": "^1.12.1",
     "apollo3-cache-persist": "^0.14.1",
     "common-types": "1.0.0",
     "graphql": "^16.8.0",

--- a/patches/@react-native-clipboard+clipboard+1.12.1.patch
+++ b/patches/@react-native-clipboard+clipboard+1.12.1.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/@react-native-clipboard/clipboard/macos/RNCClipboard.m b/node_modules/@react-native-clipboard/clipboard/macos/RNCClipboard.m
+index 9e729f8..488763f 100644
+--- a/node_modules/@react-native-clipboard/clipboard/macos/RNCClipboard.m
++++ b/node_modules/@react-native-clipboard/clipboard/macos/RNCClipboard.m
+@@ -31,4 +31,12 @@ - (dispatch_queue_t)methodQueue
+   resolve(([pasteboard stringForType:NSPasteboardTypeString] ? : @""));
+ }
+ 
++RCT_EXPORT_METHOD(addListener : (NSString *)eventName) {
++  // Keep: Required for RN built in Event Emitter Calls.
++}
++
++RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
++  // Keep: Required for RN built in Event Emitter Calls.
++}
++
+ @end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,10 +2658,10 @@
   dependencies:
     merge-options "^3.0.4"
 
-"@react-native-clipboard/clipboard@^1.11.2":
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.11.2.tgz#e826d0336b34e67294aaffa6878308900bc7d197"
-  integrity sha512-bHyZVW62TuleiZsXNHS1Pv16fWc0fh8O9WvBzl4h2fykqZRW9a+Pv/RGTH56E3X2PqzHP38K5go8zmCZUoIsoQ==
+"@react-native-clipboard/clipboard@^1.12.1":
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.12.1.tgz#a23f9defb732077afa860d0598baa95f5ee9f54b"
+  integrity sha512-+PNk8kflpGte0W1Nz61/Dp8gHTxyuRjkVyRYBawymSIGTDHCC/zOJSbig6kGIkD8MeaGHC2vGYQJyUyCrgVPBQ==
 
 "@react-native-community/cli-clean@11.3.7":
   version "11.3.7"


### PR DESCRIPTION
# Why

There should be no warnings when running menu-bar locally 

# How

Update @react-native-clipboard/clipboard to the latest version and patch `new NativeEventEmitter() was called with a non-null argument ` warnings based on https://github.com/react-native-clipboard/clipboard/pull/207

# Test Plan

Run menu-bar locally and ensure that using `useClipboard` does not throw any warnings 
