### PR TITLE
[menu-bar] Improve popover height calculations when using multiple displays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix installing apps on Android real devices. ([#123](https://github.com/expo/orbit/pull/123) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix Settings window size when opening it from the context menu. ([#127](https://github.com/expo/orbit/pull/127) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix osascript error when launching apps on the Simulator. ([#139](https://github.com/expo/orbit/pull/139) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improve popover height calculations when using multiple displays. ([#140](https://github.com/expo/orbit/pull/140) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🛠 Breaking changes
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.h
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.h
@@ -15,6 +15,7 @@
 @property(nonatomic, strong, readonly) NSPopover *popover;
 - (void)openPopover;
 - (void)closePopover;
+- (void)setPopoverContentSize:(NSSize)size;
 - (IBAction)showHelp:(id)sender;
 
 @end

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.mm
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.mm
@@ -46,6 +46,7 @@
   rootViewController.view = rootView;
 
   popover = [[NSPopover alloc] init];
+  popover.contentSize = NSMakeSize(380, 450);
   popover.contentViewController = rootViewController;
   popover.behavior = NSPopoverBehaviorTransient;
 
@@ -102,16 +103,26 @@
 }
 
 - (void)openPopover {
-    [popover showRelativeToRect:statusItem.button.bounds
-                         ofView:statusItem.button
-                  preferredEdge:NSMinYEdge];
-    [popover.contentViewController.view.window makeKeyWindow];
-    [_bridge enqueueJSCall:@"RCTDeviceEventEmitter.emit"
-                            args:@[@"popoverFocused"]];
+  [popover showRelativeToRect:statusItem.button.bounds
+                       ofView:statusItem.button
+                preferredEdge:NSMinYEdge];
+  [popover.contentViewController.view.window makeKeyWindow];
+  [_bridge enqueueJSCall:@"RCTDeviceEventEmitter.emit"
+                    args:@[@"popoverFocused", @{
+                      @"screenSize": @{
+                        @"height":  @([[NSScreen mainScreen] frame].size.height),
+                        @"width":  @([[NSScreen mainScreen] frame].size.width)
+                      }
+                    }]];
 }
 
 - (void)closePopover {
     [popover close];
+}
+
+- (void)setPopoverContentSize:(NSSize)size {
+  [popover setContentSize:size];
+  [popover.contentViewController.view setFrameSize:size];
 }
 
 - (void)onPressStatusItem:(id)sender {
@@ -148,7 +159,7 @@
     if (!visibleWindows) {
       [self openPopover];
     }
-    
+
     return YES;
 }
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AutoResizerRootView.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AutoResizerRootView.m
@@ -31,7 +31,7 @@ const CGFloat minimumViewSize = 40.0;
 
   dispatch_async(dispatch_get_main_queue(), ^{
     AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
-    [[appDelegate popover] setContentSize:CGSizeMake(self.frame.size.width, newHeight)];
+    [appDelegate setPopoverContentSize:CGSizeMake(self.frame.size.width, newHeight)];
   });
 }
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/MenuBarModule.m
@@ -37,8 +37,12 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport
 {
   return @{
-    @"appVersion"      : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: [NSNull null],
-    @"buildVersion"    : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] ?: [NSNull null],
+    @"appVersion"         : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"] ?: [NSNull null],
+    @"buildVersion"       : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"] ?: [NSNull null],
+    @"initialScreenSize"  : @{
+      @"height":  @([[NSScreen mainScreen] frame].size.height),
+      @"width":  @([[NSScreen mainScreen] frame].size.width)
+    },
   };
 }
 

--- a/apps/menu-bar/src/hooks/usePopoverFocus.ts
+++ b/apps/menu-bar/src/hooks/usePopoverFocus.ts
@@ -1,7 +1,11 @@
 import { useEffect } from 'react';
 import { DeviceEventEmitter } from 'react-native';
 
