### PR TITLE
[menu-bar] Fix command check loading status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix installing EAS builds from cold start. ([#108](https://github.com/expo/orbit/pull/108) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix onboarding command check loading status. ([#110](https://github.com/expo/orbit/pull/110) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/apps/menu-bar/src/components/CommandCheckItem.tsx
+++ b/apps/menu-bar/src/components/CommandCheckItem.tsx
@@ -20,9 +20,10 @@ type Props = {
   title: string;
   description: string;
   icon: ImageSourcePropType;
+  loading: boolean;
 } & CliCommands.CheckTools.PlatformToolsCheck[keyof CliCommands.CheckTools.PlatformToolsCheck];
 
-const CommandCheckItem = ({ description, icon, title, reason, success }: Props) => {
+const CommandCheckItem = ({ description, icon, title, reason, success, loading }: Props) => {
   const showWarningAlert = () => {
     const buttons: AlertButton[] = [{ text: 'OK', style: 'default' }];
     const command = reason?.command;
@@ -62,7 +63,7 @@ const CommandCheckItem = ({ description, icon, title, reason, success }: Props) 
           </TouchableOpacity>
         ) : null}
       </View>
-      {success === undefined ? (
+      {loading ? (
         <ActivityIndicator />
       ) : success ? (
         <CheckIcon />

--- a/apps/menu-bar/src/windows/Onboarding.tsx
+++ b/apps/menu-bar/src/windows/Onboarding.tsx
@@ -82,6 +82,7 @@ const Onboarding = () => {
               icon={AndroidStudio}
               success={platformToolsCheck?.android?.success ?? false}
               reason={platformToolsCheck?.android?.reason}
+              loading={platformToolsCheck?.android?.success === undefined}
             />
             <CommandCheckItem
               title="Xcode"
@@ -89,7 +90,7 @@ const Onboarding = () => {
               icon={Xcode}
               success={platformToolsCheck?.ios?.success ?? false}
               reason={platformToolsCheck?.ios?.reason}
-              {...platformToolsCheck?.ios}
+              loading={platformToolsCheck?.ios?.success === undefined}
             />
           </View>
         </View>


### PR DESCRIPTION
# Why

Command check component on Onboarding window is not showing the loading status 

https://github.com/expo/orbit/assets/11707729/988c4053-7338-4f17-8e05-9d73b99ef675


# How

Add loading prop to CommandCheckItem component

# Test Plan

Run menu bar locally and go through onboarding


https://github.com/expo/orbit/assets/11707729/10b3f1f0-abce-4dc2-b96e-bf8535da5903

