### PR TITLE
[cli] Add default trusted sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add support for configuring trusted sources for opening URLs via the CLI and menu-bar app. ([#270](https://github.com/expo/orbit/pull/270) by [@altaywtf](https://github.com/altaywtf))
+- Add support for configuring trusted sources for opening URLs via the CLI and menu-bar app. ([#270](https://github.com/expo/orbit/pull/270), [#275](https://github.com/expo/orbit/pull/275) by [@altaywtf](https://github.com/altaywtf))
 
 ### 🐛 Bug fixes
 

--- a/apps/cli/src/commands/TrustedSources.ts
+++ b/apps/cli/src/commands/TrustedSources.ts
@@ -1,15 +1,45 @@
-import { getTrustedSources, setTrustedSources } from '../storage';
+import picomatch from 'picomatch';
 
-export const getTrustedSourcesAsync = async () => {
-  return getTrustedSources();
+import { getCustomTrustedSources, setCustomTrustedSources } from '../storage';
+import { InternalError } from 'common-types';
+
+const DEFAULT_TRUSTED_SOURCES = [
+  'https://expo.dev/**',
+  'https://staging.expo.dev/**',
+  'https://expo.test/**',
+];
+export const getTrustedSources = () => {
+  return [DEFAULT_TRUSTED_SOURCES, ...getCustomTrustedSources()];
 };
 
-export const setTrustedSourcesAsync = async (trustedSources: string | undefined) => {
+export const trustedSourcesValidatorMiddleware = (
+  fn: (url: string, ...args: any[]) => any | Promise<any>
+) => {
+  return async function (url: string, ...args: any[]) {
+    const trustedSources = getTrustedSources();
+    if (!trustedSources) {
+      return fn(url, ...args);
+    }
+
+    if (!trustedSources.some((source) => picomatch(source)(url))) {
+      throw new InternalError('UNTRUSTED_SOURCE', `This URL is from an untrusted source: ${url}`);
+    }
+
+    return fn(url, ...args);
+  };
+};
+
+// Commands
+export const getCustomTrustedSourcesAsync = async () => {
+  return getCustomTrustedSources();
+};
+
+export const setCustomTrustedSourcesAsync = async (trustedSources: string | undefined) => {
   const value = trustedSources
     ? trustedSources.split(',').map((source) => source.trim())
     : undefined;
 
-  await setTrustedSources(value);
+  await setCustomTrustedSources(value);
 
   return value;
 };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 
-import { returnLoggerMiddleware, trustedSourcesValidatorMiddleware } from './utils';
+import { returnLoggerMiddleware } from './utils';
 import { downloadBuildAsync } from './commands/DownloadBuild';
 import { listDevicesAsync } from './commands/ListDevices';
 import { bootDeviceAsync } from './commands/BootDevice';
@@ -9,7 +9,11 @@ import { launchExpoGoURLAsync } from './commands/LaunchExpoGo';
 import { checkToolsAsync } from './commands/CheckTools';
 import { setSessionAsync } from './commands/SetSession';
 import { detectIOSAppTypeAsync } from './commands/DetectIOSAppType';
-import { getTrustedSourcesAsync, setTrustedSourcesAsync } from './commands/TrustedSources';
+import {
+  getCustomTrustedSourcesAsync,
+  setCustomTrustedSourcesAsync,
+  trustedSourcesValidatorMiddleware,
+} from './commands/TrustedSources';
 
 const program = new Command();
 
@@ -78,12 +82,14 @@ program
   .argument('<string>', 'Local path of the app')
   .action(returnLoggerMiddleware(detectIOSAppTypeAsync));
 
-program.command('get-trusted-sources').action(returnLoggerMiddleware(getTrustedSourcesAsync));
+program
+  .command('get-custom-trusted-sources')
+  .action(returnLoggerMiddleware(getCustomTrustedSourcesAsync));
 
 program
-  .command('set-trusted-sources')
+  .command('set-custom-trusted-sources')
   .argument('<string>', 'Trusted sources')
-  .action(returnLoggerMiddleware(setTrustedSourcesAsync));
+  .action(returnLoggerMiddleware(setCustomTrustedSourcesAsync));
 
 if (process.argv.length < 3) {
   program.help();

--- a/apps/cli/src/storage.ts
+++ b/apps/cli/src/storage.ts
@@ -11,12 +11,12 @@ export async function setSessionSecret(sessionSecret: string): Promise<void> {
   await userSettingsJsonFile().setAsync('sessionSecret', sessionSecret);
 }
 
-export function getTrustedSources(): string[] | undefined {
+export function getCustomTrustedSources(): string[] {
   const userSettings = userSettingsJsonFile().read();
-  return userSettings.trustedSources;
+  return userSettings.trustedSources || [];
 }
 
-export async function setTrustedSources(trustedSources: string[] | undefined): Promise<void> {
+export async function setCustomTrustedSources(trustedSources: string[] | undefined): Promise<void> {
   await userSettingsJsonFile().setAsync('trustedSources', trustedSources);
 }
 

--- a/apps/cli/src/utils.test.ts
+++ b/apps/cli/src/utils.test.ts
@@ -1,8 +1,8 @@
-import { trustedSourcesValidatorMiddleware } from './utils';
-import { getTrustedSources } from './storage';
+import { trustedSourcesValidatorMiddleware } from './commands/TrustedSources';
+import { getCustomTrustedSources } from './storage';
 
 jest.mock('./storage', () => ({
-  getTrustedSources: jest.fn(() => ['https://expo.io/**']),
+  getTrustedSources: jest.fn(() => ['https://expo.dev/**']),
 }));
 
 describe('trustedSourcesValidatorMiddleware', () => {
@@ -17,27 +17,27 @@ describe('trustedSourcesValidatorMiddleware', () => {
   });
 
   it('should not throw if there are no trusted sources', async () => {
-    (getTrustedSources as jest.Mock).mockReturnValue(undefined);
+    (getCustomTrustedSources as jest.Mock).mockReturnValue(undefined);
     const fn = jest.fn();
-    await trustedSourcesValidatorMiddleware(fn)('https://expo.io/test');
-    expect(fn).toHaveBeenCalledWith('https://expo.io/test');
-    expect(getTrustedSources).toHaveBeenCalled();
+    await trustedSourcesValidatorMiddleware(fn)('https://expo.dev/test');
+    expect(fn).toHaveBeenCalledWith('https://expo.dev/test');
+    expect(getCustomTrustedSources).toHaveBeenCalled();
   });
 
   it('should not throw an error if the URL is from a trusted source', async () => {
     const fn = jest.fn();
-    await trustedSourcesValidatorMiddleware(fn)('https://expo.io/test');
-    expect(fn).toHaveBeenCalledWith('https://expo.io/test');
+    await trustedSourcesValidatorMiddleware(fn)('https://expo.dev/test');
+    expect(fn).toHaveBeenCalledWith('https://expo.dev/test');
   });
 
   it('should throw an error if the URL is from an untrusted source', async () => {
     const fn = jest.fn();
 
     try {
-      await trustedSourcesValidatorMiddleware(fn)('https://expo.io/test');
+      await trustedSourcesValidatorMiddleware(fn)('https://expo.dev/test');
     } catch (error: any) {
       expect(error).toBeInstanceOf(Error);
-      expect(error.message).toBe('This URL is from an untrusted source: https://expo.io/test');
+      expect(error.message).toBe('This URL is from an untrusted source: https://expo.dev/test');
       expect(fn).not.toHaveBeenCalled();
     }
   });

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -2,8 +2,6 @@ import { InternalError } from 'common-types';
 import { Platform } from 'common-types/build/cli-commands';
 import { Env } from 'eas-shared';
 import util from 'util';
-import picomatch from 'picomatch';
-import { getTrustedSources } from './storage';
 
 export function returnLoggerMiddleware(fn: (...args: any[]) => any | Promise<any>) {
   return async function (...args: any[]) {
@@ -60,28 +58,6 @@ export function returnLoggerMiddleware(fn: (...args: any[]) => any | Promise<any
     }
   };
 }
-
-export const trustedSourcesValidatorMiddleware = (fn: (...args: any[]) => any | Promise<any>) => {
-  return async function (...args: any[]) {
-    const urls = args.filter((arg) => typeof arg === 'string' && arg.startsWith('http'));
-    if (!urls) {
-      return fn(...args);
-    }
-
-    const trustedSources = getTrustedSources();
-    if (!trustedSources) {
-      return fn(...args);
-    }
-
-    for (const url of urls) {
-      if (!trustedSources.some((source) => picomatch(source)(url))) {
-        throw new Error(`This URL is from an untrusted source: ${url}`);
-      }
-    }
-
-    return fn(...args);
-  };
-};
 
 export const getPlatformFromURI = (uri: string) => {
   if (uri.endsWith('.apk')) {

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/PopoverManager.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/PopoverManager.swift
@@ -101,7 +101,7 @@ class PopoverManager: NSObject {
     WindowNavigator.shared().openWindow(
       "Settings",
       options: [
-        "windowStyle": ["titlebarAppearsTransparent": true, "height": 580.0, "width": 500.0]
+        "windowStyle": ["titlebarAppearsTransparent": true, "height": 660.0, "width": 500.0]
       ])
   }
 

--- a/apps/menu-bar/src/commands/getTrustesSourcesAsync.ts
+++ b/apps/menu-bar/src/commands/getTrustesSourcesAsync.ts
@@ -1,7 +1,7 @@
 import MenuBarModule from '../modules/MenuBarModule';
 
 export const getTrustedSourcesAsync = async () => {
-  const trustedSources = await MenuBarModule.runCli('get-trusted-sources', [], console.log);
+  const trustedSources = await MenuBarModule.runCli('get-custom-trusted-sources', [], console.log);
 
   if (typeof trustedSources === 'string') {
     try {

--- a/apps/menu-bar/src/commands/setTrustedSourcesAsync.ts
+++ b/apps/menu-bar/src/commands/setTrustedSourcesAsync.ts
@@ -1,5 +1,5 @@
 import MenuBarModule from '../modules/MenuBarModule';
 
 export const setTrustedSourcesAsync = async (trustedSources: string) => {
-  await MenuBarModule.runCli('set-trusted-sources', [trustedSources], console.log);
+  await MenuBarModule.runCli('set-custom-trusted-sources', [trustedSources], console.log);
 };

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -44,6 +44,7 @@ import {
   handleAuthUrl,
   identifyAndParseDeeplinkURL,
 } from '../utils/parseUrl';
+import { WindowsNavigator } from '../windows';
 
 type Props = {
   isDevWindow: boolean;
@@ -383,6 +384,16 @@ function Core(props: Props) {
           );
 
           await installAppFromURI(apps[selectedAppNameIndex].path);
+        }
+        if (error instanceof InternalError && error.code === 'UNTRUSTED_SOURCE') {
+          Alert.alert(
+            'Untrusted source',
+            `${error.message}\n\nYou add custom trusted sources through the Settings window.`,
+            [
+              { text: 'OK', style: 'default' },
+              { text: 'Open Settings', onPress: () => WindowsNavigator.open('Settings') },
+            ]
+          );
         } else if (error instanceof Error) {
           if (__DEV__) {
             console.log('Something went wrong while installing the app.', error.message);

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -341,7 +341,7 @@ const Settings = () => {
                   setTrustedSourcesAsync(trustedSources);
                 }}
                 value={trustedSources}
-                placeholder="Enter trusted sources, separated by commas (e.g. https://expo.io/**)"
+                placeholder="Enter trusted sources, separated by commas (e.g. https://expo.dev/**)"
               />
             </View>
           </View>

--- a/apps/menu-bar/src/windows/index.ts
+++ b/apps/menu-bar/src/windows/index.ts
@@ -11,7 +11,7 @@ export const WindowsNavigator = createWindowsNavigator({
       windowStyle: {
         mask: [WindowStyleMask.Titled, WindowStyleMask.Closable],
         titlebarAppearsTransparent: true,
-        height: 580,
+        height: 660,
         width: 500,
       },
     },

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -33,7 +33,8 @@ export type InternalErrorCode =
   | 'XCODE_NOT_INSTALLED'
   | 'SIMCTL_NOT_AVAILABLE'
   | 'NO_DEVELOPMENT_BUILDS_AVAILABLE'
-  | 'UNAUTHORIZED_ACCOUNT';
+  | 'UNAUTHORIZED_ACCOUNT'
+  | 'UNTRUSTED_SOURCE';
 
 export type MultipleAppsInTarballErrorDetails = {
   apps: {


### PR DESCRIPTION
# Why

For security reasons, Orbit should only allow downloading builds from Expo servers by default; if necessary, users can customise trusted sources through the Settings window 

# How

Make `https://expo.dev/**`, `https://staging.expo.dev/**` and `https://expo.test/**` default trusted sources

# Test Plan

Run menu bar locally on macOS 
