### PR TITLE
[eas-shared] Ignore osascript error when launching on Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix projects section height when the user has less than 3 projects. ([#119](https://github.com/expo/orbit/pull/119) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix installing apps on Android real devices. ([#123](https://github.com/expo/orbit/pull/123) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix Settings window size when opening it from the context menu. ([#127](https://github.com/expo/orbit/pull/127) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix osascript error when launching apps on the Simulator. ([#139](https://github.com/expo/orbit/pull/139) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🛠 Breaking changes
 

--- a/packages/eas-shared/src/run/ios/simulator.ts
+++ b/packages/eas-shared/src/run/ios/simulator.ts
@@ -130,7 +130,8 @@ async function waitForSimulatorAppToStartAsync(
 }
 
 export async function activateSimulatorWindowAsync(): Promise<void> {
-  await osascript.execAsync(`
+  try {
+    await osascript.execAsync(`
     tell application "System Events"
       set assistiveAccess to UI elements enabled
     end tell
@@ -145,6 +146,12 @@ export async function activateSimulatorWindowAsync(): Promise<void> {
       end tell
     end if
   `);
+  } catch (error: unknown) {
+    // This can fail if the user hasn't enabled accessibility access.
+    if (error instanceof Error) {
+      console.warn(error.message);
+    }
+  }
 }
 
 async function isSimulatorAppRunningAsync(): Promise<boolean> {


### PR DESCRIPTION
# Why

In some very specific cases, the user may encounter an error stating that `osascript is not allowed assistive access. (-1719)` when trying to launch a build in the simulator. This only happened once to me, I tried to reproduce this in different machines and  unfortunately couldn't find reproducible steps

# How

Add a try-catch block around the osascript call given that we can safely ignore this error and just continue with the launch of the app

# Test Plan

Run the app locally and launch a simulator build from the website 