### PR TITLE
[menu-bar] Fix react-native-macos NativeEventEmitter non-null argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🐛 Bug fixes
 
+- [macOS] Fix `new NativeEventEmitter() requires a non-null argument` error when clicking "See all". ([#225](https://github.com/expo/orbit/pull/225) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ### 🛠 Breaking changes

--- a/patches/react-native-macos+0.76.0.patch
+++ b/patches/react-native-macos+0.76.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-macos/src/private/animated/NativeAnimatedHelper.js b/node_modules/react-native-macos/src/private/animated/NativeAnimatedHelper.js
+index fac5756..723804f 100644
+--- a/node_modules/react-native-macos/src/private/animated/NativeAnimatedHelper.js
++++ b/node_modules/react-native-macos/src/private/animated/NativeAnimatedHelper.js
+@@ -430,7 +430,7 @@ export default {
+       nativeEventEmitter = new NativeEventEmitter(
+         // T88715063: NativeEventEmitter only used this parameter on iOS. Now it uses it on all platforms, so this code was modified automatically to preserve its behavior
+         // If you want to use the native module on other platforms, please remove this condition and test its behavior
+-        Platform.OS !== 'ios' ? null : NativeAnimatedModule,
++        Platform.OS !== 'macos' ? null : NativeAnimatedModule,
+       );
+     }
+     return nativeEventEmitter;


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/224

# How

 Patch react-native-macos as suggested by @Saadnajmi to check for `macos` instead of `ios` when creating a `NativeEventEmitter` instance inside `NativeAnimatedHelper`

# Test Plan

Run MenuBar locally