### PR TITLE
[common-types] Update api url and graphql endpoints

### DIFF
--- a/apps/cli/codegen.ts
+++ b/apps/cli/codegen.ts
@@ -1,8 +1,9 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
+import { Config } from 'common-types';
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: 'https://exp.host/--/graphql',
+  schema: `${Config.api.origin}/graphql`,
   documents: './src/graphql/**/*.gql',
   generates: {
     './src/graphql/generated/graphql.ts': {

--- a/apps/cli/src/api/GraphqlClient.ts
+++ b/apps/cli/src/api/GraphqlClient.ts
@@ -4,7 +4,7 @@ import { Config } from 'common-types';
 import { getSdk } from '../graphql/generated/graphql';
 import { getSessionSecret } from '../mmkv';
 
-const endpoint = `${Config.api.origin}/--/graphql`;
+const endpoint = `${Config.api.origin}/graphql`;
 const sessionSecret = getSessionSecret();
 
 const client = new GraphQLClient(endpoint, {

--- a/apps/menu-bar/codegen.ts
+++ b/apps/menu-bar/codegen.ts
@@ -1,8 +1,9 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
+import { Config } from 'common-types';
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: 'https://exp.host/--/graphql',
+  schema: `${Config.api.origin}/graphql`,
   documents: './src/graphql/**/*.gql',
   generates: {
     './src/generated/graphql.tsx': {

--- a/apps/menu-bar/src/api/ApolloClient.tsx
+++ b/apps/menu-bar/src/api/ApolloClient.tsx
@@ -14,7 +14,7 @@ import possibleTypesData from '../generated/graphql.possibleTypes.json';
 import { storage } from '../modules/Storage';
 
 const httpLink = new HttpLink({
-  uri: `${Config.api.origin}/--/graphql`,
+  uri: `${Config.api.origin}/graphql`,
 });
 
 const mergeBasedOnOffset = (existing: any[], incoming: any[], { args }: FieldFunctionOptions) => {

--- a/packages/common-types/src/constants.ts
+++ b/packages/common-types/src/constants.ts
@@ -1,4 +1,4 @@
-const host = 'exp.host';
+const host = 'api.expo.dev';
 const origin = `https://${host}`;
 const websiteOrigin = 'https://expo.dev';
 


### PR DESCRIPTION
# Why

We shouldn't use `https://exp.host/` anymore 

# How

 Update API URL and graphql endpoints to use api.expo.dev

# Test Plan

Run `yarn gql`
