### PR TITLE
[eas-shared] Prevent qemu emualtor console window from showing up on Windows

### DIFF
--- a/apps/menu-bar/modules/progress-indicator/src/ProgressIndicatorView.web.tsx
+++ b/apps/menu-bar/modules/progress-indicator/src/ProgressIndicatorView.web.tsx
@@ -15,6 +15,8 @@ export default function ProgressIndicatorView({
       style={{
         width: 'auto',
         height: 6,
+        marginTop: 8,
+        marginBottom: 8,
       }}
     />
   );

--- a/packages/eas-shared/src/run/android/emulator.ts
+++ b/packages/eas-shared/src/run/android/emulator.ts
@@ -97,7 +97,8 @@ export async function bootEmulatorAsync(
   // Start a process to open an emulator
   const emulatorProcess = spawnAsync(emulatorExecutable, spawnArgs, {
     stdio: 'ignore',
-    detached: true,
+    // Running detached on Windows causes a CMD window to popup. windowsHide:true does not work. Check https://github.com/nodejs/node/issues/21825
+    detached: process.platform != 'win32',
   });
 
   // we don't want to wait for the emulator process to exit before we can finish `eas build:run` command


### PR DESCRIPTION
# Why

On Windows launching emulator spawns a visible  Terminal window

# How

 Prevent qemu emualtor console window from showing up on Windows and also fixes progress indicator margins on web

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
