### PR TITLE
[menu-bar] Fix app version showing undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Update devices order to show physical devices first. ([#197](https://github.com/expo/orbit/pull/197) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve listing connected Apple devices over Wi-Fi. ([#199](https://github.com/expo/orbit/pull/199) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Upgrade `react-native` to 0.75.2. ([#203](https://github.com/expo/orbit/pull/203), [#209](https://github.com/expo/orbit/pull/209), by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Upgrade to `expo` SDK 51. ([#204](https://github.com/expo/orbit/pull/204) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Upgrade to `expo` SDK 51. ([#204](https://github.com/expo/orbit/pull/204), [#212](https://github.com/expo/orbit/pull/212) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Upgrade `react-native-svg` to 15.2.0. ([#204](https://github.com/expo/orbit/pull/204) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 1.1.1 — 2024-03-15

--- a/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
+++ b/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
@@ -13,7 +13,7 @@ public class MenuBarModule: Module {
     Events(onNewCommandLine, onCLIOutput)
 
     Constants([
-      "appVersion": self.appContext?.constants?.constants()["nativeAppVersion"],
+      "appVersion": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
       "buildVersion": self.appContext?.constants?.buildVersion(),
       "initialScreenSize": [
         "width": NSScreen.main?.frame.width,

--- a/apps/menu-bar/modules/rudder/ios/RudderModule.swift
+++ b/apps/menu-bar/modules/rudder/ios/RudderModule.swift
@@ -5,9 +5,9 @@ public class RudderModule: Module {
 
   public func definition() -> ModuleDefinition {
     Name("Rudder")
-    
+
     Constants([
-      "appVersion": self.appContext?.constants?.constants()["nativeAppVersion"],
+      "appVersion": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
     ])
 
     AsyncFunction("load") { (writeKey: String, dataPlaneUrl:String) in
@@ -20,13 +20,13 @@ public class RudderModule: Module {
 
     AsyncFunction("track") { (event: String, properties: [String: Any], context: [String: [String: Any]]?) in
       let option = RSOption()
-      
+
       if let context = context, !context.isEmpty {
-        for (key, value) in context { 
+        for (key, value) in context {
           option.putCustomContext(value, withKey: key)
         }
       }
-      
+
       RSClient.sharedInstance().track(event, properties:properties, option: option)
     }
   }


### PR DESCRIPTION
# Why

Follow up of https://github.com/expo/orbit/pull/204. Now that `nativeAppVersion` has been removed from Expo constants we need to read it from the Bundle

# How

Update MenuBar module to read app version directly from the Bundle info

# Test Plan

Run Menubar locally