### PR TITLE
[menu-bar][electron] Open Popover window when receiving a deeplink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Add support for launching Expo updates. ([#134](https://github.com/expo/orbit/pull/134), [#137](https://github.com/expo/orbit/pull/137), [#138](https://github.com/expo/orbit/pull/138), [#144](https://github.com/expo/orbit/pull/144), [#148](https://github.com/expo/orbit/pull/148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165), [#170](https://github.com/expo/orbit/pull/170), [#171](https://github.com/expo/orbit/pull/171) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165), [#170](https://github.com/expo/orbit/pull/170), [#171](https://github.com/expo/orbit/pull/171), [#172](https://github.com/expo/orbit/pull/172) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/electron/src/TrayGenerator.ts
+++ b/apps/menu-bar/electron/src/TrayGenerator.ts
@@ -77,6 +77,10 @@ export default class TrayGenerator {
     app.on('second-instance', this.showWindow);
 
     this.mainWindow.on('blur', () => {
+      if (!this.tray) {
+        return;
+      }
+
       const cursor = screen.getCursorScreenPoint();
       const trayBounds = this.tray.getBounds();
       if (

--- a/apps/menu-bar/electron/src/TrayGenerator.ts
+++ b/apps/menu-bar/electron/src/TrayGenerator.ts
@@ -1,4 +1,12 @@
-import { Tray, Menu, screen, BrowserWindow, MenuItemConstructorOptions, ipcMain } from 'electron';
+import {
+  Tray,
+  Menu,
+  screen,
+  BrowserWindow,
+  MenuItemConstructorOptions,
+  ipcMain,
+  app,
+} from 'electron';
 import path from 'path';
 
 export default class TrayGenerator {
@@ -64,6 +72,25 @@ export default class TrayGenerator {
 
     ipcMain.handle('open-popover', this.showWindow);
     ipcMain.handle('close-popover', this.hideWindow);
+
+    app.on('open-url', this.showWindow);
+    app.on('second-instance', this.showWindow);
+
+    this.mainWindow.on('blur', () => {
+      const cursor = screen.getCursorScreenPoint();
+      const trayBounds = this.tray.getBounds();
+      if (
+        cursor.x >= trayBounds.x &&
+        cursor.x <= trayBounds.x + trayBounds.width &&
+        cursor.y >= trayBounds.y &&
+        cursor.y <= trayBounds.y + trayBounds.height
+      ) {
+        // Cursor is within tray bounds, do not hide
+        return;
+      }
+
+      this.hideWindow();
+    });
   };
 }
 module.exports = TrayGenerator;


### PR DESCRIPTION
 # Why

When opening a deeplink link on Windows the popover window does not become visible

# How

Update TrayGenerator to automatically open the Popover window when opening a deeplink and auto-hide the window on blur 

# Test Plan

https://github.com/expo/orbit/assets/11707729/15ddeb51-ea49-4a6a-82e6-c9eea0a27509

