### PR TITLE
[cli] Warn user when trying to an iOS app in a incompatible device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Add warning when trying to an iOS app in a incompatible device. ([#194](https://github.com/expo/orbit/pull/194) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 1.1.0 — 2024-03-06
 
 ### 🎉 New features

--- a/apps/cli/src/commands/InstallAndLaunchApp.ts
+++ b/apps/cli/src/commands/InstallAndLaunchApp.ts
@@ -32,7 +32,7 @@ async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string) {
   if (await Simulator.isSimulatorAsync(deviceId)) {
     if (appType === 'device') {
       throw new Error(
-        "iOS device builds can't be installed on simulators. Either use a physical device or generate a new simulator build."
+        "iOS apps built to target physical devices can't be installed on simulators. Either use a physical device or generate a new simulator build."
       );
     }
 
@@ -44,7 +44,7 @@ async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string) {
 
   if (appType === 'simulator') {
     throw new Error(
-      "iOS simulator builds can't be installed on real devices. Either use a simulator or generate an internal distribution build."
+      "iOS simulator builds can't be installed on physical devices. Either use a simulator or generate an internal distribution build."
     );
   }
   const appId = await AppleDevice.getBundleIdentifierForBinaryAsync(appPath);

--- a/packages/eas-shared/src/index.ts
+++ b/packages/eas-shared/src/index.ts
@@ -3,7 +3,7 @@ import {
   AppPlatform,
   extractAppFromLocalArchiveAsync,
 } from './download';
-import { runAppOnIosSimulatorAsync, runAppOnAndroidEmulatorAsync } from './run';
+import { runAppOnIosSimulatorAsync, runAppOnAndroidEmulatorAsync, detectIOSAppType } from './run';
 import * as Emulator from './run/android/emulator';
 import { assertExecutablesExistAsync as validateAndroidSystemRequirementsAsync } from './run/android/systemRequirements';
 import AppleDevice from './run/ios/device';
@@ -21,6 +21,7 @@ export {
   runAppOnAndroidEmulatorAsync,
   validateAndroidSystemRequirementsAsync,
   validateIOSSystemRequirementsAsync,
+  detectIOSAppType,
   Emulator,
   Simulator,
   AppleDevice,

--- a/packages/eas-shared/src/run/index.ts
+++ b/packages/eas-shared/src/run/index.ts
@@ -5,6 +5,7 @@ import * as Simulator from './ios/simulator';
 import { validateSystemRequirementsAsync } from './ios/systemRequirements';
 import { assertExecutablesExistAsync } from './android/systemRequirements';
 import { getAptParametersAsync } from './android/aapt';
+export { detectIOSAppType } from './ios/inspectApp';
 
 export async function runAppOnIosSimulatorAsync(
   appPath: string,

--- a/packages/eas-shared/src/run/ios/inspectApp.ts
+++ b/packages/eas-shared/src/run/ios/inspectApp.ts
@@ -1,9 +1,14 @@
 import path from 'path';
+import fs from 'fs-extra';
 
 import { parseBinaryPlistAsync } from '../../utils/parseBinaryPlistAsync';
 
 export async function detectIOSAppType(appPath: string): Promise<'device' | 'simulator'> {
   const builtInfoPlistPath = path.join(appPath, 'Info.plist');
+  if (!fs.existsSync(builtInfoPlistPath)) {
+    return 'device';
+  }
+
   const { DTPlatformName }: { DTPlatformName: string } =
     await parseBinaryPlistAsync(builtInfoPlistPath);
 

--- a/packages/eas-shared/src/run/ios/inspectApp.ts
+++ b/packages/eas-shared/src/run/ios/inspectApp.ts
@@ -1,0 +1,11 @@
+import path from 'path';
+
+import { parseBinaryPlistAsync } from '../../utils/parseBinaryPlistAsync';
+
+export async function detectIOSAppType(appPath: string): Promise<'device' | 'simulator'> {
+  const builtInfoPlistPath = path.join(appPath, 'Info.plist');
+  const { DTPlatformName }: { DTPlatformName: string } =
+    await parseBinaryPlistAsync(builtInfoPlistPath);
+
+  return DTPlatformName.includes('simulator') ? 'simulator' : 'device';
+}


### PR DESCRIPTION
# Why

A lot of times users try to install their device builds on simulators and simulator builds on devices via Orbit. Doing so will throw the following error, which is not really descriptive and leads to some confusion 

![image](https://github.com/expo/orbit/assets/11707729/48d790e8-4b75-4abd-bb9c-84e564cdff5c)


# How

Update `InstallAndLaunchApp` command to check if the type of app is compatible with the selected device before a trying to install it 

# Test Plan

https://github.com/expo/orbit/assets/11707729/9f21adac-28b3-40b6-a565-13cdb5872da2


