### PR TITLE
[eas-shared] Add support for installing iOS .app files from custom tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix extra avd info being displayed as a bootable android emulator. ([#190](https://github.com/expo/orbit/pull/190) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix installing iOS apps from tarballs that don't contain an `.app` or `.ipa` file. ([#193](https://github.com/expo/orbit/pull/193) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

When trying to install an app archive like https://dpq5q02fu5f55.cloudfront.net/Exponent-2.30.10.tar.gz, the installation fails because the extracted contents do not have the .app extension. 

# How

Update `getAppPathAsync` logic to, when extracting an archive and a `.apk`, `.app`or `.ipa` is not found, check if the output dir is an .app but was extracted as folder

# Test Plan

Install Expo Go using https://dpq5q02fu5f55.cloudfront.net/Exponent-2.30.10.tar.gz
