### PR TITLE
[electron] Add arch info to Rudder module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Add CLI archive build phase to macOS project. ([#248](https://github.com/expo/orbit/pull/248) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add arch info to Rudder module. ([#252](https://github.com/expo/orbit/pull/252) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.0.2 — 2025-02-27
 

--- a/apps/menu-bar/modules/rudder/electron/main.ts
+++ b/apps/menu-bar/modules/rudder/electron/main.ts
@@ -1,10 +1,13 @@
 import { app } from 'electron';
 import os from 'os';
 
-const RudderModule = {
+import { type ElectronRudderModule } from '../src/Rudder.types';
+
+const RudderModule: Omit<ElectronRudderModule, 'platform'> = {
   name: 'Rudder',
   appVersion: app.getVersion(),
   osVersion: os.release(),
+  osArch: os.arch(),
 };
 
 export default RudderModule;

--- a/apps/menu-bar/modules/rudder/electron/preload.ts
+++ b/apps/menu-bar/modules/rudder/electron/preload.ts
@@ -1,3 +1,5 @@
+import { ElectronRudderModule } from '../src/Rudder.types';
+
 function getAnalyticsPlatformFromPlatform(platform: string): string {
   switch (platform) {
     case 'darwin':
@@ -9,7 +11,7 @@ function getAnalyticsPlatformFromPlatform(platform: string): string {
   }
 }
 
-const RudderModule = {
+const RudderModule: Pick<ElectronRudderModule, 'name' | 'platform'> = {
   name: 'Rudder',
   platform: getAnalyticsPlatformFromPlatform(process.platform),
 };

--- a/apps/menu-bar/modules/rudder/src/Rudder.types.ts
+++ b/apps/menu-bar/modules/rudder/src/Rudder.types.ts
@@ -12,6 +12,7 @@ export interface ElectronRudderModule {
   platform: string;
   appVersion: string;
   osVersion: string;
+  osArch: string;
 }
 
 export interface RudderClient {

--- a/apps/menu-bar/modules/rudder/src/RudderModule.web.ts
+++ b/apps/menu-bar/modules/rudder/src/RudderModule.web.ts
@@ -15,6 +15,9 @@ const RudderModule: RudderClient = {
         name: RudderElectronModule.platform,
         version: RudderElectronModule.osVersion,
       },
+      device: {
+        model: RudderElectronModule.osArch,
+      },
       app: {
         name: 'orbit',
         version: RudderElectronModule.appVersion,


### PR DESCRIPTION
# Why

RudderStack alreday tracks this when using macOS, we should log the same info for eletron based platforms 

# How

Add `os.arch()` to Rudder module on Electron

# Test Plan

Run menu bar locally 
