### PR TITLE
Upgrade nodejs-mmkv to 0.2.0 and disable info logs

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,7 +25,7 @@
     "eas-shared": "*",
     "graphql": "^16.8.0",
     "graphql-request": "^6.1.0",
-    "nodejs-mmkv": "^0.1.1",
+    "nodejs-mmkv": "^0.2.0",
     "snack-content": "2.0.0-preview.1",
     "strip-ansi": "^6.0.0"
   },

--- a/apps/cli/src/mmkv.ts
+++ b/apps/cli/src/mmkv.ts
@@ -1,10 +1,12 @@
 import { StorageUtils } from 'common-types';
+import { Env } from 'eas-shared';
+import MMKVModule from 'nodejs-mmkv';
 import os from 'os';
 
-const MMKVModule = require('nodejs-mmkv');
 const storage = new MMKVModule({
   rootDir: StorageUtils.getExpoOrbitDirectory(os.homedir()),
   id: StorageUtils.MMKVInstanceId,
+  logLevel: Env.isMenuBar() ? 'warning' : 'info',
 });
 
 export function getSessionSecret(): string | undefined {

--- a/ts-declarations/nodejs-mmkv/index.d.ts
+++ b/ts-declarations/nodejs-mmkv/index.d.ts
@@ -1,0 +1,43 @@
+declare module 'nodejs-mmkv' {
+  interface MMKVModuleOptions {
+    /**
+     * File saved path [required].
+     */
+    rootDir: string;
+    /**
+     * mmap id, default: mmkv.default
+     */
+    id?: string;
+    /**
+     * Enable multi process, default: false
+     */
+    multiProcess?: boolean;
+    /**
+     * encryption key
+     */
+    cryptKey?: string;
+    /**
+     * log level, default: info
+     */
+    logLevel?: 'debug' | 'info' | 'warning' | 'error' | 'none';
+  }
+
+  class MMKVModule {
+    constructor(options: MMKVModuleOptions);
+
+    setString(key: string, value: string): boolean | undefined;
+    getString(key: string): string | undefined;
+    setBoolean(key: string, value: boolean): boolean | undefined;
+    getBoolean(key: string): boolean | undefined;
+    setNumber(key: string, value: number): boolean | undefined;
+    getNumber(key: string): number | undefined;
+
+    containsKey(key: string): boolean | undefined;
+    getKeys(): string[] | undefined;
+    removeKey(key: string): void;
+    clearMemoryCache(): void;
+    clearAll(): void;
+  }
+
+  export default MMKVModule;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11473,10 +11473,10 @@ node-stream-zip@^1.9.1:
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.15.0.tgz#158adb88ed8004c6c49a396b50a6a5de3bca33ea"
   integrity sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==
 
-nodejs-mmkv@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/nodejs-mmkv/-/nodejs-mmkv-0.1.1.tgz#3804fe41e21804e66baa94fbabf24a040500561e"
-  integrity sha512-P8AXlfpe9IHeGUvRt5W0auahbjvTbj+DcqmlRZKXpstfWTZf2KyJqvLishyX1vKzJzk4M7H71LXmM9ld5C/MXA==
+nodejs-mmkv@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nodejs-mmkv/-/nodejs-mmkv-0.2.0.tgz#4285fa40a9aab4bd6b39d00391fe5dbb47f6625e"
+  integrity sha512-Ch/79gxaf0laGjskzPA1wgdVr5DBb2TUDegEZeFDvSuPDa+Icejo7CW+qv4CEnrA3CLRUUCpazcK/elp0USuGA==
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^5.0.0"


### PR DESCRIPTION
# Why

A new version of nodejs-mmkv was just released adding the ability to configure the log level 

# How

Upgrade nodejs-mmkv to 0.2.0 and set log level to warning when running from the menubar

# Test Plan

`EXPO_MENU_BAR=1 dist/orbit-cli-arm64 list-devices`