### PR TITLE
[menu-bar] Fix installing app from cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### 🎉 New features
 
+### 🐛 Bug fixes
+
+- Fix installing EAS builds from cold start. ([#108](https://github.com/expo/orbit/pull/108) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 1.0.0 — 2023-11-14

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -160,6 +160,9 @@ function Core(props: Props) {
       }
 
       const [firstDevice] = devicesPerPlatform[platform].devices.values();
+      if (!firstDevice) {
+        return;
+      }
 
       setSelectedDevicesIds((prev) => ({ ...prev, [platform]: getDeviceId(firstDevice) }));
       return firstDevice;
@@ -170,22 +173,22 @@ function Core(props: Props) {
   const installAppFromURI = useCallback(
     async (appURI: string) => {
       let localFilePath = appURI.startsWith('/') ? appURI : undefined;
-      const platform = getPlatformFromURI(appURI);
-      const device = getDeviceByPlatform(platform);
-      if (!device) {
-        Alert.alert(
-          `You don't have any ${platform} device available to run this build, please make your environment is configured correctly and try again.`
-        );
-        return;
-      }
-      const deviceId = getDeviceId(device);
-
       try {
         if (!localFilePath) {
           setStatus(MenuBarStatus.DOWNLOADING);
           const buildPath = await downloadBuildAsync(appURI, setProgress);
           localFilePath = buildPath;
         }
+
+        const platform = getPlatformFromURI(appURI);
+        const device = getDeviceByPlatform(platform);
+        if (!device) {
+          Alert.alert(
+            `You don't have any ${platform} device available to run this build, please make your environment is configured correctly and try again.`
+          );
+          return;
+        }
+        const deviceId = getDeviceId(device);
 
         setStatus(MenuBarStatus.BOOTING_DEVICE);
         await ensureDeviceIsRunning(device);


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/107

# How

Instead of immediately trying to get the selected device when launching a build from EAS, first download the app and then check for the list of available devices, that way we can avoid a race condition while the list of devices is loaded 

# Test Plan

Launch a build from EAS with the app closed 