### PR TITLE
[menu-bar] Remove deprecated deeplink formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Upgrade `react-native-svg-transformer` to 1.5.1 ([#273](https://github.com/expo/orbit/pull/273) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Improve setup instructions for contributors. ([#271](https://github.com/expo/orbit/pull/271) by [@altaywtf](https://github.com/altaywtf))
 - Use `expo-web-browser` for authentication on macOS. ([#276](https://github.com/expo/orbit/pull/276) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Remove deprecated deeplink formats. ([#280](https://github.com/expo/orbit/pull/280) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.0.4 — 2025-06-02
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/PopoverManager.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/PopoverManager.swift
@@ -101,7 +101,7 @@ class PopoverManager: NSObject {
     WindowNavigator.shared().openWindow(
       "Settings",
       options: [
-        "windowStyle": ["titlebarAppearsTransparent": true, "height": 660.0, "width": 500.0]
+        "windowStyle": ["titlebarAppearsTransparent": true, "height": 680.0, "width": 500.0]
       ])
   }
 

--- a/apps/menu-bar/src/windows/index.ts
+++ b/apps/menu-bar/src/windows/index.ts
@@ -11,7 +11,7 @@ export const WindowsNavigator = createWindowsNavigator({
       windowStyle: {
         mask: [WindowStyleMask.Titled, WindowStyleMask.Closable],
         titlebarAppearsTransparent: true,
-        height: 660,
+        height: 680,
         width: 500,
       },
     },


### PR DESCRIPTION
# Why

We  deprecated some deeplink formats 17 months ago in https://github.com/expo/orbit/pull/151, and it's time to remove them

# How

Remove deprecated deeplink formats

# Test Plan

Run menu bar locally 
