### PR TITLE
[menu-bar] Fix Window height on electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165), [#170](https://github.com/expo/orbit/pull/170) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/electron/modules/WindowManager/main.ts
+++ b/apps/menu-bar/electron/modules/WindowManager/main.ts
@@ -19,7 +19,7 @@ const openWindow = async (moduleName: string, options: WindowOptions) => {
 
     window = new BrowserWindow({
       width: windowStyle.width ?? 300,
-      height: windowStyle.height ?? 400,
+      height: (windowStyle.height ?? 400) + (windowStyle.titlebarAppearsTransparent ? 30 : 0),
       title: options?.title ?? moduleName,
       frame: !windowStyle.mask?.includes(WindowStyleMask.FullSizeContentView),
       resizable: windowStyle.mask?.includes(WindowStyleMask.Resizable) ?? false,


### PR DESCRIPTION
# Why

When using titlebarAppearsTransparent the window height does not match the window size on macOS

# How

Add 30px to window height when `titlebarAppearsTransparent = true`

# Test Plan


<img width="914" alt="image" src="https://github.com/expo/orbit/assets/11707729/26e1e1df-9b65-44d5-9610-606ef1d5fd96">
