### PR TITLE
[menu-bar] Improve fatal CLI error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Cache builds by default. ([#156](https://github.com/expo/orbit/pull/156) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improve fatal CLI error handling. ([#163](https://github.com/expo/orbit/pull/163) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/modules/menu-bar/ios/MenuBarExceptions.swift
+++ b/apps/menu-bar/modules/menu-bar/ios/MenuBarExceptions.swift
@@ -6,6 +6,15 @@ internal class CLIOutputError: GenericException<String> {
   }
 }
 
+internal class IntenalCLIError: GenericException<String> {
+  public override var code: String {
+    "ERR_INTERNAL_CLI"
+  }
+  override var reason: String {
+    "Unable to invoke internal CLI: \(param)"
+  }
+}
+
 internal class LauncherError: Exception {
   override var reason: String {
     "Failed to update login item status."

--- a/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
+++ b/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
@@ -141,7 +141,11 @@ public class MenuBarModule: Module {
         if hasReachedError {
           promise.reject(CLIOutputError(returnOutput))
         } else {
-          promise.resolve(hasReachedReturnOutput ? returnOutput : nil)
+          if task.terminationStatus == 0 {
+            promise.resolve(hasReachedReturnOutput ? returnOutput : nil)
+          } else {
+            promise.reject(IntenalCLIError(fullOutput))
+          }
         }
       }
       

--- a/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
+++ b/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
@@ -102,6 +102,7 @@ public class MenuBarModule: Module {
       task.standardError = pipe
       
       let file = pipe.fileHandleForReading
+      var fullOutput = ""
       var returnOutput = ""
       var hasReachedReturnOutput = false
       var hasReachedError = false
@@ -121,7 +122,8 @@ public class MenuBarModule: Module {
           if output.isEmpty {
             continue
           }
-          
+          fullOutput.append(output)
+
           if hasReachedReturnOutput || hasReachedError {
             returnOutput.append(output)
           } else if output == "---- return output ----" {

--- a/apps/menu-bar/src/popover/DevicesListError.tsx
+++ b/apps/menu-bar/src/popover/DevicesListError.tsx
@@ -1,0 +1,23 @@
+import { TouchableOpacity } from 'react-native';
+
+import AlertIcon from '../assets/icons/AlertTriangle';
+import { View, Text } from '../components';
+import Alert from '../modules/Alert';
+
+const DevicesListError = ({ error }: { error: Error }) => {
+  return (
+    <View px="4" pb="4">
+      <TouchableOpacity
+        style={{ alignItems: 'center' }}
+        onPress={() => Alert.alert('Something went wrong', error.message)}>
+        <AlertIcon width="40" height="40" />
+        <Text type="InterBold">Something went wrong</Text>
+        <Text color="warning" numberOfLines={2}>
+          Unable to list devices, click here to see the full error
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+export default DevicesListError;

--- a/apps/menu-bar/src/windows/Onboarding.tsx
+++ b/apps/menu-bar/src/windows/Onboarding.tsx
@@ -46,12 +46,22 @@ const Onboarding = () => {
 
       setPlatformToolsCheck({});
       checkStatus.current = Status.RUNNING;
-      const output = await MenuBarModule.runCli('check-tools', []);
-      // eslint-disable-next-line no-eval
-      const result: CliCommands.CheckTools.PlatformToolsCheck = eval(`(${output})`);
-      checkStatus.current =
-        result?.android?.success && result?.ios?.success ? Status.SUCCESS : Status.FAILED;
-      setPlatformToolsCheck(result);
+      try {
+        const output = await MenuBarModule.runCli('check-tools', []);
+        // eslint-disable-next-line no-eval
+        const result: CliCommands.CheckTools.PlatformToolsCheck = eval(`(${output})`);
+        checkStatus.current =
+          result?.android?.success && result?.ios?.success ? Status.SUCCESS : Status.FAILED;
+        setPlatformToolsCheck(result);
+      } catch (err) {
+        checkStatus.current = Status.FAILED;
+        if (err instanceof Error) {
+          setPlatformToolsCheck({
+            android: { success: false, reason: { message: err.message } },
+            ios: { success: false, reason: { message: err.message } },
+          });
+        }
+      }
     }, [])
   );
 


### PR DESCRIPTION
# Why

When fatal errors happen on the CLI, the user gets no visual feedback that something went wrong, causing confusion and reports like this one https://github.com/expo/orbit/issues/18#issuecomment-1926576880 

# How

Improve fatal CLI error handling by handling fatal errors on Onboarding and the main Popover

# Test Plan

<img height="300" src="https://github.com/expo/orbit/assets/11707729/650eb713-4cb6-41d0-9bd1-e89d60ab2d50" />
 
<img height="400" src="https://github.com/expo/orbit/assets/11707729/01793e8b-4dc4-4b37-b58e-a1a1d4e8baf4" />

<img height="300" src="https://github.com/expo/orbit/assets/11707729/25f38941-3080-49e0-b001-de6c147612c6" />

  