### PR TITLE
[menu-bar] Improve launching tarballs with multi apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Use SF Symbols on macOS. ([#325](https://github.com/expo/orbit/pull/325) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Improve launching tarballs with multi apps. ([#324](https://github.com/expo/orbit/pull/324) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -215,7 +215,11 @@ function Core(props: Props) {
           (deviceType === 'device' && device.deviceType === deviceType) ||
           (deviceType !== 'device' && isVirtualDevice(device) && device.state === 'Booted')
         ) {
-          setSelectedDevicesIds((prev) => ({ ...prev, [platform]: getDeviceId(device) }));
+          setSelectedDevicesIds((prev) => {
+            const newValue = { ...prev, [platform]: getDeviceId(device) };
+            saveSelectedDevicesIds(newValue);
+            return newValue;
+          });
           return device as PlatformToDevice<P>;
         }
       }
@@ -494,12 +498,20 @@ function Core(props: Props) {
           const selectedAppNameIndex = await MenuBarModule.showMultiOptionAlert(
             'Multiple apps where detected in the tarball',
             'Select which app to run:',
-            apps.map((app) => app.name)
+            apps.map((app) => {
+              let label = app.name;
+              if (app.osType) {
+                label += ` - ${app.osType}`;
+              }
+              if (app.deviceType) {
+                label += ` (${app.deviceType})`;
+              }
+              return label;
+            })
           );
 
           await installAppFromURI(apps[selectedAppNameIndex].path);
-        }
-        if (error instanceof InternalError && error.code === 'UNTRUSTED_SOURCE') {
+        } else if (error instanceof InternalError && error.code === 'UNTRUSTED_SOURCE') {
           Alert.alert(
             'Untrusted source',
             `${error.message}\n\nYou add custom trusted sources through the Settings window.`,

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -41,5 +41,7 @@ export type MultipleAppsInTarballErrorDetails = {
   apps: {
     name: string;
     path: string;
+    osType?: string;
+    deviceType?: 'simulator' | 'device';
   }[];
 };

--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -14,6 +14,7 @@ import { formatBytes } from './files';
 import Log from './log';
 import { getTmpDirectory } from './paths';
 import { ProgressHandler, createProgressTracker } from './progress';
+import { detectAppleAppType } from './run/ios/inspectApp';
 
 export enum AppPlatform {
   Android = 'ANDROID',
@@ -211,25 +212,92 @@ async function getAppPathAsync(outputDir: string): Promise<string> {
     throw Error('Did not find any installable apps inside tarball.');
   }
 
-  if (appFilePaths.length === 1) {
-    return path.join(outputDir, appFilePaths[0]);
+  // Filter out .app bundles nested inside other .app bundles when they have
+  // the same size as a standalone copy (e.g. watchOS apps embedded in iOS apps).
+  const filteredAppFilePaths = await filterNestedDuplicateAppsAsync(appFilePaths, outputDir);
+
+  if (filteredAppFilePaths.length === 1) {
+    return path.join(outputDir, filteredAppFilePaths[0]);
   }
 
   Log.newLine();
   Log.log('Detected multiple apps in the tarball:');
   Log.newLine();
 
-  const details: MultipleAppsInTarballErrorDetails = {
-    apps: appFilePaths.map((filePath) => ({
-      name: filePath,
-      path: path.join(outputDir, filePath),
-    })),
-  };
+  const apps = await Promise.all(
+    filteredAppFilePaths.map(async (filePath) => {
+      const fullPath = path.join(outputDir, filePath);
+      const platformInfo =
+        filePath.endsWith('.apk') || filePath.endsWith('.aab')
+          ? { osType: 'android' }
+          : await detectAppleAppType(fullPath);
+
+      return {
+        name: path.basename(filePath),
+        path: fullPath,
+        ...platformInfo,
+      };
+    })
+  );
+
+  const details: MultipleAppsInTarballErrorDetails = { apps };
   throw new InternalError(
     'MULTIPLE_APPS_IN_TARBALL',
     'Multiple apps detected in the tarball.',
     details
   );
+}
+
+async function getAppDirectorySizeAsync(appPath: string): Promise<number> {
+  const stat = await fs.promises.stat(appPath);
+  if (!stat.isDirectory()) {
+    return stat.size;
+  }
+  const entries = await fs.promises.readdir(appPath, { withFileTypes: true });
+  const sizes = await Promise.all(
+    entries.map((entry) => getAppDirectorySizeAsync(path.join(appPath, entry.name)))
+  );
+  return sizes.reduce((total, size) => total + size, 0);
+}
+
+async function filterNestedDuplicateAppsAsync(
+  appFilePaths: string[],
+  outputDir: string
+): Promise<string[]> {
+  const nestedPaths = new Set<string>();
+
+  for (const filePath of appFilePaths) {
+    if (!filePath.endsWith('.app')) {
+      continue;
+    }
+    // Check if this .app is nested inside another .app
+    const isNested = filePath.replace(/\/[^/]+$/, '').includes('.app/');
+    if (!isNested) {
+      continue;
+    }
+
+    const baseName = path.basename(filePath);
+    // Find a standalone copy with the same filename
+    const standaloneMatch = appFilePaths.find(
+      (otherPath) =>
+        otherPath !== filePath &&
+        path.basename(otherPath) === baseName &&
+        !appFilePaths.some((p) => p !== otherPath && otherPath.includes(`${p}/`))
+    );
+    if (!standaloneMatch) {
+      continue;
+    }
+
+    const [nestedSize, standaloneSize] = await Promise.all([
+      getAppDirectorySizeAsync(path.join(outputDir, filePath)),
+      getAppDirectorySizeAsync(path.join(outputDir, standaloneMatch)),
+    ]);
+    if (nestedSize === standaloneSize) {
+      nestedPaths.add(filePath);
+    }
+  }
+
+  return appFilePaths.filter((filePath) => !nestedPaths.has(filePath));
 }
 
 export async function tarExtractAsync(input: string, output: string): Promise<void> {


### PR DESCRIPTION
# Why

Launching tarballs with multiple apps will prompt the user to choose which .app they want to launch, but it will still show an error alert after selecting 

<img  height="352" alt="image" src="https://github.com/user-attachments/assets/45ec3451-a891-4744-93fd-42307d5a6200" />


# How

This PR filters out duplicated artifacts and adds the OS type right next to the path so that the user can easily decide which artifact to launch 



# Test Plan

Run menu-bar locally 

<img height="352"  alt="image" src="https://github.com/user-attachments/assets/5301c6a8-4738-4829-9bce-9cad25c4b97d" />
