### PR TITLE
[cli] Read auth credentials from menu-bar MMKV storage

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "commander": "^10.0.1",
     "common-types": "1.0.0",
     "eas-shared": "*",
+    "nodejs-mmkv": "^0.1.1",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {

--- a/apps/cli/src/mmkv.ts
+++ b/apps/cli/src/mmkv.ts
@@ -1,0 +1,12 @@
+import { StorageUtils } from 'common-types';
+import os from 'os';
+
+const MMKVModule = require('nodejs-mmkv');
+const storage = new MMKVModule({
+  rootDir: StorageUtils.getExpoOrbitDirectory(os.homedir()),
+  id: StorageUtils.MMKVInstanceId,
+});
+
+export function getSessionSecret() {
+  return storage.getString('sessionSecret');
+}

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
@@ -43,6 +43,7 @@ RCT_EXPORT_MODULE();
       @"height":  @([[NSScreen mainScreen] frame].size.height),
       @"width":  @([[NSScreen mainScreen] frame].size.width)
     },
+    @"homedir": NSHomeDirectory(),
   };
 }
 

--- a/apps/menu-bar/src/modules/MenuBarModule.ts
+++ b/apps/menu-bar/src/modules/MenuBarModule.ts
@@ -18,6 +18,7 @@ type MenuBarModuleConstants = {
   appVersion: string;
   buildVersion: string;
   initialScreenSize: { height: number; width: number };
+  homedir: string;
 };
 const constants: MenuBarModuleConstants = NativeModules.MenuBarModule.getConstants();
 

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,6 +1,7 @@
 import * as Devices from './devices';
 import * as CliCommands from './cli-commands';
+import * as StorageUtils from './storage';
 import { Platform } from './cli-commands';
 import InternalError, { InternalErrorCode } from './InternalError';
 
-export { Devices, CliCommands, InternalError, InternalErrorCode, Platform };
+export { Devices, CliCommands, InternalError, InternalErrorCode, Platform, StorageUtils };

--- a/packages/common-types/src/storage.ts
+++ b/packages/common-types/src/storage.ts
@@ -1,0 +1,5 @@
+export const MMKVInstanceId = 'mmkv.default';
+
+export function getExpoOrbitDirectory(homedir: string) {
+  return `${homedir}/.expo/orbit`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4644,6 +4644,13 @@ big-integer@1.6.x, big-integer@^1.6.44:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
   integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
@@ -6475,6 +6482,11 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -9362,6 +9374,11 @@ node-addon-api@^3.2.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
 node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
@@ -9436,6 +9453,14 @@ node-stream-zip@^1.9.1:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.15.0.tgz#158adb88ed8004c6c49a396b50a6a5de3bca33ea"
   integrity sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==
+
+nodejs-mmkv@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/nodejs-mmkv/-/nodejs-mmkv-0.1.1.tgz#3804fe41e21804e66baa94fbabf24a040500561e"
+  integrity sha512-P8AXlfpe9IHeGUvRt5W0auahbjvTbj+DcqmlRZKXpstfWTZf2KyJqvLishyX1vKzJzk4M7H71LXmM9ld5C/MXA==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^5.0.0"
 
 nopt@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
# Why

Fetching specific data from an Expo update requires the request to be authenticated, and given that this logic will be handled by the CLI we need to add support for sharing auth credentials between the cli and the menu-bar

Related to https://github.com/expo/orbit/pull/134

# How

- Add nodejs-mmkv dependency to access the same MMKV instance used by the menu-bar  
- Add `homedir` constant to `MenuBarModule`
- Move MMKV path to the same folder as other expo apps (e.g. expo-cli and eas-cli)

# Test Plan

- Run menu-bar and ensure all data is being migrated correctly 
- Run cli and read session secret using getSessionSecret