### PR TITLE
[menu-bar] Add localhost to local server whitelisted domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Upgrade to `expo` SDK 54 and react-native `0.81`. ([#254](https://github.com/expo/orbit/pull/254) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Optimize code for React 19. ([#307](https://github.com/expo/orbit/pull/307) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Upgrade `react-native-svg` to 15.15.2. ([#308](https://github.com/expo/orbit/pull/308) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add localhost to local server whitelisted domains. ([#317](https://github.com/expo/orbit/pull/317) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.2.0 — 2025-11-11
 

--- a/apps/menu-bar/electron/src/LocalServer.ts
+++ b/apps/menu-bar/electron/src/LocalServer.ts
@@ -2,7 +2,7 @@ import { app as electronApp } from 'electron';
 import express, { Express } from 'express';
 
 const PORTS = [35783, 47909, 44171, 50799];
-const WHITELISTED_DOMAINS = ['expo.dev', 'expo.test', 'exp.host'];
+const WHITELISTED_DOMAINS = ['expo.dev', 'expo.test', 'exp.host', 'localhost'];
 
 export class LocalServer {
   app: Express;
@@ -76,7 +76,10 @@ export class LocalServer {
       }
 
       if (!hostName.includes('.')) {
-        hostName = originUrl.pathname.split('/').filter(Boolean)[1];
+        const pathSegments = originUrl.pathname.split('/').filter(Boolean);
+        if (pathSegments.length > 1) {
+          hostName = pathSegments[1];
+        }
       }
       const components = hostName.split('.');
       return components.slice(-2).join('.');

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
@@ -3,7 +3,7 @@ import Swifter
 import Dispatch
 
 private let PORTS = [35783, 47909, 44171, 50799]
-private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host"]
+private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localhost"]
 
 @objc class SwifterWrapper: NSObject {
   let server = HttpServer()
@@ -98,7 +98,7 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host"]
       }
     }
 
-    if !hostName.contains(".") {
+    if !hostName.contains(".") && originUrl.pathComponents.count > 1 {
       hostName = originUrl.pathComponents[1]
     }
 

--- a/packages/eas-shared/src/run/ios/macOS.ts
+++ b/packages/eas-shared/src/run/ios/macOS.ts
@@ -8,7 +8,8 @@ import path from 'path';
 export async function installOnMacOSAsync(appPath: string): Promise<string> {
   const appName = path.basename(appPath);
   const destination = path.join('/Applications', appName);
-  await fs.copy(appPath, destination, { overwrite: true });
+  await fs.remove(destination);
+  await fs.copy(appPath, destination);
   return destination;
 }
 


### PR DESCRIPTION
# Why

Orbit was crashing when fetching the local server using localhost origin

# How

Add localhost to the local server whitelisted domains and fix the parsing logic 

# Test Plan

Run locally on macOS and Electron 
