### PR TITLE
[menu-bar] Add /devices route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Add release automation scripts. ([#327](https://github.com/expo/orbit/pull/327) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Add `/devices` route to local servers. ([#326](https://github.com/expo/orbit/pull/326) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.4.0 — 2026-03-23
 

--- a/apps/menu-bar/electron/src/LocalServer.ts
+++ b/apps/menu-bar/electron/src/LocalServer.ts
@@ -1,5 +1,9 @@
 import { app as electronApp } from 'electron';
 import express, { Express } from 'express';
+import path from 'path';
+
+import { getUserSettingsJsonFile } from '../../modules/menu-bar/electron/main';
+import spawnCliAsync from '../../modules/menu-bar/electron/spawnCliAsync';
 
 const PORTS = [35783, 47909, 44171, 50799];
 const WHITELISTED_DOMAINS = ['expo.dev', 'expo.test', 'exp.host', 'localhost'];
@@ -44,6 +48,21 @@ export class LocalServer {
 
       electronApp.emit('open-url', null, deeplinkURL);
       res.json({ ok: true });
+    });
+
+    this.app.get('/orbit/devices', async (req, res) => {
+      const cliPath = path.join(__dirname, './cli/index.js');
+
+      const userSettingsJsonFile = getUserSettingsJsonFile();
+      const { envVars } = await userSettingsJsonFile.readAsync();
+
+      try {
+        const commandOutput = await spawnCliAsync(cliPath, 'list-devices', [], undefined, envVars);
+
+        res.json(JSON.parse(commandOutput));
+      } catch (error) {
+        res.json({ error: `Failed to run CLI: ${error instanceof Error ? error.message : error}` });
+      }
     });
   }
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
@@ -28,6 +28,47 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localho
       return self.okJsonResponseWithCorsHeaders(json: ["ok": true, "version": version], request: request)
     }
 
