### PR TITLE
[github] bump workflow actions

### DIFF
--- a/.github/workflows/lint-and-tsc.yml
+++ b/.github/workflows/lint-and-tsc.yml
@@ -29,11 +29,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: 👀 Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          node-version: 18
           submodules: true
       - name: ⬢ Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: 🧶 Install workspace node modules
@@ -62,7 +63,7 @@ jobs:
         working-directory: apps/cli
 
       - name: Check CHANGELOG entry
-        uses: dangoslen/changelog-enforcer@v3.2.0
+        uses: dangoslen/changelog-enforcer@v3
         with:
           skipLabels: "skip-changelog-check"
           missingUpdateErrorMessage: "Your changes should be noted in the changelog. Read [Updating Changelogs](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelogs.md) guide and consider adding an appropriate entry."

--- a/.github/workflows/lint-and-tsc.yml
+++ b/.github/workflows/lint-and-tsc.yml
@@ -31,7 +31,6 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
-          node-version: 18
           submodules: true
       - name: ⬢ Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
# Why

![Screenshot 2024-01-03 at 17 37 15](https://github.com/expo/orbit/assets/719641/7214d207-0b9d-4042-872b-a8c16b36a9f8)

# How

Fix changelog warning check step, GHA core actions bumps.

# Test Plan

There is no warning in changelog step output.
