### PR TITLE
[menu-bar] correct links in GHA credentials function

### DIFF
--- a/apps/menu-bar/.eas/build/configureMacOSCredentials/README.md
+++ b/apps/menu-bar/.eas/build/configureMacOSCredentials/README.md
@@ -32,4 +32,4 @@ doesn't add official support. It can be used as a step in a [custom build](https
 
 ## Learn more
 
-Refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/schema/).
+Refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/get-started/).

--- a/apps/menu-bar/.eas/build/configureMacOSCredentials/README.md
+++ b/apps/menu-bar/.eas/build/configureMacOSCredentials/README.md
@@ -1,7 +1,7 @@
 # Configure macOS credentials
 
 This is a custom EAS build function written in TypeScript that configures the credentials for a macOS build while EAS
-doesn't add official support. It can be used as a step in a [custom build](https://docs.expo.dev/preview/custom-build-config/).
+doesn't add official support. It can be used as a step in a [custom build](https://docs.expo.dev/custom-builds/schema/).
 
 ## How to use it
 
@@ -32,4 +32,4 @@ doesn't add official support. It can be used as a step in a [custom build](https
 
 ## Learn more
 
-Refer to the [custom builds documentation](https://docs.expo.dev/preview/custom-build-config/).
+Refer to the [custom builds documentation](https://docs.expo.dev/custom-builds/schema/).


### PR DESCRIPTION
# Why

Old links lead to 404.

# How

Update used docs links.

# Test Plan

No 404 anymore.
