### PR TITLE
[menu-bar] Fix Settings window size when opening it from the context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix device selection logic when a simulator or device is no longer available. ([#114](https://github.com/expo/orbit/pull/114) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix projects section height when the user has less than 3 projects. ([#119](https://github.com/expo/orbit/pull/119) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix installing apps on Android real devices. ([#123](https://github.com/expo/orbit/pull/123) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix Settings window size when opening it from the context menu. ([#127](https://github.com/expo/orbit/pull/127) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🛠 Breaking changes
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.mm
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.mm
@@ -92,7 +92,13 @@
 
 - (void)settingsAction:(id)sender {
   WindowNavigator *windowNavigator = [WindowNavigator shared];
-  [windowNavigator openWindow:@"Settings" options:@{}];
+  [windowNavigator openWindow:@"Settings" options:@{
+    @"windowStyle": @{
+      @"titlebarAppearsTransparent": @YES,
+      @"height": @(580.0),
+      @"width": @(500.0)
+    }
+  }];
 }
 
 - (void)openPopover {


### PR DESCRIPTION
# Why

Closes ENG-11012

# How

Provide the appropriate options to `windowNavigator openWindow`

# Test Plan


https://github.com/expo/orbit/assets/11707729/c929da5b-e59f-4647-98f1-333cea3fcd8e


