### PR TITLE
[cli] Fix installing apps on Android real devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix device selection logic when a simulator or device is no longer available. ([#114](https://github.com/expo/orbit/pull/114) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix projects section height when the user has less than 3 projects. ([#119](https://github.com/expo/orbit/pull/119) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix installing apps on Android real devices. ([#123](https://github.com/expo/orbit/pull/123) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🛠 Breaking changes
 

--- a/packages/eas-shared/src/run/android/emulator.ts
+++ b/packages/eas-shared/src/run/android/emulator.ts
@@ -115,10 +115,12 @@ export async function installAppAsync(
   Log.log('Installing your app...');
 
   assert(emulator.pid);
-  await activateEmulatorWindowAsync({
-    pid: emulator.pid,
-    deviceType: 'emulator',
-  });
+  if (emulator.deviceType === 'emulator') {
+    await activateEmulatorWindowAsync({
+      pid: emulator.pid,
+      deviceType: 'emulator',
+    });
+  }
   await adbAsync('-s', emulator.pid, 'install', '-r', '-d', apkFilePath);
 
   Log.succeed('Successfully installed your app!');


### PR DESCRIPTION
# Why

Installing apps on Android real devices gives the following error

<img width="372" alt="image" src="https://github.com/expo/orbit/assets/11707729/490a5715-61ab-4824-b323-bd0e321c0ea8">


# How

Check the device type before trying to activate the emulator window

# Test Plan

Tested installing an apk in a real device  
