### PR TITLE
[menu-bar][electron] Fix OAauth with 3rd party provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix OAauth with 3rd party providers on Windows and Linux. ([#335](https://github.com/expo/orbit/pull/335) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 - Use EAS custom builds for macOS releases. ([#330](https://github.com/expo/orbit/pull/330) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/modules/web-authentication-session/electron/main.ts
+++ b/apps/menu-bar/modules/web-authentication-session/electron/main.ts
@@ -7,7 +7,6 @@ import {
 } from '../src/WebAuthenticationSession.types';
 
 async function openAuthSessionAsync(urlString: string): Promise<WebBrowserResult> {
-  const url = new URL(urlString);
   const window = new BrowserWindow({
     width: 860,
     height: 740,
@@ -16,26 +15,48 @@ async function openAuthSessionAsync(urlString: string): Promise<WebBrowserResult
   window.loadURL(urlString);
 
   return new Promise((resolve, reject) => {
+    let resolved = false;
+
+    function completeWithSuccess(resultUrl: string) {
+      if (resolved) return;
+      resolved = true;
+      window.close();
+      resolve({ type: WebBrowserResultType.SUCCESS, url: resultUrl });
+    }
+
     function handleRedirect(
       event: Electron.Event<
         Electron.WebContentsWillRedirectEventParams | Electron.WebContentsWillNavigateEventParams
       >
     ) {
-      if (event.isSameDocument || url.origin === new URL(event.url).origin) {
+      if (event.isSameDocument) {
+        return;
+      }
+
+      const redirectProtocol = new URL(event.url).protocol;
+      if (redirectProtocol === 'https:' || redirectProtocol === 'http:') {
         return;
       }
 
       event.preventDefault();
-      window.close();
-
-      resolve({ type: WebBrowserResultType.SUCCESS, url: event.url });
+      completeWithSuccess(event.url);
     }
 
     window.webContents.on('will-redirect', handleRedirect);
     window.webContents.on('will-navigate', handleRedirect);
 
+    // Allow OAuth provider popups (e.g. Google sign-in) and monitor them for redirects
+    window.webContents.setWindowOpenHandler(() => ({ action: 'allow' }));
+    window.webContents.on('did-create-window', (childWindow) => {
+      childWindow.webContents.on('will-redirect', handleRedirect);
+      childWindow.webContents.on('will-navigate', handleRedirect);
+    });
+
     window.on('closed', () => {
-      resolve({ type: WebBrowserResultType.CANCEL });
+      if (!resolved) {
+        resolved = true;
+        resolve({ type: WebBrowserResultType.CANCEL });
+      }
     });
 
     window.webContents.on('render-process-gone', (event, details) => {


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/333

Currently, the login auth callback intercepts any cross-origin navigation. This worked for email/password login (where the only cross-origin redirect is the final `expo-orbit:///auth` callback), but broke OAuth providers like Google

# How

- Added `setWindowOpenHandler` to permit child windows from the auth page, and attached redirect handlers to them via `did-create-window`.
- Fixed callback detection: Replaced the origin-comparison check with a protocol-based check 

# Test Plan

Run electron menu-bar locally 
