### PR TITLE
[menu-bar] Add support for launching updates from local server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
@@ -79,8 +79,13 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host"]
 
   private func extractRootDomain(from urlString: String) -> String {
     guard let originUrl = URL(string: urlString.removingPercentEncoding ?? ""),
-          let hostName = originUrl.host else {
+          var hostName = originUrl.host else {
       return ""
+    }
+
+    // Orbit deeplink may include specific routes in the URL e.g. /update, /snack, /download, etc.
+    if !hostName.contains(".") {
+      hostName = originUrl.pathComponents[1]
     }
 
     let components = hostName.components(separatedBy: ".")

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -322,23 +322,29 @@ function Core(props: Props) {
     useCallback(
       ({ url: deeplinkUrl }) => {
         if (!props.isDevWindow) {
-          const { urlType, url } = identifyAndParseDeeplinkURL(deeplinkUrl);
+          try {
+            const { urlType, url } = identifyAndParseDeeplinkURL(deeplinkUrl);
 
-          switch (urlType) {
-            case URLType.AUTH:
-              handleAuthUrl(url);
-              break;
-            case URLType.SNACK:
-              handleSnackUrl(url);
-              break;
-            case URLType.EXPO_UPDATE:
-              handleUpdateUrl(url);
-              break;
-            case URLType.EXPO_BUILD:
-            case URLType.UNKNOWN:
-            default:
-              installAppFromURI(url);
-              break;
+            switch (urlType) {
+              case URLType.AUTH:
+                handleAuthUrl(url);
+                break;
+              case URLType.SNACK:
+                handleSnackUrl(url);
+                break;
+              case URLType.EXPO_UPDATE:
+                handleUpdateUrl(url);
+                break;
+              case URLType.EXPO_BUILD:
+              case URLType.UNKNOWN:
+              default:
+                installAppFromURI(url);
+                break;
+            }
+          } catch (error) {
+            if (error instanceof Error) {
+              Alert.alert('Unsupported URL', error.message);
+            }
           }
         }
       },

--- a/apps/menu-bar/src/utils/parseUrl.ts
+++ b/apps/menu-bar/src/utils/parseUrl.ts
@@ -30,11 +30,25 @@ export function identifyAndParseDeeplinkURL(deeplinkURL: string): {
       url: `https://${urlWithoutProtocol.replace('update/', '')}`,
     };
   }
-  if (urlWithoutProtocol.startsWith('expo.dev/artifacts')) {
-    return { urlType: URLType.EXPO_BUILD, url: `https://${urlWithoutProtocol}` };
+  if (
+    urlWithoutProtocol.startsWith('expo.dev/artifacts') ||
+    urlWithoutProtocol.startsWith('download/')
+  ) {
+    return {
+      urlType: URLType.EXPO_BUILD,
+      url: `https://${urlWithoutProtocol.replace('download/', '')}`,
+    };
   }
-  if (urlWithoutProtocol.includes('exp.host/')) {
-    return { urlType: URLType.SNACK, url: `exp://${urlWithoutProtocol}` };
+  if (urlWithoutProtocol.includes('exp.host/') || urlWithoutProtocol.startsWith('snack/')) {
+    return { urlType: URLType.SNACK, url: `exp://${urlWithoutProtocol.replace('snack/', '')}` };
+  }
+
+  // For future usage when we add support for other URL formats
+  if (
+    urlWithoutProtocol.indexOf('/') < urlWithoutProtocol.indexOf('.') ||
+    !urlWithoutProtocol.includes('.')
+  ) {
+    throw new Error('Please make sure you are using the latest version of Expo Orbit.');
   }
 
   return { urlType: URLType.UNKNOWN, url: `https://${urlWithoutProtocol}` };


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/orbit/pull/134

# How

- Update the local server to parse deep links that include routes (e.g. /update, /snack, /download) 
- Update `identifyAndParseDeeplinkURL` to be handle unsupported routes that we may add in future versions  

# Test Plan

Send a GET request to `http://127.0.0.1:35783/orbit/open?url=expo-orbit://update/staging-u.expo.dev/update/aa4316ea-2dae-47c4-9405-49c7ceeefb5d?platform=android`
