### PR TITLE
[eas-shared] fix: update cache check to return app path instead of directory

### DIFF
--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -126,7 +126,10 @@ export async function downloadAndMaybeExtractAppAsync(url: string): Promise<stri
 
   const outputDir = path.join(_downloadsCacheDirectory(), `${name}`);
   if (await checkCacheAvailabilityAsync(outputDir)) {
-    return outputDir;
+    const cachedAppPath = await getAppPathAsync(outputDir);
+    if (cachedAppPath) {
+      return cachedAppPath;
+    }
   }
 
   await fs.promises.mkdir(outputDir, { recursive: true });


### PR DESCRIPTION
# Why

Currently the cache checker is not functioning properly, it's returning the directory instead of the cached app file. 

It seems like the defect has been introduced in https://github.com/expo/orbit/pull/256

# How

While trying to install the same APK several times by using the same URL.

# Test Plan

I have uploaded an example APK to here: `https://altay.wtf/stuff/example.apk`, you can use it for convenience.

If you run `expo-orbit-cli download https://altay.wtf/stuff/example.apk` twice with the current version, you'll see the CLI returning parent directory path instead of the APK:

```
➜  cli git:(main) ✗ yarn cli download-build https://altay.wtf/stuff/example.apk
'/var/folders/m7/b6d5xtzd7vd0jw4002s1wh_m0000gn/T/expo-orbit-nodejs/downloads-cache/altay.wtf%2Fstuff%2Fexample.apk'
```

and this error in the menubar app:

![287371D5-2D28-4F8F-911D-B5AE3CB7577C_4_5005_c](https://github.com/user-attachments/assets/fad5246a-f429-4004-9503-e9f5b2855a2b)

If you run it with the version that includes changes in this MR, it'll return the cached APK file as expected.

```
➜  cli git:(main) ✗ yarn cli download-build https://altay.wtf/stuff/example.apk
Downloading app (2.3 KB / 1.4 MB)
Downloading app (1.4 MB / 1.4 MB)

Successfully downloaded app
'/var/folders/m7/b6d5xtzd7vd0jw4002s1wh_m0000gn/T/expo-orbit-nodejs/downloads-cache/altay.wtf%2Fstuff%2Fexample.apk/164cf63d-ab22-49a0-a1da-d9c4905abc11.apk'
```

```
➜  cli git:(main) ✗ yarn cli download-build https://altay.wtf/stuff/example.apk
'/var/folders/m7/b6d5xtzd7vd0jw4002s1wh_m0000gn/T/expo-orbit-nodejs/downloads-cache/altay.wtf%2Fstuff%2Fexample.apk/164cf63d-ab22-49a0-a1da-d9c4905abc11.apk'
```

If you run it once, then delete the APK (not the directory) and run again, it'll re-download the APK as expected. 👍 