### PR TITLE
  [menu-bar] Fix launchUpdateAsync errors not being displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/cli/src/commands/LaunchUpdate.ts
+++ b/apps/cli/src/commands/LaunchUpdate.ts
@@ -3,6 +3,7 @@ import { Emulator, Simulator, ManifestUtils, Manifest } from 'eas-shared';
 import { graphqlSdk } from '../api/GraphqlClient';
 import { AppPlatform, DistributionType } from '../graphql/generated/graphql';
 import { downloadBuildAsync } from './DownloadBuild';
+import { InternalError } from 'common-types';
 
 type launchUpdateAsyncOptions = {
   platform: 'android' | 'ios';
@@ -178,15 +179,16 @@ async function getBuildArtifactsURLForUpdateAsync({
 
   const build = app?.byId?.buildsPaginated?.edges?.[0]?.node;
   if (
-    build.__typename === 'Build' &&
-    build.expirationDate &&
+    build?.__typename === 'Build' &&
+    build?.expirationDate &&
     Date.parse(build.expirationDate) > Date.now() &&
     build.artifacts?.buildUrl
   ) {
     return build.artifacts.buildUrl;
   }
 
-  throw new Error(
-    `No Development Builds available for ${manifest.extra?.expoClient?.name}. Please generate a new build`
+  throw new InternalError(
+    'NO_DEVELOPMENT_BUILDS_AVAILABLE',
+    `No Development Builds available for ${manifest.extra?.expoClient?.name} on EAS. Please generate a new Development Build`
   );
 }

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -230,7 +230,7 @@ function Core(props: Props) {
           }
         );
       } catch (error) {
-        if (error instanceof InternalError) {
+        if (error instanceof InternalError || error instanceof Error) {
           Alert.alert('Something went wrong', error.message);
         }
         console.log(`error: ${JSON.stringify(error)}`);

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -31,7 +31,8 @@ export type InternalErrorCode =
   | 'XCODE_COMMAND_LINE_TOOLS_NOT_INSTALLED'
   | 'XCODE_LICENSE_NOT_ACCEPTED'
   | 'XCODE_NOT_INSTALLED'
-  | 'SIMCTL_NOT_AVAILABLE';
+  | 'SIMCTL_NOT_AVAILABLE'
+  | 'NO_DEVELOPMENT_BUILDS_AVAILABLE';
 
 export type MultipleAppsInTarballErrorDetails = {
   apps: Array<{


### PR DESCRIPTION
# Why

`launchUpdateAsync` errors are getting silently dismissed 

# How

Update catch condition to also alert messages from Error instances 

# Test Plan

Run menu-bar locally 
