### PR TITLE
Allow users to manually launch updates in Expo Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🎉 New features
 
+- Allow users to manually launch updates in Expo Go. ([#226](https://github.com/expo/orbit/pull/226) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - [macOS] Fix `new NativeEventEmitter() requires a non-null argument` error when clicking "See all". ([#225](https://github.com/expo/orbit/pull/225) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -57,6 +57,7 @@ program
   .requiredOption('-p, --platform <string>', 'Selected platform')
   .requiredOption('--device-id  <string>', 'UDID or name of the device')
   .option('--skip-install', 'Skip app installation')
+  .option('--force-expo-go', 'Force update to be launched using Expo Go')
   .action(async (...args) => {
     const { launchUpdateAsync } = await import('./commands/LaunchUpdate');
     returnLoggerMiddleware(launchUpdateAsync)(...args);

--- a/apps/menu-bar/src/commands/launchUpdateAsync.ts
+++ b/apps/menu-bar/src/commands/launchUpdateAsync.ts
@@ -6,17 +6,21 @@ type LaunchUpdateAsyncOptions = {
   deviceId: string;
   url: string;
   noInstall?: boolean;
+  forceExpoGo?: boolean;
 };
 
 type LaunchUpdateCallback = (status: MenuBarStatus, progress: number) => void;
 
 export async function launchUpdateAsync(
-  { url, platform, deviceId, noInstall }: LaunchUpdateAsyncOptions,
+  { url, platform, deviceId, noInstall, forceExpoGo }: LaunchUpdateAsyncOptions,
   callback: LaunchUpdateCallback
 ) {
   const args = [url, '-p', platform, '--device-id', deviceId];
   if (noInstall) {
     args.push('--skip-install');
+  }
+  if (forceExpoGo) {
+    args.push('--force-expo-go');
   }
 
   await MenuBarModule.runCli('launch-update', args, (output) => {

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -283,6 +283,26 @@ function Core(props: Props) {
                     }, 2000);
                   },
                 },
+                {
+                  text: 'Launch with Expo Go',
+                  onPress: async () => {
+                    setStatus(MenuBarStatus.OPENING_UPDATE);
+                    await launchUpdateAsync(
+                      {
+                        url,
+                        deviceId: getDeviceId(device),
+                        platform: getDeviceOS(device),
+                        forceExpoGo: true,
+                      },
+                      (status) => {
+                        setStatus(status);
+                      }
+                    );
+                    setTimeout(() => {
+                      setStatus(MenuBarStatus.LISTENING);
+                    }, 2000);
+                  },
+                },
               ]
             );
           } else {


### PR DESCRIPTION
# Why

When users manually set their `runtimeVersion` to something other than `exposdk:x.x.x`, there is no way for us to detect if that app is compatible with Expo Go or not, given that, we should allow user to manually launch updates in Expo Go

# How

Introduce a new `--force-expo-go` flag to launch-update command allowing users to manually specify that their runtime version is compatible with Expo Go

# Test Plan

Run MenuBar locally
