### PR TITLE
[menu-bar] Fix projects section height when the user has less than 3 projects

### DIFF
--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -7,7 +7,7 @@ import { SectionList } from 'react-native';
 import BuildsSection, { BUILDS_SECTION_HEIGHT } from './BuildsSection';
 import DeviceListSectionHeader from './DeviceListSectionHeader';
 import { FOOTER_HEIGHT } from './Footer';
-import ProjectsSection, { PROJECTS_SECTION_HEIGHT } from './ProjectsSection';
+import ProjectsSection, { getProjectSectionHeight } from './ProjectsSection';
 import { SECTION_HEADER_HEIGHT } from './SectionHeader';
 import { withApolloProvider } from '../api/ApolloClient';
 import { bootDeviceAsync } from '../commands/bootDeviceAsync';
@@ -46,8 +46,6 @@ function Core(props: Props) {
   const { apps, refetch: refetchApps } = useGetPinnedApps();
   usePopoverFocusEffect(refetchApps);
 
-  const showProjectsSection = Boolean(apps?.length);
-
   const [status, setStatus] = useState(MenuBarStatus.LISTENING);
   const [progress, setProgress] = useState(0);
 
@@ -65,7 +63,7 @@ function Core(props: Props) {
     (displayDimensions.height || 0) -
     FOOTER_HEIGHT -
     BUILDS_SECTION_HEIGHT -
-    (showProjectsSection ? PROJECTS_SECTION_HEIGHT : 0) -
+    getProjectSectionHeight(apps?.length) -
     30;
   const heightOfAllDevices =
     DEVICE_ITEM_HEIGHT * numberOfDevices + SECTION_HEADER_HEIGHT * (sections?.length || 0);
@@ -299,7 +297,7 @@ function Core(props: Props) {
   return (
     <View shrink="1">
       <BuildsSection status={status} installAppFromURI={installAppFromURI} progress={progress} />
-      {apps?.length ? <ProjectsSection apps={apps} /> : null}
+      <ProjectsSection apps={apps} />
       <View shrink="1" pt="tiny">
         <SectionList
           sections={sections}

--- a/apps/menu-bar/src/popover/ProjectsSection.tsx
+++ b/apps/menu-bar/src/popover/ProjectsSection.tsx
@@ -2,17 +2,32 @@ import { spacing } from '@expo/styleguide-native';
 import { Linking, StyleSheet, TouchableOpacity, FlatList } from 'react-native';
 
 import Item from './Item';
-import SectionHeader from './SectionHeader';
+import SectionHeader, { SECTION_HEADER_HEIGHT } from './SectionHeader';
 import { Row, Text, View } from '../components';
 import { ProjectIcon } from '../components/ProjectIcon';
 import { AppForPinnedListFragment } from '../generated/graphql';
 import { PinnedApp, minNumberOfApps } from '../hooks/useGetPinnedApps';
 import MenuBarModule from '../modules/MenuBarModule';
 
-export const PROJECTS_SECTION_HEIGHT = 192;
+const PROJECTS_ITEM_HEIGHT = 50;
+const PROJECTS_ITEM_MARGIN_BOTTOM = spacing[1];
+const MAX_NUMBER_OF_VISIBLE_ITEMS = 3;
+
+export function getProjectSectionHeight(numberOfApps: number) {
+  if (numberOfApps === 0) {
+    return 0;
+  }
+
+  return (
+    SECTION_HEADER_HEIGHT +
+    PROJECTS_ITEM_HEIGHT * Math.min(numberOfApps, MAX_NUMBER_OF_VISIBLE_ITEMS) +
+    PROJECTS_ITEM_MARGIN_BOTTOM * Math.min(numberOfApps, MAX_NUMBER_OF_VISIBLE_ITEMS - 1) +
+    18
+  );
+}
 
 interface Props {
-  apps: PinnedApp[];
+  apps?: PinnedApp[];
 }
 
 export const ProjectsSection = ({ apps }: Props) => {
@@ -22,6 +37,10 @@ export const ProjectsSection = ({ apps }: Props) => {
     );
     MenuBarModule.closePopover();
   };
+
+  if (!apps?.length) {
+    return null;
+  }
 
   return (
     <View pt="2.5" pb="tiny" gap="1" style={styles.container}>
@@ -44,7 +63,7 @@ export const ProjectsSection = ({ apps }: Props) => {
         alwaysBounceVertical={apps.length > minNumberOfApps}
         renderItem={({ item: app, index }) => (
           <Item
-            style={apps.length - 1 !== index && styles.itemMargin}
+            style={[styles.item, apps.length - 1 !== index && styles.itemMargin]}
             key={app.id}
             onPress={() => openProjectURL(app)}>
             <Row gap="2" align="center">
@@ -69,7 +88,10 @@ export default ProjectsSection;
 
 const styles = StyleSheet.create({
   container: {
-    height: PROJECTS_SECTION_HEIGHT,
+    maxHeight: getProjectSectionHeight(MAX_NUMBER_OF_VISIBLE_ITEMS),
+  },
+  item: {
+    height: PROJECTS_ITEM_HEIGHT,
   },
   itemMargin: {
     marginBottom: spacing[1],

--- a/apps/menu-bar/src/popover/SectionHeader.tsx
+++ b/apps/menu-bar/src/popover/SectionHeader.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from 'react';
+import { StyleSheet } from 'react-native';
 
 import { Row, Text } from '../components';
 import { useTheme } from '../providers/ThemeProvider';
@@ -13,7 +14,7 @@ type Props = {
 const SectionHeader = ({ accessoryRight, label }: Props) => {
   const theme = useTheme();
   return (
-    <Row px="medium" justify="between">
+    <Row px="medium" justify="between" style={styles.row}>
       <Text
         weight="semibold"
         size="tiny"
@@ -27,3 +28,7 @@ const SectionHeader = ({ accessoryRight, label }: Props) => {
 };
 
 export default memo(SectionHeader);
+
+const styles = StyleSheet.create({
+  row: { height: SECTION_HEADER_HEIGHT },
+});


### PR DESCRIPTION
# Why

Closes ENG-10995

# How

Instead of using a fixed height, this PR adds a helper function to dynamically calculate the height of the Projects section 

# Test Plan

<table>
<tr>
<th>
1 project 
</th>
<th>
2 projects
</th>
<th>
3 projects
</th>
</tr>
<tr>
<td>
<img width="200" alt="image" src="https://github.com/expo/orbit/assets/11707729/f5f1ef8f-7d48-4a4a-9468-77a766031fc3">
</td>
<td>
<img width="200" alt="image" src="https://github.com/expo/orbit/assets/11707729/c44036d8-6f9f-4cda-b5a5-183f71ffadf6">
</td>
<td>
<img width="200" alt="image" src="https://github.com/expo/orbit/assets/11707729/37998f0e-3c1a-4588-800c-aed7b20eea4c"> 
</td>
</tr>
</table>

more than 3 projects 

https://github.com/expo/orbit/assets/11707729/06b5c754-d31d-4222-b243-45b509c74cf9

