### PR TITLE
Bump EAS image to macos-tahoe-26.4-xcode-26.4

### DIFF
--- a/apps/menu-bar/eas.json
+++ b/apps/menu-bar/eas.json
@@ -8,7 +8,7 @@
       "config": "build-preview.yml",
       "credentialsSource": "remote",
       "ios": {
-        "image": "macos-sequoia-15.6-xcode-26.2",
+        "image": "macos-tahoe-26.4-xcode-26.4",
         "applicationArchivePath": "build/Release/*.app"
       }
     },
@@ -16,7 +16,7 @@
       "config": "build-release.yml",
       "credentialsSource": "remote",
       "ios": {
-        "image": "macos-sequoia-15.6-xcode-26.2",
+        "image": "macos-tahoe-26.4-xcode-26.4",
         "applicationArchivePath": "build/Release/*.zip"
       }
     }


### PR DESCRIPTION
# Why

This should fix some flakiness we've been seeing with Xcode 26 when building Orbit 

# How

Bump EAS image to macos-tahoe-26.4-xcode-26.4

# Test Plan

N / A
