### PR TITLE
[cli] Filter extra avd info when listing emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix extra avd info being displayed as a bootable android emulator. ([#190](https://github.com/expo/orbit/pull/190) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 1.1.0 — 2024-03-06

--- a/packages/eas-shared/src/run/android/emulator.ts
+++ b/packages/eas-shared/src/run/android/emulator.ts
@@ -51,14 +51,21 @@ export async function getAvailableAndroidEmulatorsAsync(): Promise<
   try {
     const { stdout } = await emulatorAsync('-list-avds');
 
-    return stdout
-      .split(os.EOL)
-      .filter(Boolean)
-      .map((name) => ({
-        name,
-        osType: 'Android',
-        deviceType: 'emulator',
-      }));
+    return (
+      stdout
+        .split(os.EOL)
+        .filter(Boolean)
+        /**
+         * AVD names cannot contain spaces. This removes extra info lines from the output. e.g.
+         * "INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db
+         */
+        .filter((name) => !name.trim().includes(' '))
+        .map((name) => ({
+          name,
+          osType: 'Android',
+          deviceType: 'emulator',
+        }))
+    );
   } catch {
     return [];
   }


### PR DESCRIPTION
# Why
 
Recently got a few reports from @brentvatne and @Simek regarding a nonbootable devices being listed in Orbit
 

![image](https://github.com/expo/expo/assets/11707729/12301bbe-5442-4e13-807f-26654349526a)

 
# How

AVD IDs cannot contain spaces,  so in order to remove all the extra info returned by `emulator -list-avds`, we can just filter out lines that contain spaces 

# Test Plan

Running `yarn cli list-devices -p android` should not list ` INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db, detection is enabled for process: 92342 (emulator)` 