+    server.GET["/orbit/devices"] = { request in
+      let task = Process()
+      let pipe = Pipe()
+
+      task.executableURL = Bundle.main.url(forResource: self.getCliResourceNameForArch(), withExtension: nil)
+      task.arguments = ["list-devices"]
+      task.standardOutput = pipe
+      task.standardError = FileHandle.nullDevice
+
+      var environment = ProcessInfo.processInfo.environment
+      environment["EXPO_MENU_BAR"] = "true"
+      task.environment = environment
+
+      do {
+        try task.run()
+      } catch {
+        return self.okJsonResponseWithCorsHeaders(json: ["error": "Failed to run CLI: \(error.localizedDescription)"], request: request)
+      }
+
+      task.waitUntilExit()
+
+      let data = pipe.fileHandleForReading.readDataToEndOfFile()
+      let output = String(data: data, encoding: .utf8) ?? ""
+
+      // The CLI outputs "---- return output ----" before the JSON payload
+      let marker = "---- return output ----"
+      let jsonString: String
+      if let range = output.range(of: marker) {
+        jsonString = String(output[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+      } else {
+        jsonString = output.trimmingCharacters(in: .whitespacesAndNewlines)
+      }
+
+      guard let jsonData = jsonString.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: jsonData) else {
+        return self.okJsonResponseWithCorsHeaders(json: ["error": "Failed to parse device list"], request: request)
+      }
+
+      return self.okJsonResponseWithCorsHeaders(json: json, request: request)
+    }
+
     server.GET["/orbit/open"] = { request in
       guard let (_, urlParam) = request.queryParams.first(where: { $0.0 == "url" }),
             let decodedURLParam = urlParam.removingPercentEncoding else {
@@ -104,6 +145,17 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localho
     } else {
       return hostName
     }
+  }
+
+  private func getCliResourceNameForArch() -> String {
+    var sysinfo = utsname()
+    uname(&sysinfo)
+    let machine = withUnsafePointer(to: &sysinfo.machine) {
+      $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+        String(validatingUTF8: $0) ?? "unknown"
+      }
+    }
+    return machine == "arm64" ? "orbit-cli-arm64" : "orbit-cli-x64"
   }
 
   func okJsonResponseWithCorsHeaders(json: Any, request: HttpRequest) -> HttpResponse {

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/SwifterWrapper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Swifter
 import Dispatch
+import MenuBar
 
 private let PORTS = [35783, 47909, 44171, 50799]
 private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localhost"]
@@ -32,7 +33,7 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localho
       let task = Process()
       let pipe = Pipe()
 
-      task.executableURL = Bundle.main.url(forResource: self.getCliResourceNameForArch(), withExtension: nil)
+      task.executableURL = Bundle.main.url(forResource: getCliResourceNameForArch(), withExtension: nil)
       task.arguments = ["list-devices"]
       task.standardOutput = pipe
       task.standardError = FileHandle.nullDevice
@@ -51,17 +52,14 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localho
 
       let data = pipe.fileHandleForReading.readDataToEndOfFile()
       let output = String(data: data, encoding: .utf8) ?? ""
+      let result = parseCliOutput(output)
 
-      // The CLI outputs "---- return output ----" before the JSON payload
-      let marker = "---- return output ----"
-      let jsonString: String
-      if let range = output.range(of: marker) {
-        jsonString = String(output[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
-      } else {
-        jsonString = output.trimmingCharacters(in: .whitespacesAndNewlines)
+      if let error = result.error {
+        return self.okJsonResponseWithCorsHeaders(json: ["error": error], request: request)
       }
 
-      guard let jsonData = jsonString.data(using: .utf8),
+      guard let jsonString = result.returnOutput,
+            let jsonData = jsonString.data(using: .utf8),
             let json = try? JSONSerialization.jsonObject(with: jsonData) else {
         return self.okJsonResponseWithCorsHeaders(json: ["error": "Failed to parse device list"], request: request)
       }
@@ -145,17 +143,6 @@ private let WHITELISTED_DOMAINS = ["expo.dev", "expo.test", "exp.host", "localho
     } else {
       return hostName
     }
-  }
-
-  private func getCliResourceNameForArch() -> String {
-    var sysinfo = utsname()
-    uname(&sysinfo)
-    let machine = withUnsafePointer(to: &sysinfo.machine) {
-      $0.withMemoryRebound(to: CChar.self, capacity: 1) {
-        String(validatingUTF8: $0) ?? "unknown"
-      }
-    }
-    return machine == "arm64" ? "orbit-cli-arm64" : "orbit-cli-x64"
   }
 
   func okJsonResponseWithCorsHeaders(json: Any, request: HttpRequest) -> HttpResponse {

--- a/apps/menu-bar/modules/menu-bar/electron/main.ts
+++ b/apps/menu-bar/modules/menu-bar/electron/main.ts
@@ -7,7 +7,7 @@ import path from 'path';
 import spawnCliAsync from './spawnCliAsync';
 import { ElectronMainMenuBarModule } from '../src/types';
 
-function getUserSettingsJsonFile() {
+export function getUserSettingsJsonFile() {
   return new JsonFile<StorageUtils.UserSettingsData>(StorageUtils.userSettingsFile(os.homedir()), {
     jsonParseErrorDefault: {},
     cantReadFileDefault: {},

--- a/apps/menu-bar/modules/menu-bar/ios/CLIOutputParser.swift
+++ b/apps/menu-bar/modules/menu-bar/ios/CLIOutputParser.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+private let returnOutputMarker = "---- return output ----"
+private let thrownErrorMarker = "---- thrown error ----"
+
+public struct CLIOutputResult {
+  public let returnOutput: String?
+  public let error: String?
+  public let fullOutput: String
+}
+
+public func isCliOutputMarker(_ line: String) -> Bool {
+  return line == returnOutputMarker || line == thrownErrorMarker
+}
+
+public func parseCliOutput(_ output: String) -> CLIOutputResult {
+  let lines = output.components(separatedBy: .newlines).filter { !$0.isEmpty }
+
+  var fullOutput = ""
+  var returnOutput = ""
+  var hasReachedReturnOutput = false
+  var hasReachedError = false
+
+  for line in lines {
+    fullOutput.append(line)
+
+    if hasReachedReturnOutput || hasReachedError {
+      returnOutput.append(line)
+    } else if line == returnOutputMarker {
+      hasReachedReturnOutput = true
+    } else if line == thrownErrorMarker {
+      hasReachedError = true
+    }
+  }
+
+  if hasReachedError {
+    return CLIOutputResult(returnOutput: nil, error: returnOutput, fullOutput: fullOutput)
+  }
+
+  return CLIOutputResult(
+    returnOutput: hasReachedReturnOutput ? returnOutput : nil,
+    error: nil,
+    fullOutput: fullOutput
+  )
+}
+
+public func getCliResourceNameForArch() -> String {
+  var sysinfo = utsname()
+  uname(&sysinfo)
+  let machine = withUnsafePointer(to: &sysinfo.machine) {
+    $0.withMemoryRebound(to: CChar.self, capacity: Int(_SYS_NAMELEN)) {
+      ptr in String(cString: ptr)
+    }
+  }
+  return machine == "arm64" ? "orbit-cli-arm64" : "orbit-cli-x64"
+}

--- a/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
+++ b/apps/menu-bar/modules/menu-bar/ios/MenuBarModule.swift
@@ -85,10 +85,10 @@ public class MenuBarModule: Module {
       
       task.executableURL = Bundle.main.url(forResource: getCliResourceNameForArch(), withExtension: nil)
       task.arguments = [command] + arguments
-      
+
       var environment = ProcessInfo.processInfo.environment
       environment["EXPO_MENU_BAR"] = "true"
-      
+
       if let envVars = UserDefaults.standard.object(forKey: "envVars") as? Dictionary<String, String> {
         if envVars.count > 0 {
           environment = environment.merging(envVars) { _, new in
@@ -96,61 +96,53 @@ public class MenuBarModule: Module {
           }
         }
       }
-      
+
       task.environment = environment
       task.standardOutput = pipe
       task.standardError = pipe
-      
+
       let file = pipe.fileHandleForReading
-      var fullOutput = ""
-      var returnOutput = ""
-      var hasReachedReturnOutput = false
-      var hasReachedError = false
-      
+      var accumulatedOutput = ""
+
       file.readabilityHandler = { [weak self] handle in
         guard let self else {
           return
         }
-        
+
         let availableData = handle.availableData
         let wholeOutput = String(data: availableData, encoding: .utf8)
         guard let outputs = wholeOutput?.components(separatedBy: .newlines) else {
           return
         }
-        
+
         for output in outputs {
           if output.isEmpty {
             continue
           }
-          fullOutput.append(output)
+          accumulatedOutput.append(output + "\n")
 
-          if hasReachedReturnOutput || hasReachedError {
-            returnOutput.append(output)
-          } else if output == "---- return output ----" {
-            hasReachedReturnOutput = true
-          } else if output == "---- thrown error ----" {
-            hasReachedError = true
-          } else if hasListeners && !output.isEmpty && output != "\n" {
+          if hasListeners && !output.isEmpty && output != "\n"
+              && !isCliOutputMarker(output) {
             let eventData = ["listenerId": listenerId, "output": output]
             sendEvent(onCLIOutput, eventData)
           }
         }
       }
-      
+
       task.terminationHandler = { task in
         file.readabilityHandler = nil
-        
-        if hasReachedError {
-          promise.reject(CLIOutputError(returnOutput))
+
+        let result = parseCliOutput(accumulatedOutput)
+
+        if let error = result.error {
+          promise.reject(CLIOutputError(error))
+        } else if task.terminationStatus == 0 {
+          promise.resolve(result.returnOutput)
         } else {
-          if task.terminationStatus == 0 {
-            promise.resolve(hasReachedReturnOutput ? returnOutput : nil)
-          } else {
-            promise.reject(IntenalCLIError(fullOutput))
-          }
+          promise.reject(IntenalCLIError(result.fullOutput))
         }
       }
-      
+
       try task.run()
     }
     
@@ -209,24 +201,4 @@ public class MenuBarModule: Module {
     }
   }
   
-  private func getHardwareArch() -> String? {
-    var sysinfo = utsname()
-    let result = uname(&sysinfo)
-    
-    if result != 0 {
-      return nil
-    }
-    
-    let machine = withUnsafePointer(to: &sysinfo.machine) {
-      $0.withMemoryRebound(to: CChar.self, capacity: Int(_SYS_NAMELEN)) {
-        ptr in String(cString: ptr)
-      }
-    }
-    
-    return machine
-  }
-  
-  private func getCliResourceNameForArch() -> String {
-    return getHardwareArch() == "arm64" ? "orbit-cli-arm64" : "orbit-cli-x64"
-  }
 }


### PR DESCRIPTION
# Why

Expose the list of available devices through the local HTTP server so that Expo Agent can query them via `GET /orbit/devices`.

# How

- Extracted CLI output parsing logic into a shared `CLIOutputParser` file  
- Added a `GET /orbit/devices` route to  Local Servers (Electron) 


# Test Plan
 
`curl -H "Origin: https://expo.dev" http://localhost:35783/orbit/devices` should return a JSON object with the available devices grouped by platform. 
