### PR TITLE
[cli] Lazy-load command modules to speed up CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add cross-platform E2E testing with WebdriverIO for Electron and Appium mac2 for macOS. ([#334](https://github.com/expo/orbit/pull/334) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix flaky onboarding E2E test by switching off the closed onboarding window instead of querying it. ([#349](https://github.com/expo/orbit/pull/349) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Speed up the macOS E2E workflow by caching CocoaPods. ([#349](https://github.com/expo/orbit/pull/349) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Speed up CLI commands by lazy-loading command modules and listing devices in parallel. ([#351](https://github.com/expo/orbit/pull/351) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 2.7.0 — 2026-06-14
 

--- a/apps/cli/src/commands/ListDevices.ts
+++ b/apps/cli/src/commands/ListDevices.ts
@@ -14,102 +14,120 @@ export async function listDevicesAsync<P extends Platform>({
     watchos: { devices: [], error: undefined },
   };
 
-  if (platform === Platform.Ios || platform === Platform.All) {
-    // Physical Apple device discovery is cross-platform
-    try {
-      const connectedDevices = await AppleDevice.getConnectedDevicesAsync();
-      for (const connectedDevice of connectedDevices) {
-        if (!result.ios.devices.some(({ udid }) => udid === connectedDevice.udid)) {
-          result.ios.devices.push(connectedDevice);
+  const listIos = platform === Platform.Ios || platform === Platform.All;
+  const listAndroid = platform === Platform.Android || platform === Platform.All;
+  const tasks: Promise<void>[] = [];
+
+  // List devices for each platform in parallel to improve performance.
+  if (listIos) {
+    tasks.push(
+      (async () => {
+        try {
+          const connectedDevices = await AppleDevice.getConnectedDevicesAsync();
+          for (const connectedDevice of connectedDevices) {
+            if (!result.ios.devices.some(({ udid }) => udid === connectedDevice.udid)) {
+              result.ios.devices.push(connectedDevice);
+            }
+          }
+        } catch (error) {
+          console.warn('Unable to get connected Apple devices', error);
+          if (error instanceof Error) {
+            const code = error instanceof InternalError ? error.code : 'UNKNOWN_ERROR';
+            // Only show the error on Windows when an iPhone is plugged in.
+            const suppress =
+              process.platform === 'win32' &&
+              code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING' &&
+              !(await AppleDevice.isAppleUsbDeviceConnectedAsync());
+            if (!suppress) {
+              result.ios.error = {
+                code,
+                message: error.message,
+                // Surface install guidance so the menu bar can offer an assist action.
+                helper:
+                  code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING'
+                    ? (() => {
+                        const { description: _description, ...helper } =
+                          AppleDevice.getUsbmuxdHelperGuidance();
+                        return helper;
+                      })()
+                    : undefined,
+              };
+            }
+          }
         }
-      }
-    } catch (error) {
-      console.warn('Unable to get connected Apple devices', error);
-      if (error instanceof Error) {
-        const code = error instanceof InternalError ? error.code : 'UNKNOWN_ERROR';
-        // Only show the error on Windows when an iPhone is plugged in.
-        const suppress =
-          process.platform === 'win32' &&
-          code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING' &&
-          !(await AppleDevice.isAppleUsbDeviceConnectedAsync());
-        if (!suppress) {
-          result.ios.error = {
-            code,
-            message: error.message,
-            // Surface install guidance so the menu bar can offer an assist action.
-            helper:
-              code === 'APPLE_DEVICE_USBMUXD_NOT_RUNNING'
-                ? (() => {
-                    const { description: _description, ...helper } =
-                      AppleDevice.getUsbmuxdHelperGuidance();
-                    return helper;
-                  })()
-                : undefined,
-          };
-        }
-      }
-    }
+      })()
+    );
 
     // Simulators are only supported on macOS
     if (process.platform === 'darwin') {
-      try {
-        const simulators = await Simulator.getAvailableAppleSimulatorsListAsync();
-        for (const simulator of simulators) {
-          if (simulator.osType === 'watchOS') {
-            result.watchos.devices.push(simulator);
-          } else if (simulator.osType === 'tvOS') {
-            result.tvos.devices.push(simulator);
-          } else {
-            result.ios.devices.push(simulator);
+      tasks.push(
+        (async () => {
+          try {
+            const simulators = await Simulator.getAvailableAppleSimulatorsListAsync();
+            for (const simulator of simulators) {
+              if (simulator.osType === 'watchOS') {
+                result.watchos.devices.push(simulator);
+              } else if (simulator.osType === 'tvOS') {
+                result.tvos.devices.push(simulator);
+              } else {
+                result.ios.devices.push(simulator);
+              }
+            }
+          } catch (error) {
+            console.warn('Unable to get Apple simulators', error);
+            if (error instanceof Error) {
+              const errorInfo = {
+                code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
+                message: error.message,
+              };
+              result.ios.error = result.ios.error ?? errorInfo;
+              result.tvos.error = errorInfo;
+              result.watchos.error = errorInfo;
+            }
+          }
+        })()
+      );
+    }
+  }
+
+  if (listAndroid) {
+    tasks.push(
+      (async () => {
+        try {
+          const runningDevices = await Emulator.getRunningDevicesAsync();
+
+          result.android.devices = result.android.devices.concat(
+            runningDevices.filter((r) => r.deviceType === 'device')
+          );
+
+          const androidEmulators = (
+            (await Emulator.getAvailableAndroidEmulatorsAsync()) || []
+          )?.map((emulator) => {
+            const runningEmulator = runningDevices.find(
+              (r) => r.deviceType === 'emulator' && r.name === emulator.name
+            );
+            return {
+              ...emulator,
+              state: runningEmulator ? 'Booted' : 'Shutdown',
+              pid: runningEmulator?.pid,
+            } as Devices.AndroidEmulator;
+          });
+
+          result.android.devices = result.android.devices.concat(androidEmulators);
+        } catch (error) {
+          console.warn('Unable to get Android devices', error);
+          if (error instanceof Error) {
+            result.android.error = {
+              code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
+              message: error.message,
+            };
           }
         }
-      } catch (error) {
-        console.warn('Unable to get Apple simulators', error);
-        if (error instanceof Error) {
-          const errorInfo = {
-            code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
-            message: error.message,
-          };
-          result.ios.error = result.ios.error ?? errorInfo;
-          result.tvos.error = errorInfo;
-          result.watchos.error = errorInfo;
-        }
-      }
-    }
+      })()
+    );
   }
 
-  if (platform === Platform.Android || platform === Platform.All) {
-    try {
-      const runningDevices = await Emulator.getRunningDevicesAsync();
-
-      result.android.devices = result.android.devices.concat(
-        runningDevices.filter((r) => r.deviceType === 'device')
-      );
-
-      const androidEmulators = ((await Emulator.getAvailableAndroidEmulatorsAsync()) || [])?.map(
-        (emulator) => {
-          const runningEmulator = runningDevices.find(
-            (r) => r.deviceType === 'emulator' && r.name === emulator.name
-          );
-          return {
-            ...emulator,
-            state: runningEmulator ? 'Booted' : 'Shutdown',
-            pid: runningEmulator?.pid,
-          } as Devices.AndroidEmulator;
-        }
-      );
-
-      result.android.devices = result.android.devices.concat(androidEmulators);
-    } catch (error) {
-      console.warn('Unable to get Android devices', error);
-      if (error instanceof Error) {
-        result.android.error = {
-          code: error instanceof InternalError ? error.code : 'UNKNOWN_ERROR',
-          message: error.message,
-        };
-      }
-    }
-  }
+  await Promise.all(tasks);
 
   return result;
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,15 +1,9 @@
 import { Command } from 'commander';
 
 import { returnLoggerMiddleware } from './utils';
-import { downloadBuildAsync } from './commands/DownloadBuild';
-import { listDevicesAsync } from './commands/ListDevices';
-import { bootDeviceAsync } from './commands/BootDevice';
-import { installAndLaunchAppAsync } from './commands/InstallAndLaunchApp';
-import { installAppleDeviceSupportAsync } from './commands/InstallAppleDeviceSupport';
-import { launchExpoGoURLAsync } from './commands/LaunchExpoGo';
-import { checkToolsAsync } from './commands/CheckTools';
-import { setSessionAsync } from './commands/SetSession';
-import { detectAppleAppTypeAsync } from './commands/DetectAppleAppType';
+// Command modules that pull in `eas-shared`/GraphQL are loaded lazily inside their actions so a
+// single invocation only pays the import cost of the command actually being run. Keep light
+// modules (TrustedSources) eager since the validator middleware is needed up front.
 import {
   getCustomTrustedSourcesAsync,
   setCustomTrustedSourcesAsync,
@@ -25,26 +19,38 @@ program
 program
   .command('download-build')
   .argument('<string>', 'Build URL')
-  .action(returnLoggerMiddleware(trustedSourcesValidatorMiddleware(downloadBuildAsync)));
+  .action(async (...args) => {
+    const { downloadBuildAsync } = await import('./commands/DownloadBuild');
+    return returnLoggerMiddleware(trustedSourcesValidatorMiddleware(downloadBuildAsync))(...args);
+  });
 
 program
   .command('list-devices')
   .option('-p, --platform <string>', 'Selected platform', 'all')
-  .action(returnLoggerMiddleware(listDevicesAsync));
+  .action(async (...args) => {
+    const { listDevicesAsync } = await import('./commands/ListDevices');
+    return returnLoggerMiddleware(listDevicesAsync)(...args);
+  });
 
 program
   .command('boot-device')
   .requiredOption('-p, --platform <string>', 'Selected platform')
   .requiredOption('--id  <string>', 'UDID or name of the device')
   .option('--no-audio', 'Launch Android emulator without audio')
-  .action(returnLoggerMiddleware(bootDeviceAsync));
+  .action(async (...args) => {
+    const { bootDeviceAsync } = await import('./commands/BootDevice');
+    return returnLoggerMiddleware(bootDeviceAsync)(...args);
+  });
 
 program
   .command('install-and-launch')
   .requiredOption('--app-path  <string>', 'Local path of the app')
   .option('--device-id  <string>', 'UDID or name of the device')
   .option('--launch-url  <string>', 'URL to open on the device after installing the app')
-  .action(returnLoggerMiddleware(installAndLaunchAppAsync));
+  .action(async (...args) => {
+    const { installAndLaunchAppAsync } = await import('./commands/InstallAndLaunchApp');
+    return returnLoggerMiddleware(installAndLaunchAppAsync)(...args);
+  });
 
 program
   .command('launch-expo-go')
@@ -55,17 +61,26 @@ program
     '--sdk-version  <string>',
     'Version of the Expo SDK that should be used by Expo Go. E.g. 52.0.0'
   )
-  .action(returnLoggerMiddleware(trustedSourcesValidatorMiddleware(launchExpoGoURLAsync)));
+  .action(async (...args) => {
+    const { launchExpoGoURLAsync } = await import('./commands/LaunchExpoGo');
+    return returnLoggerMiddleware(trustedSourcesValidatorMiddleware(launchExpoGoURLAsync))(...args);
+  });
 
 program
   .command('install-apple-device-support')
   .description('Install the helper software required to connect to a physical iPhone over USB')
-  .action(returnLoggerMiddleware(installAppleDeviceSupportAsync));
+  .action(async (...args) => {
+    const { installAppleDeviceSupportAsync } = await import('./commands/InstallAppleDeviceSupport');
+    return returnLoggerMiddleware(installAppleDeviceSupportAsync)(...args);
+  });
 
 program
   .command('check-tools')
   .option('-p, --platform <string>', 'Selected platform')
-  .action(returnLoggerMiddleware(checkToolsAsync));
+  .action(async (...args) => {
+    const { checkToolsAsync } = await import('./commands/CheckTools');
+    return returnLoggerMiddleware(checkToolsAsync)(...args);
+  });
 
 program
   .command('launch-update')
@@ -76,18 +91,24 @@ program
   .option('--force-expo-go', 'Force update to be launched using Expo Go')
   .action(async (...args) => {
     const { launchUpdateAsync } = await import('./commands/LaunchUpdate');
-    returnLoggerMiddleware(trustedSourcesValidatorMiddleware(launchUpdateAsync))(...args);
+    return returnLoggerMiddleware(trustedSourcesValidatorMiddleware(launchUpdateAsync))(...args);
   });
 
 program
   .command('set-session')
   .argument('<string>', 'Session secret')
-  .action(returnLoggerMiddleware(setSessionAsync));
+  .action(async (...args) => {
+    const { setSessionAsync } = await import('./commands/SetSession');
+    return returnLoggerMiddleware(setSessionAsync)(...args);
+  });
 
 program
   .command('detect-apple-app-type')
   .argument('<string>', 'Local path of the app')
-  .action(returnLoggerMiddleware(detectAppleAppTypeAsync));
+  .action(async (...args) => {
+    const { detectAppleAppTypeAsync } = await import('./commands/DetectAppleAppType');
+    return returnLoggerMiddleware(detectAppleAppTypeAsync)(...args);
+  });
 
 program
   .command('get-custom-trusted-sources')

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -1,13 +1,20 @@
 import { InternalError } from 'common-types';
 import { Platform } from 'common-types/build/cli-commands';
-import { Env } from 'eas-shared';
 import util from 'util';
+
+// Intentionally avoid importing `Env` from `eas-shared` here: that package is a barrel that pulls
+// in the entire device/build toolchain. Since this module is loaded on every CLI invocation, a
+// local check keeps startup cheap for commands that don't otherwise need `eas-shared`.
+function isMenuBar(): boolean {
+  const value = process.env.EXPO_MENU_BAR?.toLowerCase();
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
 
 export function returnLoggerMiddleware(fn: (...args: any[]) => any | Promise<any>) {
   return async function (...args: any[]) {
     try {
       const result = await fn(...args);
-      if (Env.isMenuBar()) {
+      if (isMenuBar()) {
         console.log('---- return output ----');
         if (typeof result === 'string') {
           console.log(result);


### PR DESCRIPTION
# Why

Each menu bar action spawns a fresh CLI process, so CLI startup cost is paid on every interaction (and `list-devices` runs on launch and on every popover focus). Two avoidable costs were making this slower than it needs to be:

1. `index.ts` eagerly imported every command module up front. Because `eas-shared` is a barrel that pulls in the entire device/build toolchain, even a trivial command loaded the download, launch and GraphQL code paths it never used.
2. `list-devices` discovered Apple physical devices, Apple simulators and Android devices sequentially, even though they hit completely independent tooling.

# How

- Parallelize `list-devices` command:  The three independent device scans now run concurrently via `Promise.all`. This is safe because each task writes disjoint slices of `result` (physical and simulator udids never collide)
- Lazy-load command modules: The `eas-shared`/GraphQL heavy commands are now loaded with dynamic `import()` inside their actions (matching the pattern `launch-update` already used)

# Test Plan

Verified `list-devices -p all` returns identical output before and after the parallelization. Benchmarks captured with a small harness running each command N times and reporting wall-clock percentiles (`p50`, in ms).

CLI startup (`--help`, loads the import graph then exits before any command work):

| artifact | before | after | speedup |
| --- | --- | --- | --- |
| `node build/index.js` | 174 | 44 | ~4x |
| archived `pkg` binary (shipped) | 154 | 55 | ~2.8x |

`list-devices -p all` (n=15):

| version | mean | p50 |
| --- | --- | --- |
| sequential | ~2003 | ~1981 |
| parallel | ~1179 | ~1150 |

About 40% faster (~820 ms saved). The win comes from the Apple path: `-p ios` alone is ~1992 ms (physical discovery ~0.9s plus `simctl list` ~1.05s, run back to back) while `-p android` is ~191 ms, so running all scans concurrently collapses `-p all` to roughly the single slowest scan.
