### PR TITLE
[menu-bar] Add Electron support for FilePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165), [#170](https://github.com/expo/orbit/pull/170) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165), [#170](https://github.com/expo/orbit/pull/170), [#171](https://github.com/expo/orbit/pull/171) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/electron/modules/mainRegistry.ts
+++ b/apps/menu-bar/electron/modules/mainRegistry.ts
@@ -3,6 +3,7 @@ import { Registry } from 'react-native-electron-modules';
 import AutoResizerRootViewManager from './AutoResizerRootViewManager/main';
 import Linking from './Linking/main';
 import WindowManager from './WindowManager/main';
+import FilePickerModule from '../../modules/file-picker/electron/main';
 import MenuBarModule from '../../modules/menu-bar/electron/main';
 import RudderModule from '../../modules/rudder/electron/main';
 
@@ -12,4 +13,5 @@ export const MainModules: Registry = [
   AutoResizerRootViewManager,
   WindowManager,
   RudderModule,
+  FilePickerModule,
 ];

--- a/apps/menu-bar/modules/file-picker/electron/main.ts
+++ b/apps/menu-bar/modules/file-picker/electron/main.ts
@@ -1,0 +1,33 @@
+import { dialog } from 'electron';
+
+import { NativeFilePickerModule } from '../src/types';
+
+const FilePickerModule: Partial<NativeFilePickerModule> & { name: string } = {
+  name: 'FilePicker',
+  pickFileWithFilenameExtension: async (filenameExtensions: string[], prompt: string) => {
+    const { filePaths, canceled } = await dialog.showOpenDialog({
+      properties: ['openFile'],
+      buttonLabel: prompt,
+      filters: [{ name: 'Apps', extensions: filenameExtensions }],
+    });
+
+    if (canceled) {
+      throw new Error('NSModalResponseCancel');
+    }
+
+    return filePaths[0];
+  },
+  pickFolder: async () => {
+    const { filePaths, canceled } = await dialog.showOpenDialog({
+      properties: ['openDirectory'],
+    });
+
+    if (canceled) {
+      throw new Error('NSModalResponseCancel');
+    }
+
+    return filePaths[0];
+  },
+};
+
+export default FilePickerModule;

--- a/apps/menu-bar/modules/file-picker/src/FilePickerModule.web.ts
+++ b/apps/menu-bar/modules/file-picker/src/FilePickerModule.web.ts
@@ -1,12 +1,5 @@
+import { requireElectronModule } from 'react-native-electron-modules/build/requireElectronModule';
+
 import { NativeFilePickerModule } from './types';
 
-const FilePickerModule: NativeFilePickerModule = {
-  pickFolder() {
-    return Promise.resolve('');
-  },
-  pickFileWithFilenameExtension() {
-    return Promise.resolve('');
-  },
-};
-
-export default FilePickerModule;
+export default requireElectronModule<NativeFilePickerModule>('FilePicker');

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -253,7 +253,7 @@ function Core(props: Props) {
 
   const installAppFromURI = useCallback(
     async (appURI: string) => {
-      let localFilePath = appURI.startsWith('/') ? appURI : undefined;
+      let localFilePath = appURI.startsWith('https://') ? undefined : appURI;
       try {
         if (!localFilePath) {
           setStatus(MenuBarStatus.DOWNLOADING);


### PR DESCRIPTION
# Why

Closes ENG-11321

# How

Use electron's `dialog` API to add support for the FilePicker module when running electron 

# Test Plan


https://github.com/expo/orbit/assets/11707729/8f3be5ec-ddea-4258-89aa-606f2491b986


