### PR TITLE
[menu-bar] Fix useDeepLinking hook initial URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fix build using Xcode 15. ([#74](https://github.com/expo/orbit/pull/74) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix listing iOS connected devices. ([#78](https://github.com/expo/orbit/pull/78) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix SystemIconView not reacting to Appearance changes. ([#85](https://github.com/expo/orbit/pull/85) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix useDeepLinking hook initial URL. ([#99](https://github.com/expo/orbit/pull/99) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/apps/menu-bar/src/hooks/useDeepLinking.ts
+++ b/apps/menu-bar/src/hooks/useDeepLinking.ts
@@ -1,11 +1,21 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Linking } from 'react-native';
 
 export type DeepLinkingCallback = (event: { url: string }) => void;
 
 export const useDeepLinking = (callback: DeepLinkingCallback) => {
+  const [initialURL, setInitialURL] = useState<string | null>(null);
+
   useEffect(() => {
-    Linking.getInitialURL().then((url) => url && callback({ url }));
+    Linking.getInitialURL().then(setInitialURL);
+  }, []);
+
+  if (initialURL) {
+    callback({ url: initialURL });
+    setInitialURL(null);
+  }
+
+  useEffect(() => {
     const listener = Linking.addEventListener('url', callback);
 
     return listener.remove;


### PR DESCRIPTION
# Why

If a user opens Orbit through a deep link the initialURL callback gets invoked multiple times

# How

Fix useDeepLinking hook initial URL

# Test Plan

Open Orbit through a deep link and ensure the deeplink is only handled once 
