### PR TITLE
[cli][eas-shared][menu-bar] Fix Run Android emulator without audio

### DIFF
--- a/apps/cli/src/commands/BootDevice.ts
+++ b/apps/cli/src/commands/BootDevice.ts
@@ -4,10 +4,10 @@ import { Emulator, Simulator } from 'eas-shared';
 type BootDeviceAsyncOptions = {
   platform: 'android' | 'ios';
   id: string;
-  noAudio?: boolean;
+  audio?: boolean;
 };
 
-export async function bootDeviceAsync({ platform, id, noAudio }: BootDeviceAsyncOptions) {
+export async function bootDeviceAsync({ platform, id, audio }: BootDeviceAsyncOptions) {
   if (platform === 'ios') {
     await Simulator.ensureSimulatorBootedAsync({
       udid: id,
@@ -25,6 +25,6 @@ export async function bootDeviceAsync({ platform, id, noAudio }: BootDeviceAsync
     {
       name: id,
     } as AndroidEmulator,
-    { noAudio }
+    { audio }
   );
 }

--- a/apps/menu-bar/src/commands/bootDeviceAsync.ts
+++ b/apps/menu-bar/src/commands/bootDeviceAsync.ts
@@ -4,10 +4,10 @@ import { DevicePlatform } from '../utils/device';
 type BootDeviceAsyncOptions = {
   platform: DevicePlatform;
   id: string;
-  noAudio?: boolean;
+  audio?: boolean;
 };
 
-export const bootDeviceAsync = async ({ platform, id, noAudio }: BootDeviceAsyncOptions) => {
+export const bootDeviceAsync = async ({ platform, id, audio }: BootDeviceAsyncOptions) => {
   /**
    * Maps a DevicePlatform to the CLI boot-device platform parameter.
    * The CLI only supports 'ios' and 'android' for now — tvOS and watchOS simulators boot via the 'ios' path.
@@ -15,7 +15,7 @@ export const bootDeviceAsync = async ({ platform, id, noAudio }: BootDeviceAsync
   const bootPlatform = platform === 'android' ? 'android' : 'ios';
 
   const args = ['-p', bootPlatform, '--id', id];
-  if (noAudio) {
+  if (!audio) {
     args.push('--no-audio');
   }
   await MenuBarModule.runCli('boot-device', args, console.log);

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -214,7 +214,7 @@ function Core(props: Props) {
       await bootDeviceAsync({
         platform: getDeviceOS(device),
         id: deviceId,
-        noAudio: emulatorWithoutAudio,
+        audio: !emulatorWithoutAudio,
       });
     },
     [emulatorWithoutAudio]
@@ -728,7 +728,7 @@ function Core(props: Props) {
                   onPress={() => onSelectDevice(device)}
                   onPressLaunch={async () => {
                     Analytics.track(Event.LAUNCH_SIMULATOR);
-                    await bootDeviceAsync({ platform, id });
+                    await bootDeviceAsync({ platform, id, audio: !emulatorWithoutAudio });
                     refetch();
                   }}
                   selected={selectedDevicesIds[platform] === id}

--- a/packages/eas-shared/src/run/android/emulator.ts
+++ b/packages/eas-shared/src/run/android/emulator.ts
@@ -77,12 +77,12 @@ export async function bootEmulatorAsync(
   {
     timeout = EMULATOR_MAX_WAIT_TIMEOUT_MS,
     interval = 1000,
-    noAudio = false,
+    audio = true,
   }: {
     /** Time in milliseconds to wait before asserting a timeout error. */
     timeout?: number;
     interval?: number;
-    noAudio?: boolean;
+    audio?: boolean;
   } = {}
 ): Promise<AndroidEmulator> {
   Log.newLine();
@@ -90,7 +90,7 @@ export async function bootEmulatorAsync(
 
   const emulatorExecutable = await getEmulatorExecutableAsync();
   const spawnArgs = [`@${emulator.name}`];
-  if (noAudio) {
+  if (!audio) {
     spawnArgs.push('-no-audio');
   }
 


### PR DESCRIPTION
# Why

Currently, the preference `Run Android emulator without audio` is not taking effect for the following reasons: 

-  The prop `noAudio` ins't being passed to `bootDeviceAsync` in the devices list in [Core.tsx](https://github.com/expo/orbit/blob/682a248b7b5ff59ead0e5a510303826b03c2ff3a/apps/menu-bar/src/popover/Core.tsx#L731) 
- After fix the above error the preference still does not taking effect because call `bootDeviceAsync` with `noAudio:true` add `--no-audio` arg to `boot-device` script and `command` run the action `bootDeviceAsync` [eas-sahred] which expects `noAudio:true` to take effect. This is the problem,  the `commander.js` lib uses `--no` as [negatable boolean](https://github.com/tj/commander.js#other-option-types-negatable-boolean-and-booleanvalue) so insted of `noAudio:true` it passes  `audio:false` and `noAudio` as `undefined` to `bootDeviceAsync`

# How

- Changed the prop name and type from `noAudio` to `audio` to be compatible with the arg `--audio` = `audio:true` | `--no-audio` = `audio:false` and set the default value to `true` to maintain the current default behavior
- Added `audio` to `bootDeviceAsync` call in the device list

# Test Plan

Run electron menu-bar locally with `Run Android emulator without audio` preference `enabled/disabled`
