### PR TITLE
[menu-bar] Add deviceId support to deep-link routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Display user avatars uploaded on expo.dev. ([#336](https://github.com/expo/orbit/pull/336) by [@tomek-agent](https://github.com/tomek-agent))
+- Add deviceId support to deep-link routes. ([#337](https://github.com/expo/orbit/pull/337) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -132,6 +132,41 @@ function Core(props: Props) {
       ? heightOfAllDevices
       : estimatedAvailableSizeForDevices;
 
+  const persistSelectedDevice = useCallback((device: Device) => {
+    const platform = getDeviceOS(device);
+    setSelectedDevicesIds((prev) => {
+      const newValue = { ...prev, [platform]: getDeviceId(device) };
+      saveSelectedDevicesIds(newValue);
+      return newValue;
+    });
+  }, []);
+
+  const findDeviceById = useCallback(
+    (deviceId: string): Device | undefined => {
+      for (const { devices } of Object.values(devicesPerPlatform)) {
+        const device = devices.get(deviceId);
+        if (device) return device;
+      }
+      return undefined;
+    },
+    [devicesPerPlatform]
+  );
+
+  const warnDeviceIdNotFound = useCallback(
+    (deviceId: string) => {
+      createTask({
+        id: 'device-not-found',
+        status: MenuBarStatus.WARNING,
+        progress: 0,
+        message: `Device "${deviceId}" not found. Auto-selecting another device.`,
+      });
+      setTimeout(() => {
+        deleteTask('device-not-found');
+      }, 8000);
+    },
+    [createTask, deleteTask]
+  );
+
   const getAvailableDeviceForExpoGo = useCallback(() => {
     const selectedIosDevice = devicesPerPlatform.ios.devices.get(selectedDevicesIds.ios ?? '');
     const selectedAndroidDevice = devicesPerPlatform.android.devices.get(
@@ -238,8 +273,21 @@ function Core(props: Props) {
   );
 
   const handleExpoGoUrl = useCallback(
-    async (url: string, sdkVersion?: string | null) => {
-      const device = getAvailableDeviceForExpoGo();
+    async (url: string, sdkVersion?: string | null, deviceId?: string) => {
+      let device: PlatformToDevice<'ios' | 'android'> | undefined;
+      if (deviceId) {
+        const requested = findDeviceById(deviceId);
+        const requestedPlatform = requested ? getDeviceOS(requested) : undefined;
+        if (requested && (requestedPlatform === 'ios' || requestedPlatform === 'android')) {
+          device = requested as PlatformToDevice<'ios' | 'android'>;
+          persistSelectedDevice(requested);
+        } else {
+          warnDeviceIdNotFound(deviceId);
+        }
+      }
+      if (!device) {
+        device = getAvailableDeviceForExpoGo();
+      }
       if (!device) {
         return;
       }
@@ -269,11 +317,20 @@ function Core(props: Props) {
         }, 2000);
       }
     },
-    [ensureDeviceIsRunning, getAvailableDeviceForExpoGo, createTask, deleteTask, updateTask]
+    [
+      ensureDeviceIsRunning,
+      getAvailableDeviceForExpoGo,
+      findDeviceById,
+      warnDeviceIdNotFound,
+      persistSelectedDevice,
+      createTask,
+      deleteTask,
+      updateTask,
+    ]
   );
 
   const handleUpdateUrl = useCallback(
-    async (url: string) => {
+    async (url: string, deviceId?: string) => {
       if (!storage.getString(sessionSecretStorageKey)) {
         Alert.alert(
           'You need to be logged in to launch updates.',
@@ -293,7 +350,19 @@ function Core(props: Props) {
         return;
       }
 
-      const device = getDeviceByPlatform(platform);
+      let device: PlatformToDevice<typeof platform> | undefined;
+      if (deviceId) {
+        const requested = findDeviceById(deviceId);
+        if (!requested || getDeviceOS(requested) !== platform) {
+          warnDeviceIdNotFound(deviceId);
+        } else {
+          device = requested as PlatformToDevice<typeof platform>;
+          persistSelectedDevice(requested);
+        }
+      }
+      if (!device) {
+        device = getDeviceByPlatform(platform);
+      }
       if (!device) {
         Alert.alert(
           `You don't have any ${platform} devices available to open this update, please make sure your environment is configured correctly and try again.`
@@ -384,11 +453,20 @@ function Core(props: Props) {
         }, 2000);
       }
     },
-    [ensureDeviceIsRunning, getDeviceByPlatform, createTask, deleteTask, updateTask]
+    [
+      ensureDeviceIsRunning,
+      getDeviceByPlatform,
+      findDeviceById,
+      warnDeviceIdNotFound,
+      persistSelectedDevice,
+      createTask,
+      deleteTask,
+      updateTask,
+    ]
   );
 
   const installAppFromURI = useCallback(
-    async (appURI: string, launchURL?: string) => {
+    async (appURI: string, launchURL?: string, deviceId?: string) => {
       if (tasks.has(appURI)) {
         return;
       }
@@ -448,14 +526,30 @@ function Core(props: Props) {
           }
         }
 
-        const device = getDeviceByPlatform(devicePlatform, appType);
+        let device: PlatformToDevice<typeof devicePlatform> | undefined;
+        if (deviceId) {
+          const requested = findDeviceById(deviceId);
+          if (
+            !requested ||
+            getDeviceOS(requested) !== devicePlatform ||
+            (appType && requested.deviceType !== appType)
+          ) {
+            warnDeviceIdNotFound(deviceId);
+          } else {
+            device = requested as PlatformToDevice<typeof devicePlatform>;
+            persistSelectedDevice(requested);
+          }
+        }
+        if (!device) {
+          device = getDeviceByPlatform(devicePlatform, appType);
+        }
         if (!device) {
           Alert.alert(
             `You don't have any ${devicePlatform} device available to run this build, please make sure your environment is configured correctly and try again.`
           );
           return;
         }
-        const deviceId = getDeviceId(device);
+        const resolvedDeviceId = getDeviceId(device);
 
         if (tasks.get(appURI)) {
           updateTask({ id: appURI, status: MenuBarStatus.BOOTING_DEVICE });
@@ -470,7 +564,11 @@ function Core(props: Props) {
 
         try {
           updateTask({ id: appURI, status: MenuBarStatus.INSTALLING_APP });
-          await installAndLaunchAppAsync({ appPath: localFilePath, deviceId, launchURL });
+          await installAndLaunchAppAsync({
+            appPath: localFilePath,
+            deviceId: resolvedDeviceId,
+            launchURL,
+          });
         } catch (error) {
           if (error instanceof InternalError) {
             if (error.code === 'APPLE_DEVICE_LOCKED') {
@@ -533,7 +631,17 @@ function Core(props: Props) {
         }, 2000);
       }
     },
-    [ensureDeviceIsRunning, getDeviceByPlatform, createTask, deleteTask, updateTask, tasks]
+    [
+      ensureDeviceIsRunning,
+      getDeviceByPlatform,
+      findDeviceById,
+      warnDeviceIdNotFound,
+      persistSelectedDevice,
+      createTask,
+      deleteTask,
+      updateTask,
+      tasks,
+    ]
   );
 
   useFileHandler({ onOpenFile: installAppFromURI });
@@ -552,7 +660,7 @@ function Core(props: Props) {
                 break;
               case URLType.GO:
                 Analytics.track(Event.LAUNCH_EXPO_GO);
-                handleExpoGoUrl(url, deeplinkInfo.sdkVersion);
+                handleExpoGoUrl(url, deeplinkInfo.sdkVersion, deeplinkInfo.deviceId);
                 break;
               case URLType.SNACK:
                 Analytics.track(Event.LAUNCH_SNACK);
@@ -560,11 +668,11 @@ function Core(props: Props) {
                 break;
               case URLType.EXPO_UPDATE:
                 Analytics.track(Event.LAUNCH_EXPO_UPDATE);
-                handleUpdateUrl(url);
+                handleUpdateUrl(url, deeplinkInfo.deviceId);
                 break;
               case URLType.EXPO_BUILD:
                 Analytics.track(Event.LAUNCH_BUILD);
-                installAppFromURI(url, deeplinkInfo.launchURL);
+                installAppFromURI(url, deeplinkInfo.launchURL, deeplinkInfo.deviceId);
                 break;
             }
           } catch (error) {

--- a/apps/menu-bar/src/utils/__tests__/parseUrl.test.ts
+++ b/apps/menu-bar/src/utils/__tests__/parseUrl.test.ts
@@ -48,6 +48,27 @@ describe('identifyAndParseDeeplinkURL', () => {
 
       expect(result.launchURL).toBeUndefined();
     });
+
+    it('Should parse deviceId parameter from /download route', () => {
+      const artifactURL = 'https://expo.dev/artifacts/eas/v3WshxGCF87UzsHSxfRnAh.tar.gz';
+      const deviceId = '00008101-001964A22629003A';
+      const artifactDeeplinkURL = `expo-orbit:///download/?url=${encodeURIComponent(artifactURL)}&deviceId=${encodeURIComponent(deviceId)}`;
+
+      expect(identifyAndParseDeeplinkURL(artifactDeeplinkURL)).toEqual({
+        urlType: URLType.EXPO_BUILD,
+        url: artifactURL,
+        deviceId,
+      });
+    });
+
+    it('Should return undefined deviceId when not provided in /download route', () => {
+      const artifactURL = 'https://expo.dev/artifacts/eas/v3WshxGCF87UzsHSxfRnAh.tar.gz';
+      const artifactDeeplinkURL = `expo-orbit:///download/?url=${encodeURIComponent(artifactURL)}`;
+
+      const result = identifyAndParseDeeplinkURL(artifactDeeplinkURL) as DowndloadDeeplinkURLType;
+
+      expect(result.deviceId).toBeUndefined();
+    });
   });
 
   describe('Update URLs', () => {
@@ -65,6 +86,18 @@ describe('identifyAndParseDeeplinkURL', () => {
       const updateDeeplinkURL = `expo-orbit:///update`;
 
       expect(() => identifyAndParseDeeplinkURL(updateDeeplinkURL)).toThrowError();
+    });
+
+    it('Should parse deviceId parameter from /update route', () => {
+      const updateURL = 'https://u.expo.dev/update/addecbed-f477-4a75-bd88-0732dc928fe9';
+      const deviceId = 'Pixel_5_API_30';
+      const updateDeeplinkURL = `expo-orbit:///update?url=${encodeURIComponent(updateURL)}&deviceId=${encodeURIComponent(deviceId)}`;
+
+      expect(identifyAndParseDeeplinkURL(updateDeeplinkURL)).toEqual({
+        urlType: URLType.EXPO_UPDATE,
+        url: updateURL,
+        deviceId,
+      });
     });
   });
 
@@ -91,6 +124,20 @@ describe('identifyAndParseDeeplinkURL', () => {
         urlType: URLType.GO,
         url,
         sdkVersion,
+      });
+    });
+
+    it('Should parse deviceId parameter from /go route', () => {
+      const deviceId = '00008101-001964A22629003A';
+      const url =
+        'exp://staging-u.expo.dev/2dce2748-c51f-4865-bae0-392af794d60a?runtime-version=exposdk%3A50.0.0&channel-name=production&snack-channel=Hhhqw6NhFw';
+      const deeplinkURL = `expo-orbit:///go?url=${encodeURIComponent(url)}&deviceId=${encodeURIComponent(deviceId)}`;
+
+      expect(identifyAndParseDeeplinkURL(deeplinkURL)).toEqual({
+        urlType: URLType.GO,
+        url,
+        sdkVersion: null,
+        deviceId,
       });
     });
   });

--- a/apps/menu-bar/src/utils/parseUrl.ts
+++ b/apps/menu-bar/src/utils/parseUrl.ts
@@ -16,24 +16,36 @@ export function handleAuthUrl(url: string) {
 
   saveSessionSecret(sessionSecret);
 }
-export type BaseDeeplinkURLType = {
-  urlType: Exclude<URLType, URLType.GO | URLType.EXPO_BUILD>;
+export type AuthDeeplinkURLType = {
+  urlType: URLType.AUTH;
   url: string;
+};
+
+export type BaseDeeplinkURLType = {
+  urlType: Exclude<URLType, URLType.AUTH | URLType.GO | URLType.EXPO_BUILD>;
+  url: string;
+  deviceId?: string;
 };
 
 export type GoDeeplinkURLType = {
   urlType: URLType.GO;
   url: string;
   sdkVersion: string | null;
+  deviceId?: string;
 };
 
 export type DowndloadDeeplinkURLType = {
   urlType: URLType.EXPO_BUILD;
   url: string;
   launchURL?: string;
+  deviceId?: string;
 };
 
-type DeeplinkURLType = BaseDeeplinkURLType | GoDeeplinkURLType | DowndloadDeeplinkURLType;
+type DeeplinkURLType =
+  | AuthDeeplinkURLType
+  | BaseDeeplinkURLType
+  | GoDeeplinkURLType
+  | DowndloadDeeplinkURLType;
 
 export function identifyAndParseDeeplinkURL(deeplinkURLString: string): DeeplinkURLType {
   // Replace double slash URLs with triple slash to support Slack and other deeplink previews
@@ -65,6 +77,7 @@ export function identifyAndParseDeeplinkURL(deeplinkURLString: string): Deeplink
     return {
       urlType: URLType.EXPO_UPDATE,
       url: getUrlFromSearchParams(deeplinkURL.searchParams),
+      deviceId: deeplinkURL.searchParams.get('deviceId') ?? undefined,
     };
   }
   if (pathname.startsWith('/download')) {
@@ -72,6 +85,7 @@ export function identifyAndParseDeeplinkURL(deeplinkURLString: string): Deeplink
       urlType: URLType.EXPO_BUILD,
       url: getUrlFromSearchParams(deeplinkURL.searchParams),
       launchURL: deeplinkURL.searchParams.get('launchURL') ?? undefined,
+      deviceId: deeplinkURL.searchParams.get('deviceId') ?? undefined,
     };
   }
   if (pathname.startsWith('/go')) {
@@ -79,6 +93,7 @@ export function identifyAndParseDeeplinkURL(deeplinkURLString: string): Deeplink
       urlType: URLType.GO,
       url: getUrlFromSearchParams(deeplinkURL.searchParams),
       sdkVersion: deeplinkURL.searchParams.get('sdkVersion'),
+      deviceId: deeplinkURL.searchParams.get('deviceId') ?? undefined,
     };
   }
   // Deprecate in future versions


### PR DESCRIPTION
# Why

To allow Expo Agent to target a specific simulator/emulator/connected device, we need to extend the existing deep-link routes (`/go`, `/download`, `/update`) with an optional `deviceId` query parameter

# How

The CLI underneath already accepts `--device-id`, so this PR just resolves the `deviceId` from the deeplink in the menu-bar and forwards it 

# Test Plan

Happy paths:
- [x] `open "expo-orbit:///go?url=<expo-url>&deviceId=<existing-ios-udid>"` → launches Expo Go on that exact simulator.
- [x] `open "expo-orbit:///download?url=<artifact>&deviceId=<existing-android-emulator-name>"` → installs build on that emulator.
- [x] `open "expo-orbit:///update?url=<update-url-with-platform=ios>&deviceId=<existing-ios-udid>"` → launches update on that device.

Fallback paths:
- [x] Same URLs with `deviceId=does-not-exist` → transient "Device … not found" warning shows in the menu bar, then auto-select kicks in and the action still completes.
- [x] `/update` with a `deviceId` whose OS mismatches the URL's `platform` query → warning + auto-select to the correct platform.
- [x] `/download` with a `deviceId` whose `deviceType` is incompatible with the detected build (e.g. simulator id for a connected-device-only build) → warning + auto-select.

Selection persistence:
- [x] After dispatching a deep link with a valid `deviceId`, open the menu-bar UI and confirm the device is now shown as selected for its platform. A follow-up deep link without a `deviceId` should target the same device.

Backward compat:
- [x] Existing URLs without `deviceId` behave exactly as before (auto-select). The deprecated `/snack` route is unchanged.
