### PR TITLE
Patch react-native-macos to find correct Hermes prebuild

### DIFF
--- a/patches/react-native-macos+0.78.3.patch
+++ b/patches/react-native-macos+0.78.3.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb b/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb
+index 1592a89..5c29959 100644
+--- a/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb
++++ b/node_modules/react-native-macos/sdks/hermes-engine/hermes-utils.rb
+@@ -6,6 +6,7 @@
+ require 'net/http'
+ require 'rexml/document'
+ require 'open3' # [macOS]
++require 'json' # [macOS]
+ 
+ HERMES_GITHUB_URL = "https://github.com/facebook/hermes.git"
+ ENV_BUILD_FROM_SOURCE = "RCT_BUILD_HERMES_FROM_SOURCE"
+@@ -242,22 +243,12 @@ end
+ # [macOS react-native-macos does not publish macos specific hermes artifacts
+ # so we attempt to find the latest patch version of the iOS artifacts and use that
+ def findLastestVersionWithArtifact(version)
+-    versionWithoutPatch = version.match(/^(\d+\.\d+)/)
+-    xml_data, = Open3.capture3("curl -s https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/maven-metadata.xml")
+-
+-    metadata = REXML::Document.new(xml_data)
+-    versions = metadata.elements.to_a('//metadata/versioning/versions/version')
+-
+-    # Extract version numbers and sort them
+-    filtered_versions = versions.select { |version| version.text.match?(/^#{versionWithoutPatch}\.\d+$/) }
+-    if filtered_versions.empty?
+-        return
+-    end
+-
+-    version_numbers = filtered_versions.map { |version| version.text }
+-    sorted_versions = version_numbers.sort_by { |v| Gem::Version.new(v) }
+-
+-    return sorted_versions.last
++    # See https://central.sonatype.org/search/rest-api-guide/ for details on query params
++    versionWithoutPatch = "#{version.match(/^(\d+\.\d+)/)}"
++    res, = Open3.capture3("curl -s https://search.maven.org/solrsearch/select?q=g:com.facebook.react+AND+a:react-native-artifacts+AND+v:#{versionWithoutPatch}.*&core=gav&rows=1&wt=json")
++    wt = JSON.parse(res)
++    response = wt['response']
++    return response['docs'][0]['v'] unless response['numFound'] == 0
+ end
+ # macOS]
+ 


### PR DESCRIPTION
# Why

`react-native-macos` fails to find older versions of Hermes prebuilds because the Maven endpoint it uses does not return all versions. While a new `react-native-macos` version is not released, we need to mually patch this. More context can be found in: https://github.com/microsoft/react-native-macos/issues/2499

# How

Patch `react-native-macos` to find the correct Hermes prebuild based on https://github.com/microsoft/react-native-macos/pull/2505


# Test Plan

Run menu-bar locally on macOS
