### PR TITLE
[menu-bar][macos] Add CLI archive build phase to macOS project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add CLI archive build phase to macOS project. ([#248](https://github.com/expo/orbit/pull/248) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 2.0.2 — 2025-02-27
 
 ### 🎉 New features

--- a/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
+++ b/apps/menu-bar/macos/ExpoMenuBar.xcodeproj/project.pbxproj
@@ -268,6 +268,7 @@
 			buildConfigurationList = 5142015A2437B4B40078DB4F /* Build configuration list for PBXNativeTarget "ExpoMenuBar-macOS" */;
 			buildPhases = (
 				1A938104A937498D81B3BD3B /* [CP] Check Pods Manifest.lock */,
+				C091563F2D7787B200FC1EB6 /* Archive and sign CLI  */,
 				381D8A6F24576A6C00465D17 /* Start Packager */,
 				63FA8EA00DD165DC6FA0B487 /* [Expo] Configure project */,
 				514201452437B4B30078DB4F /* Sources */,
@@ -460,6 +461,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-ExpoMenuBar-macOS/expo-configure-project.sh\"\n";
+		};
+		C091563F2D7787B200FC1EB6 /* Archive and sign CLI  */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Archive and sign CLI ";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"$CONFIGURATION\" == \"Release\" ]; then \n    echo \"Archive and signing CLI...\"\n   \"$PODS_ROOT/../\"scripts/archive_cli.sh  \nelse\n    echo \"Skipping archiving CLI\"\nfi\n";
 		};
 		DF76CD60CADE3DD346ABE802 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/apps/menu-bar/macos/scripts/archive_cli.sh
+++ b/apps/menu-bar/macos/scripts/archive_cli.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+source "${REACT_NATIVE_PATH}/scripts/find-node-for-xcode.sh"
+export PROJECT_ROOT="$PODS_ROOT/../../"
+export CLI_PROJECT="$PROJECT_ROOT/../cli/"
+
+cd $CLI_PROJECT
+yarn archive
+yarn codesign
+
+cd $PROJECT_ROOT
+yarn update-cli


### PR DESCRIPTION
# Why

To prevent the CLI binary from being outdated when archiving the menu-bar, we should add an Xcode build phase to archive the CLI when building in release mode 

# How

Add build phase for archiving and signing the CLI when building the macOS project in Release mode

# Test Plan

Archive the macOS app
