### PR TITLE
[cli] Fix codesigning

### DIFF
--- a/apps/cli/macos/entitlements.plist
+++ b/apps/cli/macos/entitlements.plist
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/apps/cli/pkg.config.json
+++ b/apps/cli/pkg.config.json
@@ -1,6 +1,6 @@
 {
   "pkg": {
-    "assets": ["../../node_modules/nodejs-mmkv/**"],
+    "assets": ["../../node_modules/nodejs-mmkv/**/*.node"],
     "targets": ["node18-macos-arm64", "node18-macos-x64"]
   }
 }


### PR DESCRIPTION
# Why

`nodejs-mmkv` broke CLI when codesigning

<img width="1069" alt="image" src="https://github.com/expo/orbit/assets/11707729/76363669-0968-4e38-a4be-5188646aff15">


# How

Update pkg config to only include *.node files from `nodejs-mmkv`, reducing the final bundle size and update cli entitlements to disable library validation

# Test Plan

1. yarn archive 
2. yarn codesign
3. ./orbit-cli-arm64
