### PR TITLE
[cli] Fix error message for launching updates on iOS physical devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix error message when launching updates on iOS physical devices. ([#348](https://github.com/expo/orbit/pull/348) by [@patrickwehbe](https://github.com/patrickwehbe))
+
 ### 💡 Others
 
 - Add cross-platform E2E testing with WebdriverIO for Electron and Appium mac2 for macOS. ([#334](https://github.com/expo/orbit/pull/334) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/apps/cli/src/commands/LaunchUpdate.ts
+++ b/apps/cli/src/commands/LaunchUpdate.ts
@@ -148,7 +148,7 @@ async function launchUpdateOnIOSAsync(
 ) {
   const isSimulator = await Simulator.isSimulatorAsync(deviceId);
   if (!isSimulator) {
-    throw new Error('Launching updates on iOS physical is not supported yet');
+    throw new Error('Launching updates on iOS physical devices is not supported yet');
   }
 
   await downloadAndInstallLatestDevBuildAsync({


### PR DESCRIPTION
# Why

The error thrown when launching an update on an iOS physical device is missing a word. In `launchUpdateOnIOSAsync` it currently reads:

> Launching updates on iOS physical is not supported yet

The equivalent guard in `launchUpdateOnExpoGoIosAsync` (same file, line 115) already has the correct wording:

> Launching updates on iOS physical devices is not supported yet

Both run the same `!isSimulator` check, so the two messages should match.

# How

Added the missing word "devices" to the error string on line 151 of `apps/cli/src/commands/LaunchUpdate.ts` so it matches its sibling on line 115. Also added a changelog entry under the Unpublished bug fixes section.

# Test Plan

This is a one-word change to a string literal inside an existing `throw new Error(...)`. The two error messages in the file are now identical, which can be confirmed by searching the file for "Launching updates on iOS physical" and seeing both lines read the same.
