### PR TITLE
[menu-bar] Use primaryAccountProfileImageUrl in CurrentUser fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Display user avatars uploaded on expo.dev. ([#336](https://github.com/expo/orbit/pull/336) by [@tomek-agent](https://github.com/tomek-agent))
+
 ### 🐛 Bug fixes
 
 - Fix OAauth with 3rd party providers on Windows and Linux. ([#335](https://github.com/expo/orbit/pull/335) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/menu-bar/src/components/Avatar.tsx
+++ b/apps/menu-bar/src/components/Avatar.tsx
@@ -6,16 +6,14 @@ import { View } from './View';
 import { scale } from '../utils/theme';
 
 type Props = {
-  name?: string;
-  profilePhoto?: string;
+  profileImageUrl?: string | null;
   size?: React.ComponentProps<typeof Image>['size'];
 };
 
-export function Avatar({ profilePhoto, size = 'large', name = '' }: Props) {
-  const firstLetter = name?.charAt(0).toLowerCase();
+export function Avatar({ profileImageUrl, size = 'large' }: Props) {
   const viewSize = getViewSize(size);
 
-  if (!profilePhoto || !firstLetter) {
+  if (!profileImageUrl) {
     return (
       <View
         style={{ height: viewSize, width: viewSize }}
@@ -27,20 +25,12 @@ export function Avatar({ profilePhoto, size = 'large', name = '' }: Props) {
     );
   }
 
-  let _profilePhoto = profilePhoto;
-  if (profilePhoto.match('gravatar.com')) {
-    const defaultProfilePhoto = encodeURIComponent(
-      `https://storage.googleapis.com/expo-website-default-avatars-2023/${firstLetter}.png`
-    );
-    _profilePhoto = `${profilePhoto}&d=${defaultProfilePhoto}`;
-  }
-
   return (
     <View rounded="full" bg="secondary">
       <Image
         rounded="full"
         source={{
-          uri: _profilePhoto,
+          uri: profileImageUrl,
         }}
         size={size}
       />

--- a/apps/menu-bar/src/generated/graphql.tsx
+++ b/apps/menu-bar/src/generated/graphql.tsx
@@ -10721,16 +10721,16 @@ export type GetAppsForPinnedListQueryVariables = Exact<{ [key: string]: never; }
 
 export type GetAppsForPinnedListQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, pinnedApps: Array<{ __typename?: 'App', id: string, name: string, slug: string, latestActivity: any, profileImageUrl?: string | null, icon?: { __typename?: 'AppIcon', url: string, primaryColor?: string | null } | null, ownerAccount: { __typename?: 'Account', name: string } }>, accounts: Array<{ __typename?: 'Account', id: string, appsPaginated: { __typename?: 'AccountAppsConnection', edges: Array<{ __typename?: 'AccountAppsEdge', cursor: string, node: { __typename?: 'App', id: string, name: string, slug: string, latestActivity: any, profileImageUrl?: string | null, icon?: { __typename?: 'AppIcon', url: string, primaryColor?: string | null } | null, ownerAccount: { __typename?: 'Account', name: string } } }> } }> } | { __typename?: 'User', id: string, pinnedApps: Array<{ __typename?: 'App', id: string, name: string, slug: string, latestActivity: any, profileImageUrl?: string | null, icon?: { __typename?: 'AppIcon', url: string, primaryColor?: string | null } | null, ownerAccount: { __typename?: 'Account', name: string } }>, accounts: Array<{ __typename?: 'Account', id: string, appsPaginated: { __typename?: 'AccountAppsConnection', edges: Array<{ __typename?: 'AccountAppsEdge', cursor: string, node: { __typename?: 'App', id: string, name: string, slug: string, latestActivity: any, profileImageUrl?: string | null, icon?: { __typename?: 'AppIcon', url: string, primaryColor?: string | null } | null, ownerAccount: { __typename?: 'Account', name: string } } }> } }> } | null };
 
-type CurrentUserData_SsoUser_Fragment = { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, profilePhoto: string };
+type CurrentUserData_SsoUser_Fragment = { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, primaryAccountProfileImageUrl?: string | null };
 
-type CurrentUserData_User_Fragment = { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, profilePhoto: string };
+type CurrentUserData_User_Fragment = { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, primaryAccountProfileImageUrl?: string | null };
 
 export type CurrentUserDataFragment = CurrentUserData_SsoUser_Fragment | CurrentUserData_User_Fragment;
 
 export type GetCurrentUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetCurrentUserQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, profilePhoto: string } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, profilePhoto: string } | null };
+export type GetCurrentUserQuery = { __typename?: 'RootQuery', meUserActor?: { __typename?: 'SSOUser', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, primaryAccountProfileImageUrl?: string | null } | { __typename?: 'User', id: string, username: string, firstName?: string | null, lastName?: string | null, bestContactEmail?: string | null, primaryAccountProfileImageUrl?: string | null } | null };
 
 export const AppForPinnedListFragmentDoc = gql`
     fragment AppForPinnedList on App {
@@ -10755,7 +10755,7 @@ export const CurrentUserDataFragmentDoc = gql`
   firstName
   lastName
   bestContactEmail
-  profilePhoto
+  primaryAccountProfileImageUrl
 }
     `;
 export const GetAppsForPinnedListDocument = gql`

--- a/apps/menu-bar/src/graphql/user.gql
+++ b/apps/menu-bar/src/graphql/user.gql
@@ -4,7 +4,7 @@ fragment CurrentUserData on UserActor {
   firstName
   lastName
   bestContactEmail
-  profilePhoto
+  primaryAccountProfileImageUrl
 }
 
 query GetCurrentUser {

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -224,10 +224,7 @@ const Settings = () => {
                 <Row align="center" mt="1" gap="2" flex="1">
                   {currentUser ? (
                     <Row align="center" flex="1">
-                      <Avatar
-                        name={getCurrentUserDisplayName(currentUser)}
-                        profilePhoto={currentUser.profilePhoto}
-                      />
+                      <Avatar profileImageUrl={currentUser.primaryAccountProfileImageUrl} />
                       <View mx="2" flex="1">
                         <Text weight="medium" numberOfLines={1}>
                           {getCurrentUserDisplayName(currentUser)}


### PR DESCRIPTION
# Why

The `CurrentUserData` fragment fetched `UserActor.profilePhoto`, which is the gravatar-based field. We want the avatar in the menu bar to prefer the user's uploaded account profile image when one is set.

# How

- Switched the fragment from `profilePhoto` to `primaryAccountProfileImageUrl`.
- Renamed the `Avatar` prop from `profilePhoto` to `profileImageUrl` and accept `string | null` since the new field is nullable.
- Removed the client-side gravatar default-image fallback in `Avatar.tsx`. The www resolver for `primaryAccountProfileImageUrl` already returns a gravatar URL with `d=<default-image>` baked in via `getUserAvatarUrl`, so the client copy was redundant. The unused `name` prop is dropped along with it.
- Regenerated only the affected types in `generated/graphql.tsx`.

# Test Plan

`yarn typecheck`, `yarn lint`, and `yarn test` in `apps/menu-bar`.