### PR TITLE
[menu-bar] Update metro config to support Expo CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Use Expo CLI instead of react-native community CLI. ([#155](https://github.com/expo/orbit/pull/155) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 1.0.3 — 2024-01-29
 
 ### 🎉 New features

--- a/apps/menu-bar/package.json
+++ b/apps/menu-bar/package.json
@@ -10,7 +10,7 @@
     "notarize": "xcodebuild -exportNotarizedApp -archivePath build/ExpoOrbit.xcarchive -exportPath build/Notarized",
     "lint": "eslint .",
     "macos": "react-native run-macos",
-    "start": "react-native start",
+    "start": "expo start",
     "test": "jest",
     "update-cli": "mkdir -p cli && cp -R ../cli/dist/ cli/",
     "gql": "graphql-codegen --config codegen.ts",


### PR DESCRIPTION
# Why

We should Expo CLI for all platforms

# How

Update metro.config.js to resolve `react-native` imports to `react-native-macos` when building for macos

# Test Plan

Run menu-bar for macos and web 
