### PR TITLE
[cli] Update download function to cache builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Cache builds by default. ([#156](https://github.com/expo/orbit/pull/156) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 


### PR DESCRIPTION
# Why

In some cases, users might launch the same build multiple times through Orbit and there is not need to redownload the build file everytime 

# How

Update the download function to cache build downloads by default 

# Test Plan

Run `yarn cli download-build https://expo.dev/artifacts/eas/5QUw5J97RyQod9fxvGad5a.apk`
