### PR TITLE
[menu-bar][cli] Add support for physical iPhones on Windows and Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add support for physical iPhones on Windows and Linux. ([#347](https://github.com/expo/orbit/pull/347) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ To talk to the device over USB, Orbit relies on Apple's device service. If it is
 Connect your iPhone, unlock it, and tap **Trust** when prompted. The device then appears under **iOS** in Orbit, ready to install to.
 
 > [!note]
+> On Linux, `usbmuxd` starts automatically when an Apple device is attached and stops shortly after it's unplugged, so you'll only see the device while it's connected. If a connected iPhone still isn't detected (and no Trust prompt appears), make sure the daemon is running with `sudo systemctl start usbmuxd`.
+
+> [!note]
 > On Windows and Linux, Orbit installs the app but cannot launch it automatically (that requires Xcode). After installing, open the app from your iPhone's Home Screen. On macOS the app is launched for you.
 
 ## 👏 Contributing

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ brew install expo-orbit
 > [!note]
 > If you want Orbit to automatically start when you log in, click on the Orbit icon in the menu bar or task bar, then select "Settings" and check the "Launch on Login" option.
 
+## 📱 Installing apps on a physical iPhone
+
+Orbit can install builds onto a physical iPhone connected over USB from macOS, Windows, and Linux. This installs an already-signed build (for example, an internal-distribution or development build from EAS) — **no paid Apple Developer account is required**, and the device just needs to be included in the build's provisioning profile (a free Apple account works).
+
+To talk to the device over USB, Orbit relies on Apple's device service. If it isn't available yet, Orbit detects this and offers to install the required helper software for you:
+
+| Platform | Helper software |
+| --- | --- |
+| macOS | Built in — nothing to install. |
+| Windows | The [Apple Devices app](https://apps.microsoft.com/detail/9np83lwlpz9k) (or iTunes), which installs the Apple USB drivers and the Apple Mobile Device Service. |
+| Linux | The open-source `usbmuxd` daemon (e.g. `sudo apt-get install usbmuxd`). |
+
+Connect your iPhone, unlock it, and tap **Trust** when prompted. The device then appears under **iOS** in Orbit, ready to install to.
+
+> [!note]
+> On Windows and Linux, Orbit installs the app but cannot launch it automatically (that requires Xcode). After installing, open the app from your iPhone's Home Screen. On macOS the app is launched for you.
+
 ## 👏 Contributing
 
 If you like Expo Orbit and want to help make it better then check out our [contributing guide](./CONTRIBUTING.md)!

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To talk to the device over USB, Orbit relies on Apple's device service. If it is
 | Platform | Helper software |
 | --- | --- |
 | macOS | Built in — nothing to install. |
-| Windows | The [Apple Devices app](https://apps.microsoft.com/detail/9np83lwlpz9k) (or iTunes), which installs the Apple USB drivers and the Apple Mobile Device Service. |
+| Windows | Apple Mobile Device Support — the official Apple USB driver and device service. Orbit can install it for you (via `winget`); the [Apple Devices app](https://apps.microsoft.com/detail/9np83lwlpz9k) or iTunes also include it. |
 | Linux | The open-source `usbmuxd` daemon (e.g. `sudo apt-get install usbmuxd`). |
 
 Connect your iPhone, unlock it, and tap **Trust** when prompted. The device then appears under **iOS** in Orbit, ready to install to.

--- a/README.md
+++ b/README.md
@@ -35,26 +35,6 @@ brew install expo-orbit
 > [!note]
 > If you want Orbit to automatically start when you log in, click on the Orbit icon in the menu bar or task bar, then select "Settings" and check the "Launch on Login" option.
 
-## 📱 Installing apps on a physical iPhone
-
-Orbit can install builds onto a physical iPhone connected over USB from macOS, Windows, and Linux. This installs an already-signed build (for example, an internal-distribution or development build from EAS) — **no paid Apple Developer account is required**, and the device just needs to be included in the build's provisioning profile (a free Apple account works).
-
-To talk to the device over USB, Orbit relies on Apple's device service. If it isn't available yet, Orbit detects this and offers to install the required helper software for you:
-
-| Platform | Helper software |
-| --- | --- |
-| macOS | Built in — nothing to install. |
-| Windows | Apple Mobile Device Support — the official Apple USB driver and device service. Orbit can install it for you (via `winget`); the [Apple Devices app](https://apps.microsoft.com/detail/9np83lwlpz9k) or iTunes also include it. |
-| Linux | The open-source `usbmuxd` daemon (e.g. `sudo apt-get install usbmuxd`). |
-
-Connect your iPhone, unlock it, and tap **Trust** when prompted. The device then appears under **iOS** in Orbit, ready to install to.
-
-> [!note]
-> On Linux, `usbmuxd` starts automatically when an Apple device is attached and stops shortly after it's unplugged, so you'll only see the device while it's connected. If a connected iPhone still isn't detected (and no Trust prompt appears), make sure the daemon is running with `sudo systemctl start usbmuxd`.
-
-> [!note]
-> On Windows and Linux, Orbit installs the app but cannot launch it automatically (that requires Xcode). After installing, open the app from your iPhone's Home Screen. On macOS the app is launched for you.
-
 ## 👏 Contributing
 
 If you like Expo Orbit and want to help make it better then check out our [contributing guide](./CONTRIBUTING.md)!

--- a/apps/cli/src/commands/CheckTools.ts
+++ b/apps/cli/src/commands/CheckTools.ts
@@ -1,7 +1,9 @@
 import { InternalError } from 'common-types';
 import { FailureReason, PlatformToolsCheck } from 'common-types/build/cli-commands/checkTools';
 import {
+  AppleDevice,
   validateAndroidSystemRequirementsAsync,
+  validateAppleDeviceRequirementsAsync,
   validateIOSSystemRequirementsAsync,
 } from 'eas-shared';
 import stripAnsi from 'strip-ansi';
@@ -23,6 +25,7 @@ export async function checkToolsAsync({ platform = 'all' }: CheckToolsOptions) {
     new Promise(async (resolve) => {
       if (platform === 'ios' || platform === 'all') {
         result.ios = await checkIosToolsAsync();
+        result.appleDevice = await checkAppleDeviceToolsAsync();
       }
       resolve(null);
     }),
@@ -56,5 +59,17 @@ async function checkIosToolsAsync(): Promise<PlatformToolsCheck['ios']> {
     }
 
     return { reason, success: false };
+  }
+}
+
+async function checkAppleDeviceToolsAsync(): Promise<PlatformToolsCheck['appleDevice']> {
+  try {
+    await validateAppleDeviceRequirementsAsync();
+    return { success: true };
+  } catch (error: any) {
+    const reason: FailureReason = { message: stripAnsi(error.message) };
+    // Surface install guidance so the onboarding can offer a one-click setup.
+    const { description: _description, ...helper } = AppleDevice.getUsbmuxdHelperGuidance();
+    return { reason, helper, success: false };
   }
 }

--- a/apps/cli/src/commands/CheckTools.ts
+++ b/apps/cli/src/commands/CheckTools.ts
@@ -25,7 +25,12 @@ export async function checkToolsAsync({ platform = 'all' }: CheckToolsOptions) {
     new Promise(async (resolve) => {
       if (platform === 'ios' || platform === 'all') {
         result.ios = await checkIosToolsAsync();
-        result.appleDevice = await checkAppleDeviceToolsAsync();
+        // usbmuxd ships with macOS and is the default on Linux (socket-activated,
+        // starts when a device is plugged in). Only Windows needs Apple Mobile
+        // Device Support installed explicitly, so only surface the check there.
+        if (process.platform === 'win32') {
+          result.appleDevice = await checkAppleDeviceToolsAsync();
+        }
       }
       resolve(null);
     }),
@@ -67,9 +72,12 @@ async function checkAppleDeviceToolsAsync(): Promise<PlatformToolsCheck['appleDe
     await validateAppleDeviceRequirementsAsync();
     return { success: true };
   } catch (error: any) {
-    const reason: FailureReason = { message: stripAnsi(error.message) };
-    // Surface install guidance so the onboarding can offer a one-click setup.
     const { description: _description, ...helper } = AppleDevice.getUsbmuxdHelperGuidance();
+    const reason: FailureReason = {
+      message: stripAnsi(error.message),
+      // Surface the install command so the onboarding's "Copy command" affordance works.
+      command: helper.installCommand,
+    };
     return { reason, helper, success: false };
   }
 }

--- a/apps/cli/src/commands/InstallAndLaunchApp.ts
+++ b/apps/cli/src/commands/InstallAndLaunchApp.ts
@@ -35,7 +35,11 @@ export async function installAndLaunchAppAsync(options: InstallAndLaunchAppAsync
 async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string, launchURL?: string) {
   const appInfo = await detectAppleAppType(appPath);
 
-  if (await Simulator.isSimulatorAsync(deviceId)) {
+  // Simulators only exist on macOS, and `isSimulatorAsync` shells out to `simctl`
+  // (macOS only). On Windows/Linux a device id always refers to a physical device.
+  const isSimulator = process.platform === 'darwin' && (await Simulator.isSimulatorAsync(deviceId));
+
+  if (isSimulator) {
     if (appInfo.deviceType === 'device') {
       throw new Error(
         "Apps built to target physical devices can't be installed on simulators. Either use a physical device or generate a new simulator build."

--- a/apps/cli/src/commands/InstallAppleDeviceSupport.ts
+++ b/apps/cli/src/commands/InstallAppleDeviceSupport.ts
@@ -2,13 +2,13 @@ import spawnAsync from '@expo/spawn-async';
 
 /**
  * Best-effort install of the helper software needed to talk to a physical iPhone
- * over USB. None of this requires an Apple account.
+ * over USB.
  *
  * - Linux: installs the open-source `usbmuxd` daemon via the system package
  *   manager, using `pkexec` for the privilege prompt.
  * - Windows: installs the Apple Devices app via winget (it bundles the Apple USB
  *   drivers and the Apple Mobile Device Service).
- * - macOS: no-op — usbmuxd ships with the OS.
+ * - macOS: no-op — natively supported.
  */
 export async function installAppleDeviceSupportAsync(): Promise<void> {
   if (process.platform === 'darwin') {
@@ -31,8 +31,6 @@ export async function installAppleDeviceSupportAsync(): Promise<void> {
     ]);
     return;
   }
-
-  throw new Error(`Installing Apple device support is not supported on ${process.platform}.`);
 }
 
 async function installOnLinuxAsync(): Promise<void> {

--- a/apps/cli/src/commands/InstallAppleDeviceSupport.ts
+++ b/apps/cli/src/commands/InstallAppleDeviceSupport.ts
@@ -6,8 +6,9 @@ import spawnAsync from '@expo/spawn-async';
  *
  * - Linux: installs the open-source `usbmuxd` daemon via the system package
  *   manager, using `pkexec` for the privilege prompt.
- * - Windows: installs the Apple Devices app via winget (it bundles the Apple USB
- *   drivers and the Apple Mobile Device Service).
+ * - Windows: installs Apple Mobile Device Support via winget — the lightweight
+ *   official package with just the Apple USB driver and the Apple Mobile Device
+ *   Service (no full iTunes/Apple Devices app).
  * - macOS: no-op — natively supported.
  */
 export async function installAppleDeviceSupportAsync(): Promise<void> {
@@ -21,15 +22,31 @@ export async function installAppleDeviceSupportAsync(): Promise<void> {
   }
 
   if (process.platform === 'win32') {
+    await installOnWindowsAsync();
+    return;
+  }
+}
+
+async function installOnWindowsAsync(): Promise<void> {
+  try {
     await spawnAsync('winget', [
       'install',
       '--id',
-      'Apple.AppleDevices',
+      'Apple.AppleMobileDeviceSupport',
       '-e',
+      '--silent',
       '--accept-package-agreements',
       '--accept-source-agreements',
     ]);
-    return;
+  } catch (error: any) {
+    // `winget` itself is missing (App Installer not present) — let the caller fall
+    // back to opening the official download page.
+    if (error?.code === 'ENOENT') {
+      throw new Error(
+        'winget is not available on this machine. Install Apple Mobile Device Support (or the Apple Devices app) manually.'
+      );
+    }
+    throw error;
   }
 }
 

--- a/apps/cli/src/commands/InstallAppleDeviceSupport.ts
+++ b/apps/cli/src/commands/InstallAppleDeviceSupport.ts
@@ -1,0 +1,65 @@
+import spawnAsync from '@expo/spawn-async';
+
+/**
+ * Best-effort install of the helper software needed to talk to a physical iPhone
+ * over USB. None of this requires an Apple account.
+ *
+ * - Linux: installs the open-source `usbmuxd` daemon via the system package
+ *   manager, using `pkexec` for the privilege prompt.
+ * - Windows: installs the Apple Devices app via winget (it bundles the Apple USB
+ *   drivers and the Apple Mobile Device Service).
+ * - macOS: no-op — usbmuxd ships with the OS.
+ */
+export async function installAppleDeviceSupportAsync(): Promise<void> {
+  if (process.platform === 'darwin') {
+    return;
+  }
+
+  if (process.platform === 'linux') {
+    await installOnLinuxAsync();
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    await spawnAsync('winget', [
+      'install',
+      '--id',
+      'Apple.AppleDevices',
+      '-e',
+      '--accept-package-agreements',
+      '--accept-source-agreements',
+    ]);
+    return;
+  }
+
+  throw new Error(`Installing Apple device support is not supported on ${process.platform}.`);
+}
+
+async function installOnLinuxAsync(): Promise<void> {
+  // Prefer apt (Debian/Ubuntu), fall back to dnf (Fedora/RHEL).
+  const managers: { bin: string; args: string[] }[] = [
+    { bin: 'apt-get', args: ['install', '-y', 'usbmuxd'] },
+    { bin: 'dnf', args: ['install', '-y', 'usbmuxd'] },
+  ];
+
+  for (const { bin, args } of managers) {
+    if (await commandExistsAsync(bin)) {
+      // `pkexec` shows the graphical privilege prompt, mirroring the auto-updater.
+      await spawnAsync('pkexec', [bin, ...args]);
+      return;
+    }
+  }
+
+  throw new Error(
+    'Could not find a supported package manager (apt-get or dnf). Install the usbmuxd package manually.'
+  );
+}
+
+async function commandExistsAsync(bin: string): Promise<boolean> {
+  try {
+    await spawnAsync('which', [bin]);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/cli/src/commands/ListDevices.ts
+++ b/apps/cli/src/commands/ListDevices.ts
@@ -15,7 +15,7 @@ export async function listDevicesAsync<P extends Platform>({
   };
 
   if (platform === Platform.Ios || platform === Platform.All) {
-    // Physical Apple device discovery is cross-platform (macOS, Windows, Linux).
+    // Physical Apple device discovery is cross-platform
     try {
       const connectedDevices = await AppleDevice.getConnectedDevicesAsync();
       for (const connectedDevice of connectedDevices) {
@@ -43,8 +43,7 @@ export async function listDevicesAsync<P extends Platform>({
       }
     }
 
-    // Simulators only exist on macOS. Listing them shells out to `simctl`, so we
-    // skip it elsewhere to avoid poisoning the iOS section with a tooling error.
+    // Simulators are only supported on macOS
     if (process.platform === 'darwin') {
       try {
         const simulators = await Simulator.getAvailableAppleSimulatorsListAsync();
@@ -64,7 +63,6 @@ export async function listDevicesAsync<P extends Platform>({
             code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
             message: error.message,
           };
-          // Preserve any connected-device error already set on the iOS section.
           result.ios.error = result.ios.error ?? errorInfo;
           result.tvos.error = errorInfo;
           result.watchos.error = errorInfo;

--- a/apps/cli/src/commands/ListDevices.ts
+++ b/apps/cli/src/commands/ListDevices.ts
@@ -27,19 +27,26 @@ export async function listDevicesAsync<P extends Platform>({
       console.warn('Unable to get connected Apple devices', error);
       if (error instanceof Error) {
         const code = error instanceof InternalError ? error.code : 'UNKNOWN_ERROR';
-        result.ios.error = {
-          code,
-          message: error.message,
-          // Surface install guidance so the menu bar can offer an assist action.
-          helper:
-            code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING'
-              ? (() => {
-                  const { description: _description, ...helper } =
-                    AppleDevice.getUsbmuxdHelperGuidance();
-                  return helper;
-                })()
-              : undefined,
-        };
+        // Only show the error on Windows when an iPhone is plugged in.
+        const suppress =
+          process.platform === 'win32' &&
+          code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING' &&
+          !(await AppleDevice.isAppleUsbDeviceConnectedAsync());
+        if (!suppress) {
+          result.ios.error = {
+            code,
+            message: error.message,
+            // Surface install guidance so the menu bar can offer an assist action.
+            helper:
+              code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING'
+                ? (() => {
+                    const { description: _description, ...helper } =
+                      AppleDevice.getUsbmuxdHelperGuidance();
+                    return helper;
+                  })()
+                : undefined,
+          };
+        }
       }
     }
 

--- a/apps/cli/src/commands/ListDevices.ts
+++ b/apps/cli/src/commands/ListDevices.ts
@@ -15,6 +15,7 @@ export async function listDevicesAsync<P extends Platform>({
   };
 
   if (platform === Platform.Ios || platform === Platform.All) {
+    // Physical Apple device discovery is cross-platform (macOS, Windows, Linux).
     try {
       const connectedDevices = await AppleDevice.getConnectedDevicesAsync();
       for (const connectedDevice of connectedDevices) {
@@ -22,27 +23,52 @@ export async function listDevicesAsync<P extends Platform>({
           result.ios.devices.push(connectedDevice);
         }
       }
-
-      const simulators = await Simulator.getAvailableAppleSimulatorsListAsync();
-      for (const simulator of simulators) {
-        if (simulator.osType === 'watchOS') {
-          result.watchos.devices.push(simulator);
-        } else if (simulator.osType === 'tvOS') {
-          result.tvos.devices.push(simulator);
-        } else {
-          result.ios.devices.push(simulator);
-        }
-      }
     } catch (error) {
-      console.warn('Unable to get Apple devices', error);
+      console.warn('Unable to get connected Apple devices', error);
       if (error instanceof Error) {
-        const errorInfo = {
-          code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
+        const code = error instanceof InternalError ? error.code : 'UNKNOWN_ERROR';
+        result.ios.error = {
+          code,
           message: error.message,
+          // Surface install guidance so the menu bar can offer an assist action.
+          helper:
+            code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING'
+              ? (() => {
+                  const { description: _description, ...helper } =
+                    AppleDevice.getUsbmuxdHelperGuidance();
+                  return helper;
+                })()
+              : undefined,
         };
-        result.ios.error = errorInfo;
-        result.tvos.error = errorInfo;
-        result.watchos.error = errorInfo;
+      }
+    }
+
+    // Simulators only exist on macOS. Listing them shells out to `simctl`, so we
+    // skip it elsewhere to avoid poisoning the iOS section with a tooling error.
+    if (process.platform === 'darwin') {
+      try {
+        const simulators = await Simulator.getAvailableAppleSimulatorsListAsync();
+        for (const simulator of simulators) {
+          if (simulator.osType === 'watchOS') {
+            result.watchos.devices.push(simulator);
+          } else if (simulator.osType === 'tvOS') {
+            result.tvos.devices.push(simulator);
+          } else {
+            result.ios.devices.push(simulator);
+          }
+        }
+      } catch (error) {
+        console.warn('Unable to get Apple simulators', error);
+        if (error instanceof Error) {
+          const errorInfo = {
+            code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
+            message: error.message,
+          };
+          // Preserve any connected-device error already set on the iOS section.
+          result.ios.error = result.ios.error ?? errorInfo;
+          result.tvos.error = errorInfo;
+          result.watchos.error = errorInfo;
+        }
       }
     }
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,6 +5,7 @@ import { downloadBuildAsync } from './commands/DownloadBuild';
 import { listDevicesAsync } from './commands/ListDevices';
 import { bootDeviceAsync } from './commands/BootDevice';
 import { installAndLaunchAppAsync } from './commands/InstallAndLaunchApp';
+import { installAppleDeviceSupportAsync } from './commands/InstallAppleDeviceSupport';
 import { launchExpoGoURLAsync } from './commands/LaunchExpoGo';
 import { checkToolsAsync } from './commands/CheckTools';
 import { setSessionAsync } from './commands/SetSession';
@@ -55,6 +56,11 @@ program
     'Version of the Expo SDK that should be used by Expo Go. E.g. 52.0.0'
   )
   .action(returnLoggerMiddleware(trustedSourcesValidatorMiddleware(launchExpoGoURLAsync)));
+
+program
+  .command('install-apple-device-support')
+  .description('Install the helper software required to connect to a physical iPhone over USB')
+  .action(returnLoggerMiddleware(installAppleDeviceSupportAsync));
 
 program
   .command('check-tools')

--- a/apps/menu-bar/electron/modules/Alert/main.ts
+++ b/apps/menu-bar/electron/modules/Alert/main.ts
@@ -3,16 +3,22 @@ import type { AlertButton } from 'react-native';
 
 const AlertModule: {
   name: string;
-  alert: (title: string, message?: string, buttons?: AlertButton[]) => void;
+  alert: (title: string, message?: string, buttons?: AlertButton[]) => Promise<number>;
 } = {
   name: 'Alert',
-  alert(title: string, message?: string, buttons?: AlertButton[]) {
-    dialog.showMessageBox({
+  async alert(title: string, message?: string, buttons?: AlertButton[]) {
+    const labels = buttons?.map((button) => button.text ?? '') ?? ['OK'];
+    // Map any 'cancel'-styled button so the dialog's default-cancel behavior
+    // (Esc / window close) reports the right index back to the renderer.
+    const cancelId = buttons?.findIndex((button) => button.style === 'cancel');
+    const { response } = await dialog.showMessageBox({
       type: 'info',
       message: title,
       detail: message ?? '',
-      buttons: buttons?.map((button) => button.text ?? '') ?? ['OK'],
+      buttons: labels,
+      cancelId: cancelId !== undefined && cancelId >= 0 ? cancelId : undefined,
     });
+    return response;
   },
 };
 

--- a/apps/menu-bar/electron/vite.main.config.mts
+++ b/apps/menu-bar/electron/vite.main.config.mts
@@ -5,7 +5,7 @@ import path from 'node:path';
 // normalizePath(path.resolve(__dirname, './foo')); // C:/project/foo
 
 // https://vitejs.dev/config
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   resolve: {
     mainFields: ['module', 'jsnext:main', 'jsnext'],
   },
@@ -32,14 +32,21 @@ export default defineConfig({
       ],
       structured: true,
     }),
-    viteStaticCopy({
-      targets: [
-        {
-          src: './dist/**/*',
-          dest: 'renderer/',
-        },
-      ],
-      structured: true,
-    }),
+    // Only copy the renderer's built output into the packaged main bundle;
+    // in dev mode the renderer is served from the Vite dev server and
+    // ./dist doesn't exist.
+    ...(command === 'build'
+      ? [
+          viteStaticCopy({
+            targets: [
+              {
+                src: './dist/**/*',
+                dest: 'renderer/',
+              },
+            ],
+            structured: true,
+          }),
+        ]
+      : []),
   ],
-});
+}));

--- a/apps/menu-bar/src/commands/installAppleDeviceSupportAsync.ts
+++ b/apps/menu-bar/src/commands/installAppleDeviceSupportAsync.ts
@@ -1,0 +1,9 @@
+import MenuBarModule from '../modules/MenuBarModule';
+
+/**
+ * Installs the helper software required to connect to a physical iPhone over USB
+ * (usbmuxd on Linux, the Apple Devices app on Windows). No-op on macOS.
+ */
+export const installAppleDeviceSupportAsync = async () => {
+  await MenuBarModule.runCli('install-apple-device-support', [], console.log);
+};

--- a/apps/menu-bar/src/components/CommandCheckItem.tsx
+++ b/apps/menu-bar/src/components/CommandCheckItem.tsx
@@ -1,6 +1,7 @@
 import { spacing } from '@expo/styleguide-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { CliCommands } from 'common-types';
+import { useState } from 'react';
 import {
   ActivityIndicator,
   AlertButton,
@@ -21,13 +22,44 @@ type Props = {
   description: string;
   icon: ImageSourcePropType;
   loading: boolean;
+  onPressFix?: () => Promise<void>;
+  fixLabel?: string;
 } & CliCommands.CheckTools.PlatformToolsCheck[keyof CliCommands.CheckTools.PlatformToolsCheck];
 
-const CommandCheckItem = ({ description, icon, title, reason, success, loading }: Props) => {
+const CommandCheckItem = ({
+  description,
+  icon,
+  title,
+  reason,
+  success,
+  loading,
+  onPressFix,
+  fixLabel,
+}: Props) => {
+  const [isFixing, setIsFixing] = useState(false);
+
+  const runFix = async () => {
+    if (!onPressFix || isFixing) {
+      return;
+    }
+    setIsFixing(true);
+    try {
+      await onPressFix();
+    } finally {
+      setIsFixing(false);
+    }
+  };
+
   const showWarningAlert = () => {
     const buttons: AlertButton[] = [{ text: 'OK', style: 'default' }];
-    const command = reason?.command;
-    if (command) {
+    if (onPressFix) {
+      buttons.unshift({
+        text: fixLabel ?? 'Install',
+        style: 'default',
+        onPress: runFix,
+      });
+    } else if (reason?.command) {
+      const command = reason.command;
       buttons.unshift({
         text: 'Copy command',
         style: 'default',
@@ -63,7 +95,7 @@ const CommandCheckItem = ({ description, icon, title, reason, success, loading }
           </TouchableOpacity>
         ) : null}
       </View>
-      {loading ? (
+      {loading || isFixing ? (
         <ActivityIndicator />
       ) : success ? (
         <CheckIcon />

--- a/apps/menu-bar/src/modules/Alert/index.web.ts
+++ b/apps/menu-bar/src/modules/Alert/index.web.ts
@@ -2,13 +2,22 @@ import { Alert as RNAlert, AlertButton } from 'react-native';
 import { requireElectronModule } from 'react-native-electron-modules/build/requireElectronModule';
 
 const ElectronAlert = requireElectronModule<{
-  alert(title: string, message?: string, buttons?: AlertButton[]): void;
+  alert(
+    title: string,
+    message?: string,
+    buttons?: Pick<AlertButton, 'text' | 'style'>[]
+  ): Promise<number>;
 }>('Alert');
 
 const Alert = {
   ...RNAlert,
-  alert(title: string, message?: string, buttons?: AlertButton[]) {
-    ElectronAlert.alert(title, message, buttons);
+  async alert(title: string, message?: string, buttons?: AlertButton[]) {
+    // The IPC bridge serializes args via structured clone, so onPress callbacks would
+    // be dropped on the way to main. Strip them before sending, then dispatch the
+    // matching one ourselves once main returns the clicked button's index.
+    const serializable = buttons?.map(({ text, style }) => ({ text, style }));
+    const index = await ElectronAlert.alert(title, message, serializable);
+    buttons?.[index]?.onPress?.();
   },
 };
 

--- a/apps/menu-bar/src/modules/Storage.ts
+++ b/apps/menu-bar/src/modules/Storage.ts
@@ -14,7 +14,6 @@ export type UserPreferences = {
   emulatorWithoutAudio: boolean;
   customSdkPath?: string;
   showIosSimulators: boolean;
-  showIosDevices: boolean;
   showTvosSimulators: boolean;
   showWatchosSimulators: boolean;
   showAndroidEmulators: boolean;
@@ -23,9 +22,9 @@ export type UserPreferences = {
 export const defaultUserPreferences: UserPreferences = {
   launchOnLogin: false,
   emulatorWithoutAudio: false,
-  showIosSimulators: Platform.OS === 'macos',
-  // Physical iPhones can be used from macOS, Windows, and Linux.
-  showIosDevices: true,
+  // Controls the whole iOS section (simulators on macOS, physical iPhones on all
+  // platforms). Enabled everywhere so connected iPhones are discoverable.
+  showIosSimulators: true,
   showTvosSimulators: false,
   showWatchosSimulators: Platform.OS === 'macos',
   showAndroidEmulators: true,

--- a/apps/menu-bar/src/modules/Storage.ts
+++ b/apps/menu-bar/src/modules/Storage.ts
@@ -14,6 +14,7 @@ export type UserPreferences = {
   emulatorWithoutAudio: boolean;
   customSdkPath?: string;
   showIosSimulators: boolean;
+  showIosDevices: boolean;
   showTvosSimulators: boolean;
   showWatchosSimulators: boolean;
   showAndroidEmulators: boolean;
@@ -23,6 +24,8 @@ export const defaultUserPreferences: UserPreferences = {
   launchOnLogin: false,
   emulatorWithoutAudio: false,
   showIosSimulators: Platform.OS === 'macos',
+  // Physical iPhones can be used from macOS, Windows, and Linux.
+  showIosDevices: true,
   showTvosSimulators: false,
   showWatchosSimulators: Platform.OS === 'macos',
   showAndroidEmulators: true,

--- a/apps/menu-bar/src/popover/AppleDeviceHelperPrompt.tsx
+++ b/apps/menu-bar/src/popover/AppleDeviceHelperPrompt.tsx
@@ -9,14 +9,16 @@ import { Linking } from '../modules/Linking';
 
 type Props = {
   error: CliCommands.ListDevices.DeviceListError;
+  /** Called after the helper software is installed so the device list can refresh. */
+  onInstalled?: () => void;
 };
 
 /**
  * Rendered in the iOS section when the usbmux helper service isn't reachable. It
  * explains what's needed and offers a one-click assist to install the helper
- * software (the Apple Devices app on Windows, usbmuxd on Linux).
+ * software (Apple Mobile Device Support on Windows, usbmuxd on Linux).
  */
-const AppleDeviceHelperPrompt = ({ error }: Props) => {
+const AppleDeviceHelperPrompt = ({ error, onInstalled }: Props) => {
   const [isInstalling, setIsInstalling] = useState(false);
   const { helper } = error;
 
@@ -30,23 +32,28 @@ const AppleDeviceHelperPrompt = ({ error }: Props) => {
       return;
     }
 
-    // Prefer opening the installer page (most reliable on Windows). Otherwise run
-    // the install command on the host (usbmuxd on Linux, via pkexec).
-    if (helper.installUrl) {
-      Linking.openURL(helper.installUrl);
-      return;
-    }
-
+    // Install the helper software for the user (winget on Windows, pkexec on
+    // Linux). Only fall back to the manual download page if that fails — e.g.
+    // winget isn't available.
     setIsInstalling(true);
     try {
       await installAppleDeviceSupportAsync();
-    } catch (e) {
       Alert.alert(
-        `Unable to install ${helper.label}`,
-        helper.installCommand
-          ? `Please run the following command manually:\n\n${helper.installCommand}`
-          : (e as Error).message
+        `${helper.label} installed`,
+        'Reconnect your iPhone over USB and tap "Trust" if prompted.'
       );
+      onInstalled?.();
+    } catch (e) {
+      if (helper.installUrl) {
+        Linking.openURL(helper.installUrl);
+      } else {
+        Alert.alert(
+          `Unable to install ${helper.label}`,
+          helper.installCommand
+            ? `Please run the following command manually:\n\n${helper.installCommand}`
+            : (e as Error).message
+        );
+      }
     } finally {
       setIsInstalling(false);
     }

--- a/apps/menu-bar/src/popover/AppleDeviceHelperPrompt.tsx
+++ b/apps/menu-bar/src/popover/AppleDeviceHelperPrompt.tsx
@@ -1,0 +1,67 @@
+import { CliCommands } from 'common-types';
+import { useState } from 'react';
+
+import { installAppleDeviceSupportAsync } from '../commands/installAppleDeviceSupportAsync';
+import { Text, View } from '../components';
+import Button from '../components/Button';
+import Alert from '../modules/Alert';
+import { Linking } from '../modules/Linking';
+
+type Props = {
+  error: CliCommands.ListDevices.DeviceListError;
+};
+
+/**
+ * Rendered in the iOS section when the usbmux helper service isn't reachable. It
+ * explains what's needed and offers a one-click assist to install the helper
+ * software (the Apple Devices app on Windows, usbmuxd on Linux).
+ */
+const AppleDeviceHelperPrompt = ({ error }: Props) => {
+  const [isInstalling, setIsInstalling] = useState(false);
+  const { helper } = error;
+
+  const onPressInstall = async () => {
+    if (!helper) {
+      return;
+    }
+
+    // Prefer opening the installer page (most reliable on Windows). Otherwise run
+    // the install command on the host (usbmuxd on Linux, via pkexec).
+    if (helper.installUrl) {
+      Linking.openURL(helper.installUrl);
+      return;
+    }
+
+    setIsInstalling(true);
+    try {
+      await installAppleDeviceSupportAsync();
+    } catch (e) {
+      Alert.alert(
+        `Unable to install ${helper.label}`,
+        helper.installCommand
+          ? `Please run the following command manually:\n\n${helper.installCommand}`
+          : (e as Error).message
+      );
+    } finally {
+      setIsInstalling(false);
+    }
+  };
+
+  return (
+    <View px="4" py="2" style={{ gap: 8 }}>
+      <Text color="secondary" size="small">
+        {error.message}
+      </Text>
+      {helper ? (
+        <Button
+          title={isInstalling ? 'Installing…' : `Install ${helper.label}`}
+          color="primary"
+          disabled={isInstalling}
+          onPress={onPressInstall}
+        />
+      ) : null}
+    </View>
+  );
+};
+
+export default AppleDeviceHelperPrompt;

--- a/apps/menu-bar/src/popover/AppleDeviceHelperPrompt.tsx
+++ b/apps/menu-bar/src/popover/AppleDeviceHelperPrompt.tsx
@@ -20,6 +20,11 @@ const AppleDeviceHelperPrompt = ({ error }: Props) => {
   const [isInstalling, setIsInstalling] = useState(false);
   const { helper } = error;
 
+  // Only offer an install action when there's actually something to install. When
+  // the helper is installed but not running (e.g. usbmuxd on Linux), the message
+  // itself explains how to start it.
+  const canInstall = Boolean(helper && (helper.installUrl || helper.installCommand));
+
   const onPressInstall = async () => {
     if (!helper) {
       return;
@@ -52,9 +57,9 @@ const AppleDeviceHelperPrompt = ({ error }: Props) => {
       <Text color="secondary" size="small">
         {error.message}
       </Text>
-      {helper ? (
+      {canInstall ? (
         <Button
-          title={isInstalling ? 'Installing…' : `Install ${helper.label}`}
+          title={isInstalling ? 'Installing…' : `Install ${helper!.label}`}
           color="primary"
           disabled={isInstalling}
           onPress={onPressInstall}

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -4,6 +4,7 @@ import { Device } from 'common-types/build/devices';
 import React, { memo, useCallback, useState } from 'react';
 import { SectionList } from 'react-native';
 
+import AppleDeviceHelperPrompt from './AppleDeviceHelperPrompt';
 import BuildsSection, { BUILDS_SECTION_HEIGHT } from './BuildsSection';
 import DeviceListSectionHeader from './DeviceListSectionHeader';
 import DevicesListError from './DevicesListError';
@@ -718,6 +719,11 @@ function Core(props: Props) {
             renderSectionHeader={({ section: { label, error } }) => (
               <DeviceListSectionHeader label={label} errorMessage={error?.message} />
             )}
+            renderSectionFooter={({ section: { key, error } }) =>
+              key === 'ios' && error?.code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING' ? (
+                <AppleDeviceHelperPrompt error={error} />
+              ) : null
+            }
             renderItem={({ item: device }: { item: Device }) => {
               const platform = getDeviceOS(device);
               const id = getDeviceId(device);

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -721,7 +721,7 @@ function Core(props: Props) {
             )}
             renderSectionFooter={({ section: { key, error } }) =>
               key === 'ios' && error?.code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING' ? (
-                <AppleDeviceHelperPrompt error={error} />
+                <AppleDeviceHelperPrompt error={error} onInstalled={refetch} />
               ) : null
             }
             renderItem={({ item: device }: { item: Device }) => {

--- a/apps/menu-bar/src/providers/DevicesProvider.tsx
+++ b/apps/menu-bar/src/providers/DevicesProvider.tsx
@@ -44,15 +44,11 @@ export function DevicesProvider({ children }: { children: React.ReactNode }) {
 
   const updateDevicesList = useCallback(async () => {
     const {
-      showIosSimulators: showIosSims,
-      showIosDevices,
+      showIosSimulators: showIos,
       showTvosSimulators: showTvos,
       showWatchosSimulators: showWatchos,
       showAndroidEmulators: showAndroid,
     } = getUserPreferences();
-
-    // Anything in the iOS section (physical devices and/or simulators).
-    const showIos = showIosSims || showIosDevices;
 
     const iosDevices = new Map<string, CliCommands.ListDevices.Device<CliCommands.Platform.Ios>>();
     const tvosDevices = new Map<
@@ -84,11 +80,7 @@ export function DevicesProvider({ children }: { children: React.ReactNode }) {
 
       if (showIos) {
         devicesList.ios.devices.forEach((device) => {
-          // Physical devices and simulators are toggled independently.
-          const isPhysicalDevice = device.deviceType === 'device';
-          if (isPhysicalDevice ? showIosDevices : showIosSims) {
-            iosDevices.set(getDeviceId(device), device);
-          }
+          iosDevices.set(getDeviceId(device), device);
         });
       }
 

--- a/apps/menu-bar/src/providers/DevicesProvider.tsx
+++ b/apps/menu-bar/src/providers/DevicesProvider.tsx
@@ -44,11 +44,15 @@ export function DevicesProvider({ children }: { children: React.ReactNode }) {
 
   const updateDevicesList = useCallback(async () => {
     const {
-      showIosSimulators: showIos,
+      showIosSimulators: showIosSims,
+      showIosDevices,
       showTvosSimulators: showTvos,
       showWatchosSimulators: showWatchos,
       showAndroidEmulators: showAndroid,
     } = getUserPreferences();
+
+    // Anything in the iOS section (physical devices and/or simulators).
+    const showIos = showIosSims || showIosDevices;
 
     const iosDevices = new Map<string, CliCommands.ListDevices.Device<CliCommands.Platform.Ios>>();
     const tvosDevices = new Map<
@@ -80,7 +84,11 @@ export function DevicesProvider({ children }: { children: React.ReactNode }) {
 
       if (showIos) {
         devicesList.ios.devices.forEach((device) => {
-          iosDevices.set(getDeviceId(device), device);
+          // Physical devices and simulators are toggled independently.
+          const isPhysicalDevice = device.deviceType === 'device';
+          if (isPhysicalDevice ? showIosDevices : showIosSims) {
+            iosDevices.set(getDeviceId(device), device);
+          }
         });
       }
 

--- a/apps/menu-bar/src/utils/device.ts
+++ b/apps/menu-bar/src/utils/device.ts
@@ -13,7 +13,7 @@ import { SectionListData } from 'react-native';
 export type DevicesPerPlatform = {
   [P in Exclude<CliCommands.Platform, CliCommands.Platform.All>]: {
     devices: Map<string, CliCommands.ListDevices.Device<P>>;
-    error?: { code: string; message: string };
+    error?: CliCommands.ListDevices.DeviceListError;
   };
 };
 

--- a/apps/menu-bar/src/windows/Onboarding.tsx
+++ b/apps/menu-bar/src/windows/Onboarding.tsx
@@ -14,7 +14,6 @@ import CommandCheckItem from '../components/CommandCheckItem';
 import MenuBarModule from '../modules/MenuBarModule';
 import { storage } from '../modules/Storage';
 import { useWindowFocusEffect } from '../modules/WindowManager/useWindowFocus';
-import AppleDeviceHelperPrompt from '../popover/AppleDeviceHelperPrompt';
 import { useExpoTheme } from '../utils/useExpoTheme';
 
 export const hasSeenOnboardingStorageKey = 'has-seen-onboarding';
@@ -110,27 +109,18 @@ const Onboarding = () => {
                 loading={platformToolsCheck?.ios?.success === undefined}
               />
             )}
-          </View>
-          {/* On Windows/Linux, let the user opt in to installing the device support
-              needed to install apps on a physical iPhone over USB. */}
-          {Platform.OS !== 'macos' && platformToolsCheck?.appleDevice?.success === false ? (
-            <View px="large" pb="large" style={styles.container}>
-              <View>
-                <Text weight="bold">Install apps on a physical iPhone?</Text>
-                <Text size="small" color="secondary">
-                  Connect an iPhone over USB. Orbit can install the required device support for you.
-                </Text>
-              </View>
-              <AppleDeviceHelperPrompt
-                error={{
-                  code: 'APPLE_DEVICE_USBMUXD_NOT_RUNNING',
-                  message: platformToolsCheck.appleDevice.reason?.message ?? '',
-                  helper: platformToolsCheck.appleDevice.helper,
-                }}
-                onInstalled={() => runChecks({ force: true })}
+            {/* Only emitted by the CLI on Windows. macOS and Linux already ship with usbmuxd. */}
+            {platformToolsCheck?.appleDevice ? (
+              <CommandCheckItem
+                title="Apple Mobile Device Support"
+                description="Install to connect a physical iPhone over USB"
+                icon={Xcode}
+                success={platformToolsCheck.appleDevice.success}
+                reason={platformToolsCheck.appleDevice.reason}
+                loading={platformToolsCheck.appleDevice.success === undefined}
               />
-            </View>
-          ) : null}
+            ) : null}
+          </View>
         </View>
       </ScrollView>
       <View

--- a/apps/menu-bar/src/windows/Onboarding.tsx
+++ b/apps/menu-bar/src/windows/Onboarding.tsx
@@ -14,6 +14,7 @@ import CommandCheckItem from '../components/CommandCheckItem';
 import MenuBarModule from '../modules/MenuBarModule';
 import { storage } from '../modules/Storage';
 import { useWindowFocusEffect } from '../modules/WindowManager/useWindowFocus';
+import AppleDeviceHelperPrompt from '../popover/AppleDeviceHelperPrompt';
 import { useExpoTheme } from '../utils/useExpoTheme';
 
 export const hasSeenOnboardingStorageKey = 'has-seen-onboarding';
@@ -39,31 +40,35 @@ const Onboarding = () => {
     MenuBarModule.openPopover();
   };
 
-  useWindowFocusEffect(
-    useCallback(async () => {
-      if (checkStatus.current === Status.SUCCESS) {
-        return;
-      }
+  const runChecks = useCallback(async ({ force = false }: { force?: boolean } = {}) => {
+    if (!force && checkStatus.current === Status.SUCCESS) {
+      return;
+    }
 
-      setPlatformToolsCheck({});
-      checkStatus.current = Status.RUNNING;
-      try {
-        const output = await MenuBarModule.runCli('check-tools', []);
-        // eslint-disable-next-line no-eval
-        const result: CliCommands.CheckTools.PlatformToolsCheck = eval(`(${output})`);
-        checkStatus.current =
-          result?.android?.success && result?.ios?.success ? Status.SUCCESS : Status.FAILED;
-        setPlatformToolsCheck(result);
-      } catch (err) {
-        checkStatus.current = Status.FAILED;
-        if (err instanceof Error) {
-          setPlatformToolsCheck({
-            android: { success: false, reason: { message: err.message } },
-            ios: { success: false, reason: { message: err.message } },
-          });
-        }
+    setPlatformToolsCheck({});
+    checkStatus.current = Status.RUNNING;
+    try {
+      const output = await MenuBarModule.runCli('check-tools', []);
+      // eslint-disable-next-line no-eval
+      const result: CliCommands.CheckTools.PlatformToolsCheck = eval(`(${output})`);
+      checkStatus.current =
+        result?.android?.success && result?.ios?.success ? Status.SUCCESS : Status.FAILED;
+      setPlatformToolsCheck(result);
+    } catch (err) {
+      checkStatus.current = Status.FAILED;
+      if (err instanceof Error) {
+        setPlatformToolsCheck({
+          android: { success: false, reason: { message: err.message } },
+          ios: { success: false, reason: { message: err.message } },
+        });
       }
-    }, [])
+    }
+  }, []);
+
+  useWindowFocusEffect(
+    useCallback(() => {
+      runChecks();
+    }, [runChecks])
   );
 
   return (
@@ -106,6 +111,26 @@ const Onboarding = () => {
               />
             )}
           </View>
+          {/* On Windows/Linux, let the user opt in to installing the device support
+              needed to install apps on a physical iPhone over USB. */}
+          {Platform.OS !== 'macos' && platformToolsCheck?.appleDevice?.success === false ? (
+            <View px="large" pb="large" style={styles.container}>
+              <View>
+                <Text weight="bold">Install apps on a physical iPhone?</Text>
+                <Text size="small" color="secondary">
+                  Connect an iPhone over USB. Orbit can install the required device support for you.
+                </Text>
+              </View>
+              <AppleDeviceHelperPrompt
+                error={{
+                  code: 'APPLE_DEVICE_USBMUXD_NOT_RUNNING',
+                  message: platformToolsCheck.appleDevice.reason?.message ?? '',
+                  helper: platformToolsCheck.appleDevice.helper,
+                }}
+                onInstalled={() => runChecks({ force: true })}
+              />
+            </View>
+          ) : null}
         </View>
       </ScrollView>
       <View

--- a/apps/menu-bar/src/windows/Onboarding.tsx
+++ b/apps/menu-bar/src/windows/Onboarding.tsx
@@ -8,9 +8,12 @@ import Background from '../assets/images/onboarding/background.png';
 import ExpoOrbitText from '../assets/images/onboarding/expo-orbit-text.svg';
 import Logo from '../assets/images/onboarding/logo.svg';
 import Xcode from '../assets/images/xcode.png';
+import { installAppleDeviceSupportAsync } from '../commands/installAppleDeviceSupportAsync';
 import { Text, View } from '../components';
 import Button from '../components/Button';
 import CommandCheckItem from '../components/CommandCheckItem';
+import Alert from '../modules/Alert';
+import { Linking } from '../modules/Linking';
 import MenuBarModule from '../modules/MenuBarModule';
 import { storage } from '../modules/Storage';
 import { useWindowFocusEffect } from '../modules/WindowManager/useWindowFocus';
@@ -118,6 +121,30 @@ const Onboarding = () => {
                 success={platformToolsCheck.appleDevice.success}
                 reason={platformToolsCheck.appleDevice.reason}
                 loading={platformToolsCheck.appleDevice.success === undefined}
+                fixLabel={`Install ${platformToolsCheck.appleDevice.helper?.label ?? ''}`.trim()}
+                onPressFix={async () => {
+                  const helper = platformToolsCheck.appleDevice?.helper;
+                  try {
+                    await installAppleDeviceSupportAsync();
+                    Alert.alert(
+                      `${helper?.label ?? 'Apple Mobile Device Support'} installed`,
+                      'Reconnect your iPhone over USB and tap "Trust" if prompted.'
+                    );
+                    runChecks({ force: true });
+                  } catch (e) {
+                    // Fall back to the Store page if the silent install failed (e.g. winget missing).
+                    if (helper?.installUrl) {
+                      Linking.openURL(helper.installUrl);
+                    } else {
+                      Alert.alert(
+                        `Unable to install ${helper?.label ?? 'Apple Mobile Device Support'}`,
+                        helper?.installCommand
+                          ? `Please run the following command manually:\n\n${helper.installCommand}`
+                          : (e as Error).message
+                      );
+                    }
+                  }
+                }}
               />
             ) : null}
           </View>

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -43,13 +43,7 @@ type OsListItem = {
 };
 const osList: OsListItem[] = [
   { label: 'Android', key: 'showAndroidEmulators', supported: true },
-  { label: 'iOS Devices', key: 'showIosDevices', supported: true },
-  {
-    label: 'iOS Simulators',
-    key: 'showIosSimulators',
-    supported: Platform.OS === 'macos',
-    unsupportedMessage: 'macOS only',
-  },
+  { label: 'iOS', key: 'showIosSimulators', supported: true },
   {
     label: 'tvOS',
     key: 'showTvosSimulators',

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -43,8 +43,9 @@ type OsListItem = {
 };
 const osList: OsListItem[] = [
   { label: 'Android', key: 'showAndroidEmulators', supported: true },
+  { label: 'iOS Devices', key: 'showIosDevices', supported: true },
   {
-    label: 'iOS',
+    label: 'iOS Simulators',
     key: 'showIosSimulators',
     supported: Platform.OS === 'macos',
     unsupportedMessage: 'macOS only',

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -24,6 +24,8 @@ export default class InternalError extends Error {
 export type InternalErrorCode =
   | 'APPLE_APP_VERIFICATION_FAILED'
   | 'APPLE_DEVICE_LOCKED'
+  | 'APPLE_DEVICE_USBMUXD_NOT_RUNNING'
+  | 'APPLE_DEVICE_NOT_PAIRED'
   | 'EXPO_GO_NOT_INSTALLED_ON_DEVICE'
   | 'INVALID_VERSION'
   | 'MULTIPLE_APPS_IN_TARBALL'

--- a/packages/common-types/src/cli-commands/checkTools.ts
+++ b/packages/common-types/src/cli-commands/checkTools.ts
@@ -1,3 +1,5 @@
+import { DeviceListErrorHelper } from './listDevices';
+
 export type FailureReason = {
   message: string;
   command?: string;
@@ -11,5 +13,11 @@ export type PlatformToolsCheck = {
   ios?: {
     success: boolean;
     reason?: FailureReason;
+  };
+  /** Helper software for installing apps on a physical iPhone over USB. */
+  appleDevice?: {
+    success: boolean;
+    reason?: FailureReason;
+    helper?: DeviceListErrorHelper;
   };
 };

--- a/packages/common-types/src/cli-commands/listDevices.ts
+++ b/packages/common-types/src/cli-commands/listDevices.ts
@@ -25,6 +25,8 @@ export type DeviceListErrorHelper = {
   installUrl?: string;
   /** Shell command that installs the helper software. */
   installCommand?: string;
+  /** Shell command that starts the (already installed) helper service. */
+  startCommand?: string;
 };
 
 export type DeviceListError = {

--- a/packages/common-types/src/cli-commands/listDevices.ts
+++ b/packages/common-types/src/cli-commands/listDevices.ts
@@ -18,9 +18,25 @@ export type Device<P> = P extends Platform.Ios
         ? AndroidConnectedDevice | AndroidEmulator
         : never;
 
+export type DeviceListErrorHelper = {
+  /** Short, human-readable name of the helper software to install. */
+  label: string;
+  /** URL to open so the user can install the helper software. */
+  installUrl?: string;
+  /** Shell command that installs the helper software. */
+  installCommand?: string;
+};
+
+export type DeviceListError = {
+  code: string;
+  message: string;
+  /** Present when the error is actionable by installing helper software. */
+  helper?: DeviceListErrorHelper;
+};
+
 export type DevicesPerPlatform = {
   [P in Exclude<Platform, Platform.All>]: {
     devices: Device<P>[];
-    error?: { code: string; message: string };
+    error?: DeviceListError;
   };
 };

--- a/packages/eas-shared/jest.config.js
+++ b/packages/eas-shared/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import("jest").Config} **/
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    // Transpile-only: the library tsconfig intentionally excludes tests (and
+    // their jest type globals), so let Jest run them without full type-checking.
+    '^.+\\.tsx?$': ['ts-jest', { isolatedModules: true }],
+  },
+};

--- a/packages/eas-shared/package.json
+++ b/packages/eas-shared/package.json
@@ -41,6 +41,7 @@
     "debug": "^4.3.4",
     "env-paths": "2.2.0",
     "exec-async": "2.2.0",
+    "extract-zip": "^2.0.1",
     "getenv": "^1.0.0",
     "lodash": "^4.17.21",
     "node-fetch": "2.6.7",

--- a/packages/eas-shared/package.json
+++ b/packages/eas-shared/package.json
@@ -7,7 +7,8 @@
     "build": "tsc --project tsconfig.json & tsc --project tsconfig.cjs.json",
     "watch": "yarn build --watch --preserveWatchOutput",
     "lint": "eslint .",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test": "jest"
   },
   "exports": {
     ".": {

--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -1,6 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import { InternalError } from 'common-types';
 import { MultipleAppsInTarballErrorDetails } from 'common-types/build/InternalError';
+import extractZip from 'extract-zip';
 import glob from 'fast-glob';
 import fs from 'fs-extra';
 import path from 'path';
@@ -311,6 +312,13 @@ export async function tarExtractAsync(input: string, output: string): Promise<vo
       `Failed to extract tar using native tools, falling back on JS tar module. ${error.message}`
     );
   }
+
+  if (/\.(zip|ipa)$/i.test(input)) {
+    Log.debug(`Extracting ${input} to ${output} using JS unzip module`);
+    await extractZip(input, { dir: output });
+    return;
+  }
+
   Log.debug(`Extracting ${input} to ${output} using JS tar module`);
   // tar node module has previously had problems with big files, and seems to
   // be slower, so only use it as a backup.

--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -313,7 +313,9 @@ export async function tarExtractAsync(input: string, output: string): Promise<vo
     );
   }
 
-  if (/\.(zip|ipa)$/i.test(input)) {
+  // Detect format by magic bytes since the filename can be misleading
+  // (e.g. an IPA downloaded into a uuid.tar.gz placeholder).
+  if ((await isZipFileAsync(input)) || /\.(zip|ipa)$/i.test(input)) {
     Log.debug(`Extracting ${input} to ${output} using JS unzip module`);
     await extractZip(input, { dir: output });
     return;
@@ -323,4 +325,19 @@ export async function tarExtractAsync(input: string, output: string): Promise<vo
   // tar node module has previously had problems with big files, and seems to
   // be slower, so only use it as a backup.
   await extract({ file: input, cwd: output });
+}
+
+async function isZipFileAsync(filePath: string): Promise<boolean> {
+  let fd: fs.promises.FileHandle | undefined;
+  try {
+    fd = await fs.promises.open(filePath, 'r');
+    const buffer = Buffer.alloc(4);
+    await fd.read(buffer, 0, 4, 0);
+    // ZIP local file header signature: PK\x03\x04
+    return buffer[0] === 0x50 && buffer[1] === 0x4b && buffer[2] === 0x03 && buffer[3] === 0x04;
+  } catch {
+    return false;
+  } finally {
+    await fd?.close();
+  }
 }

--- a/packages/eas-shared/src/download.ts
+++ b/packages/eas-shared/src/download.ts
@@ -302,12 +302,10 @@ async function filterNestedDuplicateAppsAsync(
 
 export async function tarExtractAsync(input: string, output: string): Promise<void> {
   try {
-    if (process.platform !== 'win32') {
-      await spawnAsync('tar', ['-xf', input, '-C', output], {
-        stdio: 'inherit',
-      });
-      return;
-    }
+    await spawnAsync('tar', ['-xf', input, '-C', output], {
+      stdio: 'inherit',
+    });
+    return;
   } catch (error: any) {
     Log.warn(
       `Failed to extract tar using native tools, falling back on JS tar module. ${error.message}`

--- a/packages/eas-shared/src/index.ts
+++ b/packages/eas-shared/src/index.ts
@@ -16,7 +16,10 @@ import * as Emulator from './run/android/emulator';
 import { assertExecutablesExistAsync as validateAndroidSystemRequirementsAsync } from './run/android/systemRequirements';
 import AppleDevice from './run/ios/device';
 import * as Simulator from './run/ios/simulator';
-import { validateSystemRequirementsAsync as validateIOSSystemRequirementsAsync } from './run/ios/systemRequirements';
+import {
+  validateAppleDeviceRequirementsAsync,
+  validateSystemRequirementsAsync as validateIOSSystemRequirementsAsync,
+} from './run/ios/systemRequirements';
 
 export {
   AppPlatform,
@@ -26,6 +29,7 @@ export {
   runAppOnAndroidEmulatorAsync,
   validateAndroidSystemRequirementsAsync,
   validateIOSSystemRequirementsAsync,
+  validateAppleDeviceRequirementsAsync,
   detectAppleAppType,
   type AppleAppInfo,
   Emulator,

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -51,16 +51,22 @@ export async function getConnectedDevicesAsync(): Promise<AppleConnectedDevice[]
     devices.push(...customResult.value);
   } else {
     // The usbmux-based custom tooling is the only cross-platform discovery path.
-    // If it failed because the helper service isn't running, surface a friendly
-    // error so the UI can guide the user to install the Apple helper software.
-    if (isUsbmuxdNotRunningError(customResult.reason)) {
+    const reason = customResult.reason;
+    // It may already have wrapped a connection failure as a user-facing
+    // InternalError (e.g. APPLE_DEVICE_USBMUXD_NOT_RUNNING) — surface it so the
+    // UI/CLI can guide the user to install the Apple helper software.
+    if (reason instanceof InternalError) {
+      throw reason;
+    }
+    // A raw socket error means the helper service isn't running.
+    if (isUsbmuxdNotRunningError(reason)) {
       throw createUsbmuxdNotRunningError();
     }
     // If the native tools also couldn't list anything, surface the original error.
     if (nativeResult.status !== 'fulfilled') {
-      throw customResult.reason;
+      throw reason;
     }
-    log('Failed to list Apple devices using custom tooling: %O', customResult.reason);
+    log('Failed to list Apple devices using custom tooling: %O', reason);
   }
 
   return uniqBy(devices, (device) => device.udid);

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -209,9 +209,13 @@ export async function runOnDevice({
       [bundleId]: appInfo,
     } = await installer.lookupApp([bundleId]);
 
-    if (appInfo && !ddiMounted) {
-      // Without the developer disk image we cannot start the debugserver, so the
-      // app can't be launched programmatically. Installation still succeeded.
+    // Programmatic launch needs either the debugserver (requires DDI) or
+    // `xcrun devicectl` (macOS + Xcode only) — both are unavailable on
+    // Windows/Linux, so skip the launch attempt there even if iOS reports a
+    // DDI as already mounted (e.g. an auto-mounted personalized image).
+    const canAttemptLaunch = ddiMounted && process.platform === 'darwin';
+    if (appInfo && !canAttemptLaunch) {
+      // Installation still succeeded; the user can tap the icon to launch.
       console.log(
         `App "${bundleId}" installed. Open it from the Home Screen on your device to launch it.`
       );
@@ -341,6 +345,10 @@ async function launchApp(
   try {
     return await launchAppWithUsbmux(clientManager, { appInfo, detach });
   } catch (error) {
+    // The devicectl fallback ships with Xcode and only exists on macOS.
+    if (process.platform !== 'darwin') {
+      throw error;
+    }
     debug(`Failed to launch app with Usbmuxd, falling back to xcrun... ${error}`);
 
     // Get the device UDID and close the connection, to allow `xcrun devicectl` to connect

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -17,22 +17,53 @@ import { IPLookupResult, OnInstallProgressCallback } from './client/Installation
 import { LockdowndClient } from './client/LockdowndClient';
 import { UsbmuxdClient } from './client/UsbmuxdClient';
 import { AFC_STATUS, AFCError } from './protocol/AFCProtocol';
+import {
+  connectUsbmuxdSocketAsync,
+  createUsbmuxdNotRunningError,
+  isUsbmuxdNotRunningError,
+} from './usbmuxd';
 import { delayAsync } from '../../../utils/delayAsync';
 import { CommandError } from '../../../utils/errors';
 import { installExitHooks } from '../../../utils/exit';
 import { uniqBy } from '../../../utils/fn';
 import { parseBinaryPlistAsync } from '../../../utils/parseBinaryPlistAsync';
 
+const log = debug('expo:apple-device');
+
 /** @returns a list of connected Apple devices. */
 export async function getConnectedDevicesAsync(): Promise<AppleConnectedDevice[]> {
-  const devices = await Promise.all([
+  const [nativeResult, customResult] = await Promise.allSettled([
     // Prioritize native tools since they can provide more accurate information.
     // NOTE: xcrun is substantially slower than custom tooling. +1.5s vs 9ms.
+    // `devicectl` is macOS + Xcode only and gracefully resolves to [] elsewhere.
     getConnectedDevicesUsingNativeToolsAsync(),
     getConnectedDevicesUsingCustomToolingAsync(),
   ]);
 
-  return uniqBy(devices.flat(), (device) => device.udid);
+  const devices: AppleConnectedDevice[] = [];
+  if (nativeResult.status === 'fulfilled') {
+    devices.push(...nativeResult.value);
+  } else {
+    log('Failed to list Apple devices using native tools: %O', nativeResult.reason);
+  }
+
+  if (customResult.status === 'fulfilled') {
+    devices.push(...customResult.value);
+  } else {
+    // The usbmux-based custom tooling is the only cross-platform discovery path.
+    // If it failed because the helper service isn't running, surface a friendly
+    // error so the UI can guide the user to install the Apple helper software.
+    if (isUsbmuxdNotRunningError(customResult.reason)) {
+      throw createUsbmuxdNotRunningError();
+    }
+    // If the native tools also couldn't list anything, surface the original error.
+    if (nativeResult.status !== 'fulfilled') {
+      throw customResult.reason;
+    }
+    log('Failed to list Apple devices using custom tooling: %O', customResult.reason);
+  }
+
+  return uniqBy(devices, (device) => device.udid);
 }
 
 async function getConnectedDevicesUsingNativeToolsAsync(): Promise<AppleConnectedDevice[]> {
@@ -66,7 +97,9 @@ async function getConnectedDevicesUsingNativeToolsAsync(): Promise<AppleConnecte
 export async function getConnectedDevicesUsingCustomToolingAsync(): Promise<
   AppleConnectedDevice[]
 > {
-  const client = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+  // Establish the initial connection up front so a missing/stopped usbmux service
+  // rejects cleanly (as an InternalError) instead of crashing the protocol layer.
+  const client = new UsbmuxdClient(await connectUsbmuxdSocketAsync());
   try {
     const devices = await client.getDevices();
 
@@ -122,7 +155,17 @@ export async function runOnDevice({
   const clientManager = await ClientManager.create(udid);
 
   try {
-    await mountDeveloperDiskImage(clientManager);
+    // The developer disk image is only required to launch/debug the app, not to
+    // install it. It can only be mounted on macOS (it ships with Xcode), so on
+    // Windows/Linux this is best-effort: if it fails, we still install the app and
+    // the user launches it by tapping its icon on the device.
+    let ddiMounted = false;
+    try {
+      await mountDeveloperDiskImage(clientManager);
+      ddiMounted = true;
+    } catch (error) {
+      log('Could not mount the developer disk image, continuing install only: %O', error);
+    }
 
     const packageName = path.basename(appPath);
     const destPackagePath = path.join('PublicStaging', packageName);
@@ -160,7 +203,13 @@ export async function runOnDevice({
       [bundleId]: appInfo,
     } = await installer.lookupApp([bundleId]);
 
-    if (appInfo) {
+    if (appInfo && !ddiMounted) {
+      // Without the developer disk image we cannot start the debugserver, so the
+      // app can't be launched programmatically. Installation still succeeded.
+      console.log(
+        `App "${bundleId}" installed. Open it from the Home Screen on your device to launch it.`
+      );
+    } else if (appInfo) {
       // launch fails with EBusy or ENotFound if you try to launch immediately after install
       await delayAsync(200);
       const debugServerClient = await launchApp(clientManager, {

--- a/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/AppleDevice.ts
@@ -174,7 +174,7 @@ export async function runOnDevice({
     }
 
     const packageName = path.basename(appPath);
-    const destPackagePath = path.join('PublicStaging', packageName);
+    const destPackagePath = path.posix.join('PublicStaging', packageName);
 
     await uploadApp(clientManager, {
       appBinaryPath: appPath,

--- a/packages/eas-shared/src/run/ios/appleDevice/ClientManager.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/ClientManager.ts
@@ -5,6 +5,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import { InternalError } from 'common-types';
 import { Socket } from 'net';
 import { Duplex } from 'stream';
 import * as tls from 'tls';
@@ -16,6 +17,7 @@ import { LockdowndClient } from './client/LockdowndClient';
 import { MobileImageMounterClient } from './client/MobileImageMounterClient';
 import { ServiceClient } from './client/ServiceClient';
 import { UsbmuxdClient, UsbmuxdDevice, UsbmuxdPairRecord } from './client/UsbmuxdClient';
+import { connectUsbmuxdSocketAsync, isUsbmuxdNotRunningError } from './usbmuxd';
 import { CommandError } from '../../../utils/errors';
 
 export class ClientManager {
@@ -29,7 +31,9 @@ export class ClientManager {
   }
 
   static async create(udid?: string) {
-    const usbmuxClient = new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket());
+    // Connect up front so a missing/stopped usbmux service rejects cleanly with a
+    // friendly InternalError instead of crashing the protocol layer.
+    const usbmuxClient = new UsbmuxdClient(await connectUsbmuxdSocketAsync());
     try {
       const device = await usbmuxClient.getDevice(udid);
       const pairRecord = await usbmuxClient.readPairRecord(device.Properties.SerialNumber);
@@ -39,6 +43,20 @@ export class ClientManager {
       return new ClientManager(pairRecord, device, lockdownClient);
     } catch (error) {
       usbmuxClient.socket.end();
+      if (isUsbmuxdNotRunningError(error)) {
+        throw new InternalError(
+          'APPLE_DEVICE_USBMUXD_NOT_RUNNING',
+          'Lost connection to the Apple device service. Make sure the helper software is installed and running.'
+        );
+      }
+      // A missing/invalid pair record means the device hasn't been trusted yet.
+      const message = error instanceof Error ? error.message : String(error);
+      if (!(error instanceof InternalError) && /pair|InvalidHostID|trust/i.test(message)) {
+        throw new InternalError(
+          'APPLE_DEVICE_NOT_PAIRED',
+          'This iPhone is not paired with this computer. Unlock the device, connect it over USB, and tap "Trust" when prompted, then try again.'
+        );
+      }
       throw error;
     }
   }

--- a/packages/eas-shared/src/run/ios/appleDevice/__tests__/getConnectedDevicesAsync.test.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/__tests__/getConnectedDevicesAsync.test.ts
@@ -16,7 +16,9 @@ jest.mock('../../devicectl', () => ({
   getConnectedAppleDevicesAsync: jest.fn(() => Promise.resolve([])),
 }));
 
+// eslint-disable-next-line import/first -- imports must follow the jest.mock calls above.
 import { getConnectedDevicesAsync } from '../AppleDevice';
+// eslint-disable-next-line import/first
 import { createUsbmuxdNotRunningError } from '../usbmuxd';
 
 describe('getConnectedDevicesAsync', () => {

--- a/packages/eas-shared/src/run/ios/appleDevice/__tests__/getConnectedDevicesAsync.test.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/__tests__/getConnectedDevicesAsync.test.ts
@@ -1,0 +1,42 @@
+const mockConnectUsbmuxdSocketAsync = jest.fn();
+
+jest.mock('../usbmuxd', () => {
+  const actual = jest.requireActual('../usbmuxd');
+  return {
+    __esModule: true,
+    ...actual,
+    connectUsbmuxdSocketAsync: (...args: unknown[]) => mockConnectUsbmuxdSocketAsync(...args),
+  };
+});
+
+// Avoid loading the real devicectl module (it touches the filesystem at import
+// time) and make native discovery resolve to no devices, like on Linux/Windows.
+jest.mock('../../devicectl', () => ({
+  __esModule: true,
+  getConnectedAppleDevicesAsync: jest.fn(() => Promise.resolve([])),
+}));
+
+import { getConnectedDevicesAsync } from '../AppleDevice';
+import { createUsbmuxdNotRunningError } from '../usbmuxd';
+
+describe('getConnectedDevicesAsync', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('surfaces APPLE_DEVICE_USBMUXD_NOT_RUNNING even when native discovery returns no devices', async () => {
+    // Regression: the wrapped InternalError used to be swallowed because the
+    // native (devicectl) path fulfilled with [] on Linux/Windows.
+    mockConnectUsbmuxdSocketAsync.mockRejectedValueOnce(createUsbmuxdNotRunningError());
+
+    await expect(getConnectedDevicesAsync()).rejects.toMatchObject({
+      code: 'APPLE_DEVICE_USBMUXD_NOT_RUNNING',
+    });
+  });
+
+  it('swallows transient custom-tooling errors when native discovery succeeded', async () => {
+    mockConnectUsbmuxdSocketAsync.mockRejectedValueOnce(new Error('transient blip'));
+
+    await expect(getConnectedDevicesAsync()).resolves.toEqual([]);
+  });
+});

--- a/packages/eas-shared/src/run/ios/appleDevice/__tests__/usbmuxd.test.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/__tests__/usbmuxd.test.ts
@@ -20,10 +20,11 @@ function withPlatform(platform: NodeJS.Platform, fn: () => void) {
 }
 
 describe('getUsbmuxdHelperGuidance', () => {
-  it('points Windows users to the Apple Devices app', () => {
+  it('installs Apple Mobile Device Support on Windows via winget, with a manual fallback URL', () => {
     withPlatform('win32', () => {
       const guidance = getUsbmuxdHelperGuidance();
-      expect(guidance.label).toBe('Apple Devices');
+      expect(guidance.label).toBe('Apple Mobile Device Support');
+      expect(guidance.installCommand).toContain('Apple.AppleMobileDeviceSupport');
       expect(guidance.installUrl).toBeDefined();
     });
   });
@@ -82,7 +83,7 @@ describe('createUsbmuxdNotRunningError', () => {
       const error = createUsbmuxdNotRunningError();
       expect(error).toBeInstanceOf(InternalError);
       expect(error.code).toBe('APPLE_DEVICE_USBMUXD_NOT_RUNNING');
-      expect(error.details?.label).toBe('Apple Devices');
+      expect(error.details?.label).toBe('Apple Mobile Device Support');
       expect(error.details?.installUrl).toBeDefined();
     });
   });

--- a/packages/eas-shared/src/run/ios/appleDevice/__tests__/usbmuxd.test.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/__tests__/usbmuxd.test.ts
@@ -1,4 +1,5 @@
 import { InternalError } from 'common-types';
+import fs from 'fs';
 
 import {
   createUsbmuxdNotRunningError,
@@ -27,12 +28,27 @@ describe('getUsbmuxdHelperGuidance', () => {
     });
   });
 
-  it('points Linux users to usbmuxd via the package manager', () => {
+  it('points Linux users to usbmuxd via the package manager when not installed', () => {
+    const existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
     withPlatform('linux', () => {
       const guidance = getUsbmuxdHelperGuidance();
       expect(guidance.label).toBe('usbmuxd');
       expect(guidance.installCommand).toContain('usbmuxd');
+      expect(guidance.startCommand).toBeUndefined();
     });
+    existsSpy.mockRestore();
+  });
+
+  it('tells Linux users to start usbmuxd when it is already installed', () => {
+    const existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    withPlatform('linux', () => {
+      const guidance = getUsbmuxdHelperGuidance();
+      expect(guidance.label).toBe('usbmuxd');
+      expect(guidance.installCommand).toBeUndefined();
+      expect(guidance.startCommand).toContain('usbmuxd');
+      expect(guidance.description).toMatch(/not running/i);
+    });
+    existsSpy.mockRestore();
   });
 
   it('tells macOS users no extra software is required', () => {

--- a/packages/eas-shared/src/run/ios/appleDevice/__tests__/usbmuxd.test.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/__tests__/usbmuxd.test.ts
@@ -1,0 +1,73 @@
+import { InternalError } from 'common-types';
+
+import {
+  createUsbmuxdNotRunningError,
+  getUsbmuxdHelperGuidance,
+  isUsbmuxdNotRunningError,
+} from '../usbmuxd';
+
+function withPlatform(platform: NodeJS.Platform, fn: () => void) {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original);
+    }
+  }
+}
+
+describe('getUsbmuxdHelperGuidance', () => {
+  it('points Windows users to the Apple Devices app', () => {
+    withPlatform('win32', () => {
+      const guidance = getUsbmuxdHelperGuidance();
+      expect(guidance.label).toBe('Apple Devices');
+      expect(guidance.installUrl).toBeDefined();
+    });
+  });
+
+  it('points Linux users to usbmuxd via the package manager', () => {
+    withPlatform('linux', () => {
+      const guidance = getUsbmuxdHelperGuidance();
+      expect(guidance.label).toBe('usbmuxd');
+      expect(guidance.installCommand).toContain('usbmuxd');
+    });
+  });
+
+  it('tells macOS users no extra software is required', () => {
+    withPlatform('darwin', () => {
+      const guidance = getUsbmuxdHelperGuidance();
+      expect(guidance.installUrl).toBeUndefined();
+      expect(guidance.installCommand).toBeUndefined();
+    });
+  });
+});
+
+describe('isUsbmuxdNotRunningError', () => {
+  it.each(['ECONNREFUSED', 'ENOENT', 'ECONNRESET', 'EPIPE'])(
+    'treats %s as a not-running error',
+    (code) => {
+      expect(isUsbmuxdNotRunningError({ code })).toBe(true);
+    }
+  );
+
+  it('ignores unrelated errors', () => {
+    expect(isUsbmuxdNotRunningError({ code: 'ETIMEDOUT' })).toBe(false);
+    expect(isUsbmuxdNotRunningError(new Error('boom'))).toBe(false);
+    expect(isUsbmuxdNotRunningError(null)).toBe(false);
+    expect(isUsbmuxdNotRunningError(undefined)).toBe(false);
+  });
+});
+
+describe('createUsbmuxdNotRunningError', () => {
+  it('builds an InternalError carrying install guidance in details', () => {
+    withPlatform('win32', () => {
+      const error = createUsbmuxdNotRunningError();
+      expect(error).toBeInstanceOf(InternalError);
+      expect(error.code).toBe('APPLE_DEVICE_USBMUXD_NOT_RUNNING');
+      expect(error.details?.label).toBe('Apple Devices');
+      expect(error.details?.installUrl).toBeDefined();
+    });
+  });
+});

--- a/packages/eas-shared/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/AFCClient.ts
@@ -150,7 +150,8 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
       const promises: Promise<void>[] = [];
       for (const file of fs.readdirSync(dirPath)) {
         const filePath = path.join(dirPath, file);
-        const remotePath = path.join(destPath, path.relative(srcPath, filePath));
+        const relativePosix = path.relative(srcPath, filePath).split(path.sep).join('/');
+        const remotePath = path.posix.join(destPath, relativePosix);
         if (fs.lstatSync(filePath).isDirectory()) {
           promises.push(_this.makeDirectory(remotePath).then(() => uploadDir(filePath)));
         } else {

--- a/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import spawnAsync from '@expo/spawn-async';
 import { InternalError } from 'common-types';
 import Debug from 'debug';
 import fs from 'fs';
@@ -170,6 +171,28 @@ export function connectUsbmuxdSocketAsync(timeoutMs = 5000): Promise<Socket> {
     socket.once('connect', onConnect);
     socket.once('error', onError);
   });
+}
+
+/**
+ * Whether any USB device with Apple's vendor ID (0x05AC) is currently attached.
+ * Windows only — used to avoid pestering the user about installing the Apple
+ * Mobile Device Service when no iPhone is plugged in to use it with.
+ */
+export async function isAppleUsbDeviceConnectedAsync(): Promise<boolean> {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+  try {
+    const { stdout } = await spawnAsync('powershell', [
+      '-NoProfile',
+      '-Command',
+      "Get-PnpDevice -PresentOnly -Status OK | Where-Object { $_.InstanceId -like 'USB\\VID_05AC*' } | Select-Object -First 1 -ExpandProperty InstanceId",
+    ]);
+    return stdout.trim().length > 0;
+  } catch (error) {
+    debug('Apple USB device check failed: %O', error);
+    return false;
+  }
 }
 
 /** Lightweight check used by doctor/UX flows — never throws. */

--- a/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
@@ -54,11 +54,13 @@ export function getUsbmuxdHelperGuidance(): UsbmuxdHelperGuidance {
   switch (process.platform) {
     case 'win32':
       return {
-        label: 'Apple Devices',
+        label: 'Apple Mobile Device Support',
         description:
-          'To connect to an iPhone over USB on Windows, install the Apple Devices app (or iTunes). It includes the Apple USB drivers and the Apple Mobile Device Service.',
+          'To connect to an iPhone over USB on Windows, Orbit can install Apple Mobile Device Support — the official Apple USB driver and device service. No Apple account or full iTunes install is required.',
+        // Manual fallback if winget isn't available: the Apple Devices app on the
+        // Microsoft Store also bundles Apple Mobile Device Support.
         installUrl: 'https://apps.microsoft.com/detail/9np83lwlpz9k',
-        installCommand: 'winget install --id Apple.AppleDevices -e',
+        installCommand: 'winget install --id Apple.AppleMobileDeviceSupport -e',
       };
     case 'linux':
       // usbmuxd is socket/udev-activated: it only runs while an Apple device is

--- a/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
@@ -6,6 +6,7 @@
  */
 import { InternalError } from 'common-types';
 import Debug from 'debug';
+import fs from 'fs';
 import { Socket } from 'net';
 
 import { UsbmuxdClient } from './client/UsbmuxdClient';
@@ -26,11 +27,28 @@ export type UsbmuxdHelperGuidance = {
   installUrl?: string;
   /** Optional shell command that installs the helper software. */
   installCommand?: string;
+  /** Optional shell command that starts the (already installed) helper service. */
+  startCommand?: string;
 };
 
+// Known locations of the usbmuxd daemon binary on Linux.
+const LINUX_USBMUXD_BINARY_PATHS = [
+  '/usr/sbin/usbmuxd',
+  '/usr/local/sbin/usbmuxd',
+  '/sbin/usbmuxd',
+  '/usr/bin/usbmuxd',
+  '/bin/usbmuxd',
+];
+
+/** Whether the usbmuxd daemon binary is installed (Linux only). */
+export function isUsbmuxdInstalled(): boolean {
+  return LINUX_USBMUXD_BINARY_PATHS.some((binaryPath) => fs.existsSync(binaryPath));
+}
+
 /**
- * Per-platform guidance for installing the helper software required to talk to a
- * physical iPhone over USB. None of this requires an Apple account.
+ * Per-platform guidance for getting the helper software required to talk to a
+ * physical iPhone over USB into a working state. None of this requires an Apple
+ * account.
  */
 export function getUsbmuxdHelperGuidance(): UsbmuxdHelperGuidance {
   switch (process.platform) {
@@ -43,12 +61,22 @@ export function getUsbmuxdHelperGuidance(): UsbmuxdHelperGuidance {
         installCommand: 'winget install --id Apple.AppleDevices -e',
       };
     case 'linux':
-      return {
-        label: 'usbmuxd',
-        description:
-          'To connect to an iPhone over USB on Linux, install the usbmuxd daemon from the libimobiledevice project.',
-        installCommand: 'sudo apt-get install -y usbmuxd',
-      };
+      // usbmuxd is socket/udev-activated: it only runs while an Apple device is
+      // attached and exits afterwards. If the binary is present but unreachable,
+      // it just needs starting — telling the user to reinstall would be wrong.
+      return isUsbmuxdInstalled()
+        ? {
+            label: 'usbmuxd',
+            description:
+              'usbmuxd is installed but not running. Connect and unlock your iPhone and tap "Trust" — usbmuxd starts automatically when a device is attached. If it still does not appear, run `sudo systemctl start usbmuxd`.',
+            startCommand: 'sudo systemctl start usbmuxd',
+          }
+        : {
+            label: 'usbmuxd',
+            description:
+              'To connect to an iPhone over USB on Linux, install the usbmuxd daemon from the libimobiledevice project.',
+            installCommand: 'sudo apt-get install -y usbmuxd',
+          };
     default:
       return {
         label: 'Apple Mobile Device Service',
@@ -73,6 +101,9 @@ export function createUsbmuxdNotRunningError(): InternalError {
   }
   if (guidance.installCommand) {
     details.installCommand = guidance.installCommand;
+  }
+  if (guidance.startCommand) {
+    details.startCommand = guidance.startCommand;
   }
   return new InternalError('APPLE_DEVICE_USBMUXD_NOT_RUNNING', guidance.description, details);
 }

--- a/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
@@ -56,7 +56,7 @@ export function getUsbmuxdHelperGuidance(): UsbmuxdHelperGuidance {
       return {
         label: 'Apple Mobile Device Support',
         description:
-          'To connect to an iPhone over USB on Windows, Orbit can install Apple Mobile Device Support — the official Apple USB driver and device service. No Apple account or full iTunes install is required.',
+          'To connect to an iPhone over USB on Windows, Orbit requires Apple Mobile Device Support.',
         // Manual fallback if winget isn't available: the Apple Devices app on the
         // Microsoft Store also bundles Apple Mobile Device Support.
         installUrl: 'https://apps.microsoft.com/detail/9np83lwlpz9k',
@@ -70,7 +70,7 @@ export function getUsbmuxdHelperGuidance(): UsbmuxdHelperGuidance {
         ? {
             label: 'usbmuxd',
             description:
-              'usbmuxd is installed but not running. Connect and unlock your iPhone and tap "Trust" — usbmuxd starts automatically when a device is attached. If it still does not appear, run `sudo systemctl start usbmuxd`.',
+              'usbmuxd is installed but not running. Connect and unlock your iPhone and tap "Trust". Usbmuxd should start automatically when a device is attached. If it still does not appear, run `sudo systemctl start usbmuxd`.',
             startCommand: 'sudo systemctl start usbmuxd',
           }
         : {

--- a/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/usbmuxd.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright © 2024 650 Industries.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import { InternalError } from 'common-types';
+import Debug from 'debug';
+import { Socket } from 'net';
+
+import { UsbmuxdClient } from './client/UsbmuxdClient';
+
+const debug = Debug('expo:apple-device:usbmuxd');
+
+// Socket/connection error codes that indicate the usbmux service (the Apple
+// Mobile Device Service on Windows, or the usbmuxd daemon on macOS/Linux) is not
+// installed or not running.
+const NOT_RUNNING_SOCKET_ERROR_CODES = ['ECONNREFUSED', 'ENOENT', 'ECONNRESET', 'EPIPE'];
+
+export type UsbmuxdHelperGuidance = {
+  /** Short, human-readable name of the helper software. */
+  label: string;
+  /** User-facing explanation of what to install and why. */
+  description: string;
+  /** Optional URL to open so the user can install the helper software. */
+  installUrl?: string;
+  /** Optional shell command that installs the helper software. */
+  installCommand?: string;
+};
+
+/**
+ * Per-platform guidance for installing the helper software required to talk to a
+ * physical iPhone over USB. None of this requires an Apple account.
+ */
+export function getUsbmuxdHelperGuidance(): UsbmuxdHelperGuidance {
+  switch (process.platform) {
+    case 'win32':
+      return {
+        label: 'Apple Devices',
+        description:
+          'To connect to an iPhone over USB on Windows, install the Apple Devices app (or iTunes). It includes the Apple USB drivers and the Apple Mobile Device Service.',
+        installUrl: 'https://apps.microsoft.com/detail/9np83lwlpz9k',
+        installCommand: 'winget install --id Apple.AppleDevices -e',
+      };
+    case 'linux':
+      return {
+        label: 'usbmuxd',
+        description:
+          'To connect to an iPhone over USB on Linux, install the usbmuxd daemon from the libimobiledevice project.',
+        installCommand: 'sudo apt-get install -y usbmuxd',
+      };
+    default:
+      return {
+        label: 'Apple Mobile Device Service',
+        description:
+          'usbmuxd ships with macOS, so no additional software is required. Make sure your iPhone is unlocked and that you have tapped "Trust" on it.',
+      };
+  }
+}
+
+/** Whether a socket/connection error indicates the usbmux service is not reachable. */
+export function isUsbmuxdNotRunningError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code;
+  return typeof code === 'string' && NOT_RUNNING_SOCKET_ERROR_CODES.includes(code);
+}
+
+/** Build the InternalError surfaced to the CLI/menu-bar when the service is down. */
+export function createUsbmuxdNotRunningError(): InternalError {
+  const guidance = getUsbmuxdHelperGuidance();
+  const details: Record<string, string> = { label: guidance.label };
+  if (guidance.installUrl) {
+    details.installUrl = guidance.installUrl;
+  }
+  if (guidance.installCommand) {
+    details.installCommand = guidance.installCommand;
+  }
+  return new InternalError('APPLE_DEVICE_USBMUXD_NOT_RUNNING', guidance.description, details);
+}
+
+/**
+ * Connect to the usbmux socket (the Apple Mobile Device Service on Windows, or the
+ * usbmuxd daemon socket on macOS/Linux), resolving only once the connection is
+ * established. Rejects with a friendly InternalError when the service is not
+ * running so callers can guide the user to install the helper software.
+ *
+ * Using this instead of the raw, synchronous `connectUsbmuxdSocket()` for the
+ * initial connection avoids an uncaught exception: the protocol layer's `error`
+ * handler throws, so a connection that fails after a `sendMessage` call would
+ * otherwise crash the process instead of rejecting a promise.
+ */
+export function connectUsbmuxdSocketAsync(timeoutMs = 5000): Promise<Socket> {
+  return new Promise<Socket>((resolve, reject) => {
+    const socket = UsbmuxdClient.connectUsbmuxdSocket();
+    let settled = false;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.removeListener('connect', onConnect);
+      socket.removeListener('error', onError);
+    };
+    const onConnect = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(socket);
+    };
+    const onError = (error: NodeJS.ErrnoException) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      try {
+        socket.destroy();
+      } catch {}
+      if (isUsbmuxdNotRunningError(error)) {
+        debug('usbmux service not reachable: %O', error);
+        reject(createUsbmuxdNotRunningError());
+      } else {
+        reject(error);
+      }
+    };
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      try {
+        socket.destroy();
+      } catch {}
+      reject(createUsbmuxdNotRunningError());
+    }, timeoutMs);
+
+    socket.once('connect', onConnect);
+    socket.once('error', onError);
+  });
+}
+
+/** Lightweight check used by doctor/UX flows — never throws. */
+export async function isUsbmuxdAvailableAsync(): Promise<boolean> {
+  try {
+    const socket = await connectUsbmuxdSocketAsync(2000);
+    socket.end();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/eas-shared/src/run/ios/device.ts
+++ b/packages/eas-shared/src/run/ios/device.ts
@@ -7,6 +7,7 @@ import {
   checkIfAppIsInstalled,
 } from './appleDevice/AppleDevice';
 import { getAppDeltaDirectory, installOnDeviceAsync } from './appleDevice/installOnDeviceAsync';
+import { getUsbmuxdHelperGuidance, isUsbmuxdAvailableAsync } from './appleDevice/usbmuxd';
 import { installOnMacOSAsync, launchOnMacOSAsync } from './macOS';
 
 const AppleDevice = {
@@ -20,6 +21,8 @@ const AppleDevice = {
   checkIfAppIsInstalled,
   installOnMacOSAsync,
   launchOnMacOSAsync,
+  isUsbmuxdAvailableAsync,
+  getUsbmuxdHelperGuidance,
 };
 
 export default AppleDevice;

--- a/packages/eas-shared/src/run/ios/device.ts
+++ b/packages/eas-shared/src/run/ios/device.ts
@@ -7,7 +7,11 @@ import {
   checkIfAppIsInstalled,
 } from './appleDevice/AppleDevice';
 import { getAppDeltaDirectory, installOnDeviceAsync } from './appleDevice/installOnDeviceAsync';
-import { getUsbmuxdHelperGuidance, isUsbmuxdAvailableAsync } from './appleDevice/usbmuxd';
+import {
+  getUsbmuxdHelperGuidance,
+  isAppleUsbDeviceConnectedAsync,
+  isUsbmuxdAvailableAsync,
+} from './appleDevice/usbmuxd';
 import { installOnMacOSAsync, launchOnMacOSAsync } from './macOS';
 
 const AppleDevice = {
@@ -23,6 +27,7 @@ const AppleDevice = {
   launchOnMacOSAsync,
   isUsbmuxdAvailableAsync,
   getUsbmuxdHelperGuidance,
+  isAppleUsbDeviceConnectedAsync,
 };
 
 export default AppleDevice;

--- a/packages/eas-shared/src/run/ios/systemRequirements.ts
+++ b/packages/eas-shared/src/run/ios/systemRequirements.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { InternalError } from 'common-types';
 import semver from 'semver';
 
+import { createUsbmuxdNotRunningError, isUsbmuxdAvailableAsync } from './appleDevice/usbmuxd';
 import { getSimulatorAppIdAsync } from './simulator';
 import { KNOWN_SIMULATOR_APP_IDS } from './simulatorApp';
 import * as xcode from './xcode';
@@ -77,4 +78,16 @@ export async function validateSystemRequirementsAsync(): Promise<void> {
   await assertCorrectXcodeVersionInstalledAsync();
   await ensureXcrunInstalledAsync();
   await assertSimulatorAppInstalledAsync();
+}
+
+/**
+ * Requirements for installing apps on a physical Apple device. Unlike the
+ * simulator requirements above, this is cross-platform (macOS, Windows, Linux)
+ * and does not depend on Xcode — it only needs the usbmux helper service to be
+ * reachable.
+ */
+export async function validateAppleDeviceRequirementsAsync(): Promise<void> {
+  if (!(await isUsbmuxdAvailableAsync())) {
+    throw createUsbmuxdNotRunningError();
+  }
 }

--- a/packages/eas-shared/tsconfig.json
+++ b/packages/eas-shared/tsconfig.json
@@ -18,5 +18,6 @@
     "target": "ES2022",
     "typeRoots": ["../../ts-declarations", "src/ts-declarations", "./node_modules/@types"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["**/__mocks__/*", "**/__tests__/*"]
 }


### PR DESCRIPTION
# Why

We should asupport installing apps in physical iPhones, not only in macOS but also in Windows and Linux
 

# How

This PR adds cross-platform physical-device support by leveraging usbmux and Apple Mobile Device Service:

-  `eas-shared` now talks to the usbmux socket on all three OSes. macOS already ships `usbmuxd`; Linux activates it via socket/udev when a device is attached; Windows needs the Apple Mobile Device Service installed separately.
- Added an iPhone row to the onboarding checklist on Windows. Clicking the warning icon opens an alert with a one-click "Install" button that runs `winget install --id Apple.AppleMobileDeviceSupport`, falls back to the Microsoft Store page if winget isn't available, then re-runs the checks so the row flips to a green check.  
- Show an "install Apple Mobile Device Support" button on the menu-bar if the user opens Orbit with an iPhone plugged in.(PowerShell `Get-PnpDevice` filtered by Apple's USB vendor id `05AC`).  
- Updated Settings to enable iOS by default on Windows and Linux

**Adjacent fixes:**
- `tar` extraction on Windows handles the busybox quirks that broke unpacking builds.
- IPA opening on Linux now picks a sensible default rather than failing.
- Fix Electron `Alert` custom onPress function 

# Test Plan

- [x] **macOS:** existing physical-iPhone flow still works (install, launch, no onboarding regression).
- [x] **Windows, no iPhone plugged in:** open Orbit, popover shows no "install Apple Mobile Device Support" prompt. Onboarding pre-flight still shows the row with a warning.
- [x] **Windows, iPhone plugged in, no Apple Mobile Device Support installed:** popover surfaces the install prompt. Onboarding row's warning icon opens an alert with an "Install Apple Mobile Device Support" button; clicking it kicks off winget, shows a spinner, and the row flips to a check on success.
- [x] **Windows with winget unavailable:** install button falls back to opening the Microsoft Store page.
- [x] **Linux:** plug in an iPhone, confirm device shows up. With `usbmuxd` stopped, error message tells the user to start it (not to reinstall).   