-export function usePopoverFocusEffect(callback: () => void) {
+type PopoverFocusedEvent = {
+  screenSize: { height: number; width: number };
+};
+
+export function usePopoverFocusEffect(callback: (event: PopoverFocusedEvent) => void) {
   useEffect(() => {
     const listener = DeviceEventEmitter.addListener('popoverFocused', callback);
 

--- a/apps/menu-bar/src/hooks/useSafeDisplayDimensions.ts
+++ b/apps/menu-bar/src/hooks/useSafeDisplayDimensions.ts
@@ -1,36 +1,30 @@
-import { useCallback, useRef, useState } from 'react';
-import { Dimensions } from 'react-native';
+import { useCallback, useState } from 'react';
 
 import { usePopoverFocusEffect } from './usePopoverFocus';
+import MenuBarModule from '../modules/MenuBarModule';
 
 export const SAFE_AREA_FACTOR = 0.85;
 
+const { initialScreenSize } = MenuBarModule.constants;
+
 export const useSafeDisplayDimensions = () => {
-  const [dimensions, setDimensions] = useState(Dimensions.get('screen'));
-  const attemptsToGetDimensions = useRef(0);
+  const [dimensions, setDimensions] = useState(initialScreenSize);
 
   usePopoverFocusEffect(
-    useCallback(() => {
-      attemptsToGetDimensions.current = 0;
-      setDimensions(Dimensions.get('screen'));
+    useCallback(({ screenSize }) => {
+      setDimensions(screenSize);
     }, [])
   );
 
-  /**
-   * Sometimes Dimensions.get('screen') returns height 0 after the computer goes to sleep
-   * from one monitor and that same monitor gets unplugged. This workaround attempts to mitigate
-   * this problem by waiting 100ms and trying to get the dimensions again.
-   */
-  if (dimensions?.height === 0 && attemptsToGetDimensions.current < 5) {
-    attemptsToGetDimensions.current++;
-    setTimeout(() => {
-      setDimensions(Dimensions.get('screen'));
-    }, 100);
-  }
-
   return {
     ...dimensions,
-    height: dimensions.height !== 0 ? dimensions.height * SAFE_AREA_FACTOR : undefined,
-    width: dimensions.width * SAFE_AREA_FACTOR,
+    height:
+      dimensions.height !== 0
+        ? dimensions.height * SAFE_AREA_FACTOR
+        : initialScreenSize.height * SAFE_AREA_FACTOR,
+    width:
+      dimensions.width !== 0
+        ? dimensions.width * SAFE_AREA_FACTOR
+        : initialScreenSize.width * SAFE_AREA_FACTOR,
   };
 };

--- a/apps/menu-bar/src/modules/MenuBarModule.ts
+++ b/apps/menu-bar/src/modules/MenuBarModule.ts
@@ -17,6 +17,7 @@ type MenuBarModuleType = NativeModule & {
 type MenuBarModuleConstants = {
   appVersion: string;
   buildVersion: string;
+  initialScreenSize: { height: number; width: number };
 };
 const constants: MenuBarModuleConstants = NativeModules.MenuBarModule.getConstants();
 

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -44,7 +44,11 @@ function Core(props: Props) {
   );
 
   const { apps, refetch: refetchApps } = useGetPinnedApps();
-  usePopoverFocusEffect(refetchApps);
+  usePopoverFocusEffect(
+    useCallback(() => {
+      refetchApps();
+    }, [refetchApps])
+  );
 
   const [status, setStatus] = useState(MenuBarStatus.LISTENING);
   const [progress, setProgress] = useState(0);
@@ -64,7 +68,7 @@ function Core(props: Props) {
     FOOTER_HEIGHT -
     BUILDS_SECTION_HEIGHT -
     getProjectSectionHeight(apps?.length) -
-    30;
+    5;
   const heightOfAllDevices =
     DEVICE_ITEM_HEIGHT * numberOfDevices + SECTION_HEADER_HEIGHT * (sections?.length || 0);
   const estimatedListHeight =
@@ -298,7 +302,7 @@ function Core(props: Props) {
     <View shrink="1">
       <BuildsSection status={status} installAppFromURI={installAppFromURI} progress={progress} />
       <ProjectsSection apps={apps} />
-      <View shrink="1" pt="tiny">
+      <View shrink="1" pt="tiny" overflow="hidden">
         <SectionList
           sections={sections}
           style={{ minHeight: estimatedListHeight }}


### PR DESCRIPTION
# Why

We always had issues with resizing the Popover height accurately, but after upgrading react-native-macos to 0.73 this has become more apparent, often cropping the "Quit" button on the UI  

<img height="450" src="https://github.com/expo/orbit/assets/11707729/57cd57a0-1838-4cf5-957c-6d00a380f8e9" />


# How

In react-native-macos to 0.73 `Dimensions.get('screen')` no longer returns the actual screen size on the first few renders (https://github.com/microsoft/react-native-macos/commit/d1ed53d49176e1621facd65c89c53be30da65f3c), so instead of relying on multiple retries this PR refactor `useSafeDisplayDimensions` to not use the Dimensions API.

By exporting the initial screen size as a constant in MenuBarModule and including the screen size in the body of the `popoverFocused` event we can ensure that the screen size data is always up to date.

# Test Plan

1. Open the Popover on a second monitor
2. Put your Mac to sleep from the second monitor
3. Unplug the monitor
4. Wake up your Mac and press the Orbit Icon on the menu bar
5. Ensure the devices list is displayed correctly 