### PR TITLE
[cli] Improve Snack support for older SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Improve Snack support for older SDKs. ([#117](https://github.com/expo/orbit/pull/117) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fix device selection logic when a simulator or device is no longer available. ([#114](https://github.com/expo/orbit/pull/114) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/cli/src/commands/LaunchSnack.ts
+++ b/apps/cli/src/commands/LaunchSnack.ts
@@ -73,10 +73,11 @@ export async function getSDKVersionForSnack(snackURL: string): Promise<string | 
         'Snack-Api-Version': '3.0.0',
       },
     });
-    const { sdkVersion } = await response.json();
+    const { sdkVersion }: { sdkVersion: string } = await response.json();
 
     return sdkVersion;
   } catch (err) {
     console.error(`Failed fetch snack with identifier: ${snackId}`, err);
+    throw err;
   }
 }

--- a/apps/cli/src/commands/LaunchSnack.ts
+++ b/apps/cli/src/commands/LaunchSnack.ts
@@ -9,11 +9,7 @@ export async function launchSnackAsync(
   snackURL: string,
   { platform, deviceId }: launchSnackAsyncOptions
 ) {
-  // Attempts to extract sdk version from url. Match "sdk.", followed by one or more digits and dots, before a hyphen
-  // e.g. exp://exp.host/@snack/sdk.48.0.0-ChmcDz6VUr
-  const regex = /sdk\.([\d.]+)(?=-)/;
-  const match = snackURL.match(regex);
-  const version = match ? match[1] : undefined;
+  const version = await getSDKVersionForSnack(snackURL);
 
   if (platform === 'android') {
     await launchSnackOnAndroidAsync(snackURL, deviceId, version);
@@ -47,4 +43,40 @@ async function launchSnackOnIOSAsync(snackURL: string, deviceId: string, version
 
   await AppleDevice.ensureExpoClientInstalledAsync(deviceId);
   await AppleDevice.openSnackURLAsync(deviceId, snackURL);
+}
+
+export async function getSDKVersionForSnack(snackURL: string): Promise<string | undefined> {
+  // Attempts to extract sdk version from url. Match "sdk.", followed by one or more digits and dots, before a hyphen
+  // e.g. exp://exp.host/@snack/sdk.48.0.0-ChmcDz6VUr
+  const versionRegex = /sdk\.([\d.]+)(?=-)/;
+  const match = snackURL.match(versionRegex);
+  if (match?.[1]) {
+    return match[1];
+  }
+
+  // For snacks saved to accounts the ID can be `@snack/<hashId>` or `@<username>/<hashId>`.
+  const snackIdentifierRegex = /(@[^\/]+\/[^\/+]+)/;
+  const snackIdentifier = snackURL.match(snackIdentifierRegex)?.[0];
+  if (!snackIdentifier) {
+    return;
+  }
+
+  const snackId = snackIdentifier.startsWith('@snack/')
+    ? snackIdentifier.substring('@snack/'.length)
+    : snackIdentifier;
+
+  // Get the SDK version for a specific snack from the Snack API.
+  try {
+    const response = await fetch(`https://exp.host/--/api/v2/snack/${snackId}`, {
+      method: 'GET',
+      headers: {
+        'Snack-Api-Version': '3.0.0',
+      },
+    });
+    const { sdkVersion } = await response.json();
+
+    return sdkVersion;
+  } catch (err) {
+    console.error(`Failed fetch snack with identifier: ${snackId}`, err);
+  }
 }


### PR DESCRIPTION
# Why

Closes ENG-10972

# How

Improve Snack support for older SDKs on iOS and Android

on iOS Simulators:
 - Check if Expo Go is installed and attempt to read compatible SDK versions from `EXSDKVersions.plist` 

on iOS Real devices:
- Only check if Expo Go is installed, we can't really do much given that we don't have access to  `EXSDKVersions.plist` (even through HouseArrest) and we can't install specific versions of Expo Go

on Android:
- We don't have a file equivalent to `EXSDKVersions.plist` on Android so we need to rely on checking the app version against the latest expo go release for a given SDK, reading from API V2 versions/latest. If the opened Snack requires a downgrade of Expo Go, first uninstall the app to avoid `INSTALL_FAILED_VERSION_DOWNGRADE`

# Test Plan


https://github.com/expo/orbit/assets/11707729/4c85d989-aa5f-440b-8967-d2fab439f03f

