### PR TITLE
[menu-bar] Fix device selection logic

### DIFF
--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -161,8 +161,17 @@ function Core(props: Props) {
   const getDeviceByPlatform = useCallback(
     (platform: 'android' | 'ios') => {
       const selectedDevicesId = selectedDevicesIds[platform];
-      if (selectedDevicesId) {
+      if (selectedDevicesId && devicesPerPlatform[platform].devices.has(selectedDevicesId)) {
         return devicesPerPlatform[platform].devices.get(selectedDevicesId);
+      }
+
+      const devices = devicesPerPlatform[platform].devices.values();
+
+      for (const device of devices) {
+        if (isVirtualDevice(device) && device.state === 'Booted') {
+          setSelectedDevicesIds((prev) => ({ ...prev, [platform]: getDeviceId(device) }));
+          return device;
+        }
       }
 
       const [firstDevice] = devicesPerPlatform[platform].devices.values();


### PR DESCRIPTION
# Why

Closes ENG-10869

# How

Update `getDeviceByPlatform` logic to check if the `selectedDevicesId` is available and otherwise fallback to the first running device, if no devices are running just return the first one 


# Test Plan

Run menu-bar locally and test the following scenarios:
- An outdated simulator selected
- No simulator selected but at least one simulator is running
- No simulator selected and no simulators running 
