### PR TITLE
[cli] Fix download-build returning cached corrupted APKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent CLI from returning invalid cached APKs when the download of the build fails. ([#156](https://github.com/expo/orbit/pull/156) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Fix typo in error alert message. ([#183](https://github.com/expo/orbit/pull/183) by [@prettyClouds](https://github.com/prettyClouds))

--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -138,19 +138,21 @@ export async function downloadAndMaybeExtractAppAsync(url: string): Promise<stri
 
   await fs.promises.mkdir(outputDir, { recursive: true });
 
+  const tmpArchivePathDir = path.join(getTmpDirectory(), uuidv4());
+  await fs.mkdir(tmpArchivePathDir, { recursive: true });
   if (url.endsWith('apk')) {
-    const apkFilePath = path.join(outputDir, `${uuidv4()}.apk`);
+    const tmpApkFilePath = path.join(tmpArchivePathDir, `${uuidv4()}.tar.gz`);
     await downloadFileWithProgressTrackerAsync(
       url,
-      apkFilePath,
+      tmpApkFilePath,
       (ratio, total) => `Downloading app (${formatBytes(total * ratio)} / ${formatBytes(total)})`,
       'Successfully downloaded app'
     );
+    // Only move the file to correct location after the download is complete to avoid corrupted files
+    const apkFilePath = path.join(outputDir, `${uuidv4()}.apk`);
+    await fs.move(tmpApkFilePath, apkFilePath);
     return apkFilePath;
   } else {
-    const tmpArchivePathDir = path.join(getTmpDirectory(), uuidv4());
-    await fs.mkdir(tmpArchivePathDir, { recursive: true });
-
     const tmpArchivePath = path.join(tmpArchivePathDir, `${uuidv4()}.tar.gz`);
 
     await downloadFileWithProgressTrackerAsync(


### PR DESCRIPTION
# Why

Closes ENG-11535

# How

Update `downloadAndMaybeExtractAppAsync` to only move the APK file to the final path once the file download is complete 

# Test Plan

run `yarn cli download-build https://expo.dev/artifacts/eas/xyz` kill process while downloading or turn off wifi and then rerun `yarn cli download-build https://expo.dev/artifacts/eas/xyz`. It should redownload the APK instead of just returning the corrupted APK path
