### PR TITLE
[menu-bar] Support deeplinks without leading /

### DIFF
--- a/apps/menu-bar/src/utils/__tests__/parseUrl.test.ts
+++ b/apps/menu-bar/src/utils/__tests__/parseUrl.test.ts
@@ -106,6 +106,28 @@ describe('identifyAndParseDeeplinkURL', () => {
     });
   });
 
+  describe('No leading / URLs', () => {
+    it('Should parse url parameter from /download route', () => {
+      const artifactURL = 'https://expo.dev/artifacts/eas/v3WshxGCF87UzsHSxfRnAh.tar.gz';
+      const artifactDeeplinkURL = `expo-orbit://download/?url=${encodeURIComponent(artifactURL)}`;
+
+      expect(identifyAndParseDeeplinkURL(artifactDeeplinkURL)).toEqual({
+        urlType: URLType.EXPO_BUILD,
+        url: artifactURL,
+      });
+    });
+
+    it('Should parse url parameter from /update route', () => {
+      const updateURL = 'https://u.expo.dev/update/addecbed-f477-4a75-bd88-0732dc928fe9';
+      const updateDeeplinkURL = `expo-orbit://update?url=${encodeURIComponent(updateURL)}`;
+
+      expect(identifyAndParseDeeplinkURL(updateDeeplinkURL)).toEqual({
+        urlType: URLType.EXPO_UPDATE,
+        url: updateURL,
+      });
+    });
+  });
+
   describe('Unsuported URLs', () => {
     it('Should throw an error when the URL route is not supported', () => {
       const unsuportedURL = 'expo-orbit:///some-future-route';

--- a/apps/menu-bar/src/utils/parseUrl.ts
+++ b/apps/menu-bar/src/utils/parseUrl.ts
@@ -37,7 +37,10 @@ export function identifyAndParseDeeplinkURL(deeplinkURLString: string): Deeplink
    */
   const urlWithoutProtocol = deeplinkURLString.replace(/^[^:]+:\/\//, '');
   const deeplinkURL = new URL(
-    Platform.OS === 'web' ? urlWithoutProtocol : deeplinkURLString,
+    Platform.OS === 'web'
+      ? urlWithoutProtocol
+      : // Replace double slash URLs with tripple slash to please the URL parser
+        deeplinkURLString.replace(/^([^:]+:\/\/)(auth|update|download|go|snack)/, '$1/$2'),
     'http://expo.dev'
   );
   // On web the pathname starts with '///' instead of '/'


### PR DESCRIPTION
# Why

Currently it's not possible to post expo orbit links in slack as it doesn't recognise it as a URI. If one does a URI with two slashes instead of 3 it works well however.

Closes #277

# How

By inserting the missing / when it is omitted. 

# Test Plan

I added unit tests for this use case.