### PR TITLE
[cli] Add macos-export-certificate to pkg assets

### DIFF
--- a/apps/cli/pkg.config.json
+++ b/apps/cli/pkg.config.json
@@ -1,5 +1,6 @@
 {
   "pkg": {
+    "assets": ["../../node_modules/macos-export-certificate-and-key/**/*.node"],
     "targets": ["node18-macos-arm64", "node18-macos-x64"]
   }
 }


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/orbit/pull/208

# How

Explicitly add `macos-export-certificate` `.node` files to pkg assets to ensure node bindings work properly when archiving the CLI

# Test Plan

yarn `archive` and test the output executable 
