### PR TITLE
[menu-bar] Automatically open popover when the user tries to reopen the app from the Dock or Spotlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Automatically open popover when the user tries to reopen the app from the Dock or Spotlight. ([#109](https://github.com/expo/orbit/pull/109) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fix installing EAS builds from cold start. ([#108](https://github.com/expo/orbit/pull/108) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.mm
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.mm
@@ -137,6 +137,15 @@
                                                       andEventID:kAEGetURL];
 }
 
+// Called when the user tries to reopen the app from the Dock or Spotlight
+- (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)visibleWindows {
+    if (!visibleWindows) {
+      [self openPopover];
+    }
+    
+    return YES;
+}
+
 - (void)getUrlEventHandler:(NSAppleEventDescriptor *)event withReplyEvent:(NSAppleEventDescriptor *)replyEvent
 {
     [self openPopover];

--- a/apps/menu-bar/src/App.tsx
+++ b/apps/menu-bar/src/App.tsx
@@ -5,6 +5,7 @@ import AutoResizerRootView from './components/AutoResizerRootView';
 import { SAFE_AREA_FACTOR } from './hooks/useSafeDisplayDimensions';
 import { PersistGate } from './modules/PersistGate';
 import Popover from './popover';
+import { DevicesProvider } from './providers/DevicesProvider';
 import { ThemeProvider } from './providers/ThemeProvider';
 
 type Props = {
@@ -19,7 +20,9 @@ function App(props: Props) {
       maxRelativeHeight={SAFE_AREA_FACTOR}>
       <PersistGate>
         <ThemeProvider themePreference="no-preference">
-          <Popover isDevWindow={props.isDevWindow} />
+          <DevicesProvider>
+            <Popover isDevWindow={props.isDevWindow} />
+          </DevicesProvider>
         </ThemeProvider>
       </PersistGate>
     </AutoResizerRootView>

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -19,7 +19,6 @@ import DeviceItem, { DEVICE_ITEM_HEIGHT } from '../components/DeviceItem';
 import { useDeepLinking } from '../hooks/useDeepLinking';
 import { useDeviceAudioPreferences } from '../hooks/useDeviceAudioPreferences';
 import { useGetPinnedApps } from '../hooks/useGetPinnedApps';
-import { useListDevices } from '../hooks/useListDevices';
 import { usePopoverFocusEffect } from '../hooks/usePopoverFocus';
 import { useSafeDisplayDimensions } from '../hooks/useSafeDisplayDimensions';
 import { useFileHandler } from '../modules/FileHandlerModule';
@@ -29,6 +28,7 @@ import {
   getSelectedDevicesIds,
   saveSelectedDevicesIds,
 } from '../modules/Storage';
+import { useListDevices } from '../providers/DevicesProvider';
 import { getDeviceId, getDeviceOS, isVirtualDevice } from '../utils/device';
 import { MenuBarStatus } from '../utils/helpers';
 import { getPlatformFromURI, handleAuthUrl } from '../utils/parseUrl';
@@ -51,6 +51,11 @@ function Core(props: Props) {
   const [progress, setProgress] = useState(0);
 
   const { devicesPerPlatform, numberOfDevices, sections, refetch } = useListDevices();
+  usePopoverFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch])
+  );
   const { emulatorWithoutAudio } = useDeviceAudioPreferences();
 
   // TODO: Extract into a hook

--- a/apps/menu-bar/src/popover/index.tsx
+++ b/apps/menu-bar/src/popover/index.tsx
@@ -5,7 +5,9 @@ import { ErrorBoundary, FallbackProps } from './ErrorBoundary';
 import Footer from './Footer';
 import { Text, View } from '../components';
 import { useSafeDisplayDimensions } from '../hooks/useSafeDisplayDimensions';
+import MenuBarModule from '../modules/MenuBarModule';
 import { storage } from '../modules/Storage';
+import { useListDevices } from '../providers/DevicesProvider';
 import { WindowsNavigator } from '../windows';
 import { hasSeenOnboardingStorageKey } from '../windows/Onboarding';
 
@@ -15,6 +17,7 @@ type Props = {
 
 function Popover(props: Props) {
   const { height } = useSafeDisplayDimensions();
+  const { hasInitialized } = useListDevices();
 
   useEffect(() => {
     const hasSeenOnboarding = storage.getBoolean(hasSeenOnboardingStorageKey);
@@ -22,6 +25,12 @@ function Popover(props: Props) {
       WindowsNavigator.open('Onboarding');
     }
   }, []);
+
+  useEffect(() => {
+    if (hasInitialized && storage.getBoolean(hasSeenOnboardingStorageKey)) {
+      MenuBarModule.openPopover();
+    }
+  }, [hasInitialized]);
 
   return (
     <View


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/105

# How

-  Refactor `useListDevices` hook to use React Context, allowing us to detect from different parts of the app that the initial list of devices has been loaded 
- Automatically open popover when the user opens the app or reopens it from the Dock or Spotlight

# Test Plan

Run menu-bar locally 
