### PR TITLE
[menu-bar][electron] Add maintainer field to deb packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [macOS] Fix `new NativeEventEmitter() requires a non-null argument` error when clicking "See all". ([#225](https://github.com/expo/orbit/pull/225) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Linux] Add maintainer field to deb packages. ([#227](https://github.com/expo/orbit/pull/227) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/apps/menu-bar/electron/forge.config.ts
+++ b/apps/menu-bar/electron/forge.config.ts
@@ -76,7 +76,10 @@ const config: ForgeConfig = {
       },
     }),
     new MakerDeb({
-      options: linuxOptions,
+      options: {
+        ...linuxOptions,
+        maintainer: 'Expo',
+      },
     }),
   ],
   plugins: [


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/223

# How

Add maintainer field to deb packages

# Test Plan

Run `yarn make` and install it on Ubuntu  
