### PR TITLE
[eas-shared] Improve listing connected Apple devices over Wi-Fi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Update devices order to show physical devices first. ([#197](https://github.com/expo/orbit/pull/197) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improve listing connected Apple devices over Wi-Fi. ([#199](https://github.com/expo/orbit/pull/199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 1.1.1 — 2024-03-15
 

--- a/packages/eas-shared/package.json
+++ b/packages/eas-shared/package.json
@@ -11,16 +11,16 @@
   },
   "exports": {
     ".": {
-    "import": "./build/esm/index.js",
-    "require": "./build/cjs/index.js",
-    "default": "./build/esm/index.js"
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js",
+      "default": "./build/esm/index.js"
     }
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/fs-extra": "^11.0.1",
     "@types/getenv": "^1.0.0",
-    "@types/lodash": "^4.14.195",
+    "@types/lodash": "^4.17.4",
     "@types/node-fetch": "^2.6.4",
     "@types/tar": "^6.1.5",
     "@types/uuid": "^9.0.1",

--- a/packages/eas-shared/src/run/ios/devicectl.ts
+++ b/packages/eas-shared/src/run/ios/devicectl.ts
@@ -1,0 +1,241 @@
+/**
+ * Copyright © 2024 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { getExpoHomeDirectory } from '@expo/config/build/getUserState';
+import JsonFile from '@expo/json-file';
+import spawnAsync, { SpawnOptions, SpawnResult } from '@expo/spawn-async';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import assert from 'node:assert';
+import path from 'path';
+import tempy from 'tempy';
+
+import { xcrunAsync } from './xcrun';
+import Log from '../../log';
+import { CommandError } from '../../utils/errors';
+
+const DEVICE_CTL_EXISTS_PATH = path.join(getExpoHomeDirectory(), 'devicectl-exists');
+
+const debug = require('debug')('expo:devicectl') as typeof console.log;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type AnyEnum<T extends string = string> = T | (string & {});
+
+type DeviceCtlDevice = {
+  capabilities: DeviceCtlDeviceCapability[];
+  connectionProperties: DeviceCtlConnectionProperties;
+  deviceProperties: DeviceCtlDeviceProperties;
+  hardwareProperties: DeviceCtlHardwareProperties;
+  /** "A1A1AAA1-0011-1AA1-11A1-10A1111AA11A" */
+  identifier: string;
+  visibilityClass: AnyEnum<'default'>;
+};
+
+type DeviceCtlHardwareProperties = {
+  cpuType: DeviceCtlCpuType;
+  deviceType: AnyEnum<'iPhone'>;
+  /** 1114404411111111 */
+  ecid: number;
+  /** "D74AP" */
+  hardwareModel: string;
+  /** 512000000000 */
+  internalStorageCapacity: number;
+  /** true */
+  isProductionFused: boolean;
+  /** "iPhone 14 Pro Max" */
+  marketingName: string;
+  /** "iOS" */
+  platform: AnyEnum<'iOS'>;
+  /** "iPhone15,3" */
+  productType: AnyEnum<'iPhone13,4' | 'iPhone15,3'>;
+  reality: AnyEnum<'physical'>;
+  /** "X2X1CC1XXX" */
+  serialNumber: string;
+  supportedCPUTypes: DeviceCtlCpuType[];
+  /** [1] */
+  supportedDeviceFamilies: number[];
+  thinningProductType: AnyEnum<'iPhone15,3'>;
+  /** "00001110-001111110110101A" */
+  udid: string;
+};
+
+type DeviceCtlDeviceProperties = {
+  /** true */
+  bootedFromSnapshot: boolean;
+  /** "com.apple.os.update-AD0CF111ACFF11A11111A76A3D1262AE42A3F56F305AF5AE1135393A7A14A7D1" */
+  bootedSnapshotName: string;
+  /** false */
+  ddiServicesAvailable: boolean;
+
+  developerModeStatus: AnyEnum<'enabled'>;
+  /** false */
+  hasInternalOSBuild: boolean;
+  /** "Evan's phone" */
+  name: string;
+  /** "21E236" */
+  osBuildUpdate: string;
+  /** "17.4.1" */
+  osVersionNumber: string;
+  /** false */
+  rootFileSystemIsWritable: boolean;
+};
+
+type DeviceCtlDeviceCapability =
+  | {
+      name: AnyEnum;
+      featureIdentifier: AnyEnum;
+    }
+  | {
+      featureIdentifier: 'com.apple.coredevice.feature.connectdevice';
+      name: 'Connect to Device';
+    }
+  | {
+      featureIdentifier: 'com.apple.coredevice.feature.unpairdevice';
+      name: 'Unpair Device';
+    }
+  | {
+      featureIdentifier: 'com.apple.coredevice.feature.acquireusageassertion';
+      name: 'Acquire Usage Assertion';
+    };
+
+type DeviceCtlConnectionProperties = {
+  authenticationType: AnyEnum<'manualPairing'>;
+  isMobileDeviceOnly: boolean;
+  /** "2024-04-20T22:50:04.244Z" */
+  lastConnectionDate: string;
+  pairingState: AnyEnum<'paired'>;
+  /** ["00001111-001111110110101A.coredevice.local", "A1A1AAA1-0011-1AA1-11A1-10A1111AA11A.coredevice.local"] */
+  potentialHostnames: string[];
+  transportType: AnyEnum<'localNetwork' | 'wired'>;
+  tunnelState: AnyEnum<'disconnected'>;
+  tunnelTransportProtocol: AnyEnum<'tcp'>;
+};
+
+type DeviceCtlCpuType = {
+  name: AnyEnum<'arm64e' | 'arm64' | 'arm64_32'>;
+  subType: number;
+  /** 16777228 */
+  type: number;
+};
+
+/** Run a `devicectl` command. */
+export async function devicectlAsync(args: string[], options?: SpawnOptions): Promise<SpawnResult> {
+  try {
+    return await xcrunAsync(['devicectl', ...args], options);
+  } catch (error: any) {
+    if (error instanceof CommandError) {
+      throw error;
+    }
+    if ('stderr' in error) {
+      const errorCodes = getDeviceCtlErrorCodes(error.stderr);
+      if (errorCodes.includes('Locked')) {
+        throw new CommandError('APPLE_DEVICE_LOCKED', 'Device is locked, unlock and try again.');
+      }
+    }
+    throw error;
+  }
+}
+
+export async function getConnectedAppleDevicesAsync() {
+  if (!hasDevicectlEverBeenInstalled()) {
+    debug('devicectl not found, skipping remote Apple devices.');
+    return [];
+  }
+
+  const tmpPath = tempy.file();
+  const devices = await devicectlAsync([
+    'list',
+    'devices',
+    '--json-output',
+    tmpPath,
+    // Give two seconds before timing out: between 5 and 9223372036854775807
+    '--timeout',
+    '5',
+  ]);
+  debug(devices.stdout);
+  const devicesJson = await JsonFile.readAsync(tmpPath);
+
+  if ((devicesJson as any)?.info?.jsonVersion !== 2) {
+    Log.warn(
+      'Unexpected devicectl JSON version output from devicectl. Connecting to physical Apple devices may not work as expected.'
+    );
+  }
+
+  assertDevicesJson(devicesJson);
+
+  return devicesJson.result.devices as DeviceCtlDevice[];
+}
+
+function assertDevicesJson(
+  results: any
+): asserts results is { result: { devices: DeviceCtlDevice[] } } {
+  assert(
+    results != null && 'result' in results && Array.isArray(results?.result?.devices),
+    'Malformed JSON output from devicectl: ' + JSON.stringify(results, null, 2)
+  );
+}
+
+export async function launchBinaryOnMacAsync(
+  bundleId: string,
+  appBinaryPath: string
+): Promise<void> {
+  const args = ['-b', bundleId, appBinaryPath];
+  try {
+    await spawnAsync('open', args);
+  } catch (error: any) {
+    if ('code' in error) {
+      if (error.code === 1) {
+        throw new CommandError(
+          'MACOS_LAUNCH',
+          'Failed to launch the compatible binary on macOS: open ' +
+            args.join(' ') +
+            '\n\n' +
+            error.message
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+export async function launchAppWithDeviceCtl(deviceId: string, bundleId: string) {
+  await devicectlAsync(['device', 'process', 'launch', '--device', deviceId, bundleId]);
+}
+
+/** Find all error codes from the output log */
+function getDeviceCtlErrorCodes(log: string): string[] {
+  return [...log.matchAll(/BSErrorCodeDescription\s+=\s+(.*)$/gim)].map(([_line, code]) => code);
+}
+
+let hasEverBeenInstalled: boolean | undefined;
+
+export function hasDevicectlEverBeenInstalled() {
+  if (hasEverBeenInstalled) return hasEverBeenInstalled;
+  // It doesn't appear possible for devicectl to ever be uninstalled. We can just check once and store this result forever
+  // to prevent cold boots of devicectl from slowing down all invocations of `expo run ios`
+  if (fs.existsSync(DEVICE_CTL_EXISTS_PATH)) {
+    hasEverBeenInstalled = true;
+    return true;
+  }
+
+  const isInstalled = isDevicectlInstalled();
+
+  if (isInstalled) {
+    fs.writeFileSync(DEVICE_CTL_EXISTS_PATH, '1');
+  }
+  hasEverBeenInstalled = isInstalled;
+  return isInstalled;
+}
+
+function isDevicectlInstalled() {
+  try {
+    execSync('xcrun devicectl --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/eas-shared/src/utils/fn.ts
+++ b/packages/eas-shared/src/utils/fn.ts
@@ -28,3 +28,15 @@ export function guardAsync<V, T extends (...args: any[]) => Promise<V>>(fn: T): 
 
   return guard;
 }
+
+export function uniqBy<T>(array: T[], key: (item: T) => string): T[] {
+  const seen: { [key: string]: boolean } = {};
+  return array.filter((item) => {
+    const k = key(item);
+    if (seen[k]) {
+      return false;
+    }
+    seen[k] = true;
+    return true;
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5877,10 +5877,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.195":
-  version "4.14.195"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.195.tgz#bafc975b252eb6cea78882ce8a7b6bf22a6de632"
-  integrity sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg==
+"@types/lodash@^4.17.4":
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.4.tgz#0303b64958ee070059e3a7184048a55159fe20b7"
+  integrity sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -15640,7 +15640,16 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15713,7 +15722,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15726,6 +15735,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16912,7 +16928,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16925,6 +16941,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Why

iPhones connected over WiFi must be unlocked for it to show up on Orbit's list of devices

# How

Update `getConnectedDevicesAsync` function to use Xcode's 15 `devicectl` tool + Usbmuxd to list connected Apple devices improving the reliability of devices connected over Wi-Fi even when the device is locked 

# Test Plan

`yarn cli list-devices -p ios`
