### PR TITLE
[cli] Update listDevices order to show physical devices first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Update devices order to show physical devices first. ([#197](https://github.com/expo/orbit/pull/197) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 1.1.1 — 2024-03-15
 
 ### 🐛 Bug fixes


### PR DESCRIPTION
# Why

While testing the new onboarding flow for expo.dev we noticed that having the physical devices showing up first on the list makes more sense than at the bottom

# How

Update listDevices order to show physical devices first

# Test Plan

<img width="452" alt="image" src="https://github.com/expo/orbit/assets/11707729/171e5806-64d3-402e-9572-0f0a4cc4b1a6">

