### PR TITLE
[menu-bar][cli] Automatically select correct iOS device depending on app type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add experimental support for Windows and Linux. ([#152](https://github.com/expo/orbit/pull/152), [#157](https://github.com/expo/orbit/pull/157), [#158](https://github.com/expo/orbit/pull/158), [#160](https://github.com/expo/orbit/pull/160), [#161](https://github.com/expo/orbit/pull/161), [#165](https://github.com/expo/orbit/pull/165), [#170](https://github.com/expo/orbit/pull/170), [#171](https://github.com/expo/orbit/pull/171), [#172](https://github.com/expo/orbit/pull/172), [#173](https://github.com/expo/orbit/pull/173), [#174](https://github.com/expo/orbit/pull/174), [#175](https://github.com/expo/orbit/pull/175), [#177](https://github.com/expo/orbit/pull/177), [#178](https://github.com/expo/orbit/pull/178), [#180](https://github.com/expo/orbit/pull/180), [#181](https://github.com/expo/orbit/pull/181), [#182](https://github.com/expo/orbit/pull/182), [#185](https://github.com/expo/orbit/pull/185), [#191](https://github.com/expo/orbit/pull/191) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Automatically select the correct iOS device depending on app type. ([#200](https://github.com/expo/orbit/pull/200) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/cli/src/commands/DetectIOSAppType.ts
+++ b/apps/cli/src/commands/DetectIOSAppType.ts
@@ -1,0 +1,11 @@
+import { extractAppFromLocalArchiveAsync, detectIOSAppType } from 'eas-shared';
+
+export async function detectIOSAppTypeAsync(appPath: string) {
+  if (!appPath.endsWith('.app') && !appPath.endsWith('.ipa')) {
+    appPath = await extractAppFromLocalArchiveAsync(appPath);
+  }
+
+  const appType = await detectIOSAppType(appPath);
+
+  return appType;
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,6 +7,7 @@ import { installAndLaunchAppAsync } from './commands/InstallAndLaunchApp';
 import { launchSnackAsync } from './commands/LaunchSnack';
 import { checkToolsAsync } from './commands/CheckTools';
 import { setSessionAsync } from './commands/SetSession';
+import { detectIOSAppTypeAsync } from './commands/DetectIOSAppType';
 import { returnLoggerMiddleware } from './utils';
 
 const program = new Command();
@@ -65,6 +66,11 @@ program
   .command('set-session')
   .argument('<string>', 'Session secret')
   .action(returnLoggerMiddleware(setSessionAsync));
+
+program
+  .command('detect-ios-app-type')
+  .argument('<string>', 'Local path of the app')
+  .action(returnLoggerMiddleware(detectIOSAppTypeAsync));
 
 if (process.argv.length < 3) {
   program.help();

--- a/apps/menu-bar/src/commands/detectIOSAppTypeAsync'.ts
+++ b/apps/menu-bar/src/commands/detectIOSAppTypeAsync'.ts
@@ -1,0 +1,11 @@
+import { Device } from 'common-types/build/devices';
+
+import MenuBarModule from '../modules/MenuBarModule';
+
+export const detectIOSAppTypeAsync = async (appPath: string) => {
+  return (await MenuBarModule.runCli(
+    'detect-ios-app-type',
+    [appPath],
+    console.log
+  )) as Device['deviceType'];
+};


### PR DESCRIPTION
# Why

When using Orbit for the first time it can be confusing to have to manually select your physical device before trying to launch an IPA. We should instead just automatically select the correct iOS device type depending on the app type

# How

Introduce new `detect-ios-app-type` command 

# Test Plan

Run orbit locally:
1. select an iOS simulator
2. launch an internal distribution build 
3. observe the physical device being auto selected  