### PR TITLE
[menu-bar] Add macos build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - Upgrade to `expo` SDK 53 and react-native `0.79`. ([#254](https://github.com/expo/orbit/pull/254) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Update ESLint, `eslint-config-universe` and setups, bump TypeScript versions. ([#261](https://github.com/expo/orbit/pull/261) by [@Simek](https://github.com/Simek))
-- Add macos build script. ([#262](https://github.com/expo/orbit/pull/262) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add macOS build script. ([#262](https://github.com/expo/orbit/pull/262) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.0.3 — 2025-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 ### 💡 Others
 
 - Upgrade to `expo` SDK 53 and react-native `0.79`. ([#254](https://github.com/expo/orbit/pull/254) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Update ESLint, `eslint-config-universe` and setups, bump TypeScript versions. 
+- Update ESLint, `eslint-config-universe` and setups, bump TypeScript versions. ([#261](https://github.com/expo/orbit/pull/261) by [@Simek](https://github.com/Simek))
+- Add macos build script. ([#262](https://github.com/expo/orbit/pull/262) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.0.3 — 2025-05-16
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@
 ## 🏎️ Start the Development environment
 
 1. From the `apps/menu-bar` directory, run `yarn start` to start Metro Bundler.
-2. Run `xed macos` and build the `menu-bar` app with Xcode.
+2. Run `yarn macos` and build the `menu-bar` app with Xcode.
 3. And Orbit should automatically show up in your menu bar.
 
 ## 📝 Writing a Commit Message

--- a/apps/menu-bar/macos/scripts/build.sh
+++ b/apps/menu-bar/macos/scripts/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+WORKSPACE_PATH='./macos/ExpoMenuBar.xcworkspace'
+CONFIGURATION='Debug'
+SCHEME='ExpoMenuBar-macOS'
+
+# Build
+xcodebuild -workspace "$WORKSPACE_PATH" -scheme "$SCHEME" -configuration "$CONFIGURATION"
+
+# Get build settings
+BUILD_SETTINGS_JSON=$(xcodebuild -showBuildSettings -workspace "$WORKSPACE_PATH" -scheme "$SCHEME" -configuration "$CONFIGURATION" -json)
+
+readBuildSetting() {
+  echo "$BUILD_SETTINGS_JSON" | jq -r --arg key "$1" '.[0] | .buildSettings | .[$key]'
+}
+
+BUILT_PRODUCTS_DIR=$(readBuildSetting "BUILT_PRODUCTS_DIR")
+FULL_PRODUCT_NAME=$(readBuildSetting "FULL_PRODUCT_NAME")
+
+open -a "$BUILT_PRODUCTS_DIR/$FULL_PRODUCT_NAME" &

--- a/apps/menu-bar/package.json
+++ b/apps/menu-bar/package.json
@@ -8,6 +8,7 @@
     "export-upload-archive": "yarn export-archive -exportOptionsPlist macos/ExportUploadOptions.plist",
     "export-local-archive": "yarn export-archive -exportOptionsPlist macos/ExportLocalOptions.plist",
     "export-web": "expo export --platform web --output-dir electron/dist",
+    "macos": "bash ./macos/scripts/build.sh",
     "notarize": "xcodebuild -exportNotarizedApp -archivePath build/ExpoOrbit.xcarchive -exportPath build/Notarized",
     "lint": "eslint .",
     "start": "expo start",


### PR DESCRIPTION
# Why

Now that we have removed the community CLI dependency, we can no longer invoke `react-native run-macos`

# How

Add macos build script

# Test Plan

run `yarn macos`
