### PR TITLE
[menu-bar] Fix opening APKs/tar from finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix Run Android emulator without audio option. ([#340](https://github.com/expo/orbit/pull/340) by [@lklima](https://github.com/lklima))
+- Fix opening APKs/tar from finder. ([#341](https://github.com/expo/orbit/pull/341) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.swift
+++ b/apps/menu-bar/macos/ExpoMenuBar-macOS/AppDelegate.swift
@@ -52,13 +52,16 @@ class AppDelegate: ExpoAppDelegate, NSUserNotificationCenterDelegate {
     NSApp.activate(ignoringOtherApps: true)
   }
 
-   func application(_ sender: NSApplication, openFile filename: String) -> Bool {
+  // Need to use this instead of `application(_ sender: NSApplication, openFile filename: String)` because of ExpoAppDelegate
+  override func application(_ application: NSApplication, open urls: [URL]) {
+    super.application(application, open: urls)
     popoverManager?.openPopover()
-    NotificationCenter.default.post(
-      name: Notification.Name("ExpoOrbit_OnOpenFile"),
-      object: filename
-    )
-    return true
+    for url in urls {
+      NotificationCenter.default.post(
+        name: Notification.Name("ExpoOrbit_OnOpenFile"),
+        object: url.path
+      )
+    }
   }
 
   override func applicationWillFinishLaunching(_ notification: Notification) {


### PR DESCRIPTION
# Why

Double-clicking an APK (or IPA / tar.gz) file in Finder is not triggering an app install. The app's existing `application(_:openFile:)` delegate method is being shadowed by `application(_:open:)` on the parent `ExpoAppDelegate`, which AppKit prefers whenever both are implemented. 

Drag-and-drop onto the menu bar icon still works because that path posts the notification directly without going through the app delegate.

# How

Replaced the legacy `application(_:openFile:)` with an override of `application(_:open:)` that fans out each URL into the existing `ExpoOrbit_OnOpenFile` notification pipeline. `super` is invoked first so Expo's subscriber manager still gets a chance at the URLs.

# Test Plan

- Build and run the macOS app.
- Quit Orbit, then double-click an `.apk` in Finder → Orbit launches, popover opens, the APK installs and launches on the running Android emulator.
- With Orbit already running, double-click an `.apk` → popover opens and install proceeds.
- Repeat with an `.ipa` and a `.tar.gz` to confirm the iOS / archive paths are unaffected.
- Drag-and-drop an APK onto the menu bar icon → still works (regression check).

