### PR TITLE
[cli] Fix cli errors not being converted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Cache builds by default. ([#156](https://github.com/expo/orbit/pull/156) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Improve fatal CLI error handling. ([#163](https://github.com/expo/orbit/pull/163) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improve fatal CLI error handling. ([#163](https://github.com/expo/orbit/pull/163),[#166](https://github.com/expo/orbit/pull/166) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/modules/menu-bar/index.ts
+++ b/apps/menu-bar/modules/menu-bar/index.ts
@@ -21,15 +21,13 @@ async function runCli(command: string, args: string[], callback?: (status: strin
     const result = await MenuBarModule.runCli(command, args, id);
     return result;
   } catch (error) {
-    if (error instanceof CodedError) {
-      if (error.code === 'ERR_INTERNAL_CLI') {
-        if (!hasShownCliErrorAlert) {
-          Alert.alert(
-            'Something went wrong',
-            'Unable to invoke internal CLI, please reinstall Orbit.'
-          );
-          hasShownCliErrorAlert = true;
-        }
+    if (error instanceof CodedError && error.code === 'ERR_INTERNAL_CLI') {
+      if (!hasShownCliErrorAlert) {
+        Alert.alert(
+          'Something went wrong',
+          'Unable to invoke internal CLI, please reinstall Orbit.'
+        );
+        hasShownCliErrorAlert = true;
       }
     } else if (error instanceof Error) {
       // Original error from CLI is a stringified JSON object


### PR DESCRIPTION
# Why

A regression of https://github.com/expo/orbit/pull/163 is causing CLI errors not to be converted correctly 

# How

Update MenuBar error catching if statement to not ignore `CodedError`s

# Test Plan

Manually trigger a CLI error return 
