### PR TITLE
[cli][menu-bar] Allow installing iOS device builds on simulators

### DIFF
--- a/apps/cli/src/commands/InstallAndLaunchApp.ts
+++ b/apps/cli/src/commands/InstallAndLaunchApp.ts
@@ -6,6 +6,7 @@ import {
   detectAppleAppType,
 } from 'eas-shared';
 import { Platform } from 'common-types/build/cli-commands';
+import { InternalError } from 'common-types';
 
 import { getPlatformFromURI } from '../utils';
 
@@ -13,6 +14,7 @@ type InstallAndLaunchAppAsyncOptions = {
   appPath: string;
   deviceId?: string;
   launchUrl?: string;
+  forceSimulator?: boolean;
 };
 
 export async function installAndLaunchAppAsync(options: InstallAndLaunchAppAsyncOptions) {
@@ -28,11 +30,21 @@ export async function installAndLaunchAppAsync(options: InstallAndLaunchAppAsync
   const platform = getPlatformFromURI(appPath);
 
   return platform === Platform.Ios
-    ? installAndLaunchIOSAppAsync(appPath, options.deviceId, options.launchUrl)
+    ? installAndLaunchIOSAppAsync(
+        appPath,
+        options.deviceId,
+        options.launchUrl,
+        options.forceSimulator
+      )
     : installAndLaunchAndroidAppAsync(appPath, options.deviceId, options.launchUrl);
 }
 
-async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string, launchURL?: string) {
+async function installAndLaunchIOSAppAsync(
+  appPath: string,
+  deviceId: string,
+  launchURL?: string,
+  forceSimulator?: boolean
+) {
   const appInfo = await detectAppleAppType(appPath);
 
   // Simulators only exist on macOS, and `isSimulatorAsync` shells out to `simctl`
@@ -40,14 +52,21 @@ async function installAndLaunchIOSAppAsync(appPath: string, deviceId: string, la
   const isSimulator = process.platform === 'darwin' && (await Simulator.isSimulatorAsync(deviceId));
 
   if (isSimulator) {
+    let simulatorAppPath = appPath;
     if (appInfo.deviceType === 'device') {
-      throw new Error(
-        "Apps built to target physical devices can't be installed on simulators. Either use a physical device or generate a new simulator build."
-      );
+      if (!forceSimulator) {
+        throw new InternalError(
+          'DEVICE_BUILD_ON_SIMULATOR',
+          "Apps built to target physical devices can't be installed on simulators. Either use a physical device or generate a new simulator build."
+        );
+      }
+      // Experimental: re-tag and re-sign the device build so it can run on the
+      // simulator. The conversion works on a copy, leaving the original intact.
+      simulatorAppPath = await Simulator.convertDeviceAppToSimulatorAsync(appPath);
     }
 
-    const bundleIdentifier = await Simulator.getAppBundleIdentifierAsync(appPath);
-    await Simulator.installAppAsync(deviceId, appPath);
+    const bundleIdentifier = await Simulator.getAppBundleIdentifierAsync(simulatorAppPath);
+    await Simulator.installAppAsync(deviceId, simulatorAppPath);
 
     if (launchURL) {
       try {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -44,6 +44,10 @@ program
   .requiredOption('--app-path  <string>', 'Local path of the app')
   .option('--device-id  <string>', 'UDID or name of the device')
   .option('--launch-url  <string>', 'URL to open on the device after installing the app')
+  .option(
+    '--force-simulator',
+    'Re-tag and re-sign an iOS device build so it can run on a simulator (experimental)'
+  )
   .action(returnLoggerMiddleware(installAndLaunchAppAsync));
 
 program

--- a/apps/menu-bar/src/commands/installAndLaunchAppAsync.ts
+++ b/apps/menu-bar/src/commands/installAndLaunchAppAsync.ts
@@ -4,12 +4,14 @@ type InstallAndLaunchAppAsyncOptions = {
   appPath: string;
   deviceId?: string;
   launchURL?: string;
+  forceSimulator?: boolean;
 };
 
 export const installAndLaunchAppAsync = async ({
   appPath,
   deviceId,
   launchURL,
+  forceSimulator,
 }: InstallAndLaunchAppAsyncOptions) => {
   const args = ['--app-path', appPath];
   if (deviceId) {
@@ -17,6 +19,9 @@ export const installAndLaunchAppAsync = async ({
   }
   if (launchURL) {
     args.push('--launch-url', launchURL);
+  }
+  if (forceSimulator) {
+    args.push('--force-simulator');
   }
   await MenuBarModule.runCli('install-and-launch', args, undefined);
 };

--- a/apps/menu-bar/src/popover/Core.tsx
+++ b/apps/menu-bar/src/popover/Core.tsx
@@ -530,10 +530,16 @@ function Core(props: Props) {
         let device: PlatformToDevice<typeof devicePlatform> | undefined;
         if (deviceId) {
           const requested = findDeviceById(deviceId);
+          // Honor an explicitly-selected iOS simulator for a device build: the
+          // install path will offer to re-tag it to run on the simulator.
+          const explicitSimulatorForDeviceBuild =
+            devicePlatform === 'ios' &&
+            appType === 'device' &&
+            requested?.deviceType === 'simulator';
           if (
             !requested ||
             getDeviceOS(requested) !== devicePlatform ||
-            (appType && requested.deviceType !== appType)
+            (appType && requested.deviceType !== appType && !explicitSimulatorForDeviceBuild)
           ) {
             warnDeviceIdNotFound(deviceId);
           } else {
@@ -582,6 +588,26 @@ function Core(props: Props) {
                 error.message,
                 'Confirm that this is an internal distribution build and that your device was provisioned to use this build.'
               );
+            } else if (error.code === 'DEVICE_BUILD_ON_SIMULATOR') {
+              const shouldConvert = await new Promise<boolean>((resolve) => {
+                Alert.alert(
+                  'This is a device build',
+                  'This app was built for physical devices. Orbit can try to re-tag and re-sign it to run on the simulator.\n\nThis is experimental and the app may crash on launch.',
+                  [
+                    { text: 'Cancel', style: 'cancel', onPress: () => resolve(false) },
+                    { text: 'Try anyway', style: 'default', onPress: () => resolve(true) },
+                  ]
+                );
+              });
+              if (shouldConvert) {
+                updateTask({ id: appURI, status: MenuBarStatus.INSTALLING_APP });
+                await installAndLaunchAppAsync({
+                  appPath: localFilePath,
+                  deviceId: resolvedDeviceId,
+                  launchURL,
+                  forceSimulator: true,
+                });
+              }
             }
           } else {
             throw error;

--- a/packages/common-types/src/InternalError.ts
+++ b/packages/common-types/src/InternalError.ts
@@ -37,7 +37,8 @@ export type InternalErrorCode =
   | 'SIMCTL_NOT_AVAILABLE'
   | 'NO_DEVELOPMENT_BUILDS_AVAILABLE'
   | 'UNAUTHORIZED_ACCOUNT'
-  | 'UNTRUSTED_SOURCE';
+  | 'UNTRUSTED_SOURCE'
+  | 'DEVICE_BUILD_ON_SIMULATOR';
 
 export type MultipleAppsInTarballErrorDetails = {
   apps: {

--- a/packages/eas-shared/src/run/ios/convertAppToSimulator.ts
+++ b/packages/eas-shared/src/run/ios/convertAppToSimulator.ts
@@ -1,0 +1,223 @@
+import spawnAsync from '@expo/spawn-async';
+import { randomUUID } from 'crypto';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+import Log from '../../log';
+
+// PLATFORM_IOSSIMULATOR from <mach-o/loader.h>. Device builds are tagged
+// PLATFORM_IOS (2); the simulator runtime only accepts (7).
+const PLATFORM_IOSSIMULATOR = '7';
+
+// Mach-O / fat magic numbers, read big-endian from the first 4 bytes on disk.
+const MACH_O_MAGICS = new Set([
+  0xfeedface, // MH_MAGIC (32-bit, BE)
+  0xfeedfacf, // MH_MAGIC_64 (64-bit, BE)
+  0xcefaedfe, // MH_CIGAM (32-bit, LE)
+  0xcffaedfe, // MH_CIGAM_64 (64-bit, LE)
+  0xcafebabe, // FAT_MAGIC
+  0xbebafeca, // FAT_CIGAM
+]);
+const FAT_MAGICS = new Set([0xcafebabe, 0xbebafeca]);
+
+async function readMagicAsync(filePath: string): Promise<number | null> {
+  let fd: fs.promises.FileHandle | undefined;
+  try {
+    fd = await fs.promises.open(filePath, 'r');
+    const buffer = Buffer.alloc(4);
+    const { bytesRead } = await fd.read(buffer, 0, 4, 0);
+    return bytesRead === 4 ? buffer.readUInt32BE(0) : null;
+  } catch {
+    return null;
+  } finally {
+    await fd?.close();
+  }
+}
+
+/**
+ * Recursively yields regular files inside `dir`, without following symlinks
+ * (framework version symlinks would otherwise cause duplicate work).
+ */
+async function* walkFilesAsync(dir: string): AsyncGenerator<string> {
+  const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      yield* walkFilesAsync(fullPath);
+    } else if (entry.isFile()) {
+      yield fullPath;
+    }
+  }
+}
+
+async function getMinOsAndSdkAsync(machoPath: string): Promise<{ minos: string; sdk: string }> {
+  try {
+    const { stdout } = await spawnAsync('vtool', ['-show-build', machoPath]);
+    const minos = stdout.match(/minos\s+([\d.]+)/)?.[1];
+    const sdk = stdout.match(/sdk\s+([\d.]+)/)?.[1];
+    return { minos: minos ?? '13.0', sdk: sdk ?? minos ?? '13.0' };
+  } catch {
+    return { minos: '13.0', sdk: '13.0' };
+  }
+}
+
+async function isFairPlayEncryptedAsync(machoPath: string): Promise<boolean> {
+  try {
+    const { stdout } = await spawnAsync('otool', ['-l', machoPath]);
+    // A cryptid of 1 means the binary is FairPlay-encrypted (App Store build).
+    return /LC_ENCRYPTION_INFO[\s\S]*?cryptid 1\b/.test(stdout);
+  } catch {
+    return false;
+  }
+}
+
+async function retagMachoAsync(machoPath: string, appPath: string): Promise<void> {
+  const magic = await readMagicAsync(machoPath);
+  if (magic === null || !MACH_O_MAGICS.has(magic)) {
+    return;
+  }
+
+  // Apple Silicon simulators run the arm64 slice; drop any other slices so the
+  // re-tagged binary matches what the simulator can load.
+  if (FAT_MAGICS.has(magic)) {
+    const thinned = `${machoPath}.__thin`;
+    try {
+      await spawnAsync('lipo', [machoPath, '-thin', 'arm64', '-output', thinned]);
+      await fs.move(thinned, machoPath, { overwrite: true });
+    } catch {
+      await fs.remove(thinned).catch(() => {});
+    }
+  }
+
+  const { minos, sdk } = await getMinOsAndSdkAsync(machoPath);
+  const retagged = `${machoPath}.__retagged`;
+  try {
+    await spawnAsync('vtool', [
+      '-set-build-version',
+      PLATFORM_IOSSIMULATOR,
+      minos,
+      sdk,
+      '-replace',
+      '-output',
+      retagged,
+      machoPath,
+    ]);
+    await fs.move(retagged, machoPath, { overwrite: true });
+    Log.debug(`Re-tagged ${path.relative(appPath, machoPath)} -> iOS-Simulator`);
+  } catch (error: any) {
+    await fs.remove(retagged).catch(() => {});
+    throw new Error(
+      `Failed to re-tag ${path.relative(appPath, machoPath)} for the simulator: ${error.message}`
+    );
+  }
+}
+
+async function codesignAsync(target: string): Promise<void> {
+  await spawnAsync('codesign', ['--force', '--sign', '-', '--timestamp=none', target]);
+}
+
+/**
+ * Re-tags an iOS *device* `.app` so it can be installed and launched on the
+ * iOS Simulator, then re-signs it ad-hoc. Works on a copy so the original
+ * (cached) device build is left untouched for physical-device installs.
+ *
+ * This is a best-effort, experimental conversion: it clears the install-time
+ * platform/signature gates, but an app that links device-only frameworks may
+ * still crash on launch. App Store (FairPlay-encrypted) builds cannot be
+ * converted and are rejected.
+ *
+ * @returns the path to the converted `.app` bundle.
+ */
+export async function convertDeviceAppToSimulatorAsync(appPath: string): Promise<string> {
+  if (process.platform !== 'darwin') {
+    throw new Error('Converting device builds to run on the simulator is only supported on macOS.');
+  }
+
+  Log.newLine();
+  Log.log('Converting device build to run on the simulator (experimental)...');
+
+  const workDir = path.join(os.tmpdir(), 'orbit-sim-convert', randomUUID());
+  await fs.mkdirp(workDir);
+  const convertedAppPath = path.join(workDir, path.basename(appPath));
+  await fs.copy(appPath, convertedAppPath, { dereference: false });
+
+  const infoPlistPath = path.join(convertedAppPath, 'Info.plist');
+  const { stdout: mainExecutable } = await spawnAsync('/usr/libexec/PlistBuddy', [
+    '-c',
+    'Print :CFBundleExecutable',
+    infoPlistPath,
+  ]);
+  const mainExecutablePath = path.join(convertedAppPath, mainExecutable.trim());
+
+  if (await isFairPlayEncryptedAsync(mainExecutablePath)) {
+    await fs.remove(workDir).catch(() => {});
+    throw new Error(
+      'This is a FairPlay-encrypted App Store build, which cannot run on the simulator. Use a build made with the simulator SDK instead.'
+    );
+  }
+
+  // 1. Re-tag every Mach-O binary in the bundle.
+  for await (const filePath of walkFilesAsync(convertedAppPath)) {
+    await retagMachoAsync(filePath, convertedAppPath);
+  }
+
+  // 2. Update the Info.plist metadata so it matches the re-tagged binaries.
+  await spawnAsync('plutil', [
+    '-replace',
+    'DTPlatformName',
+    '-string',
+    'iphonesimulator',
+    infoPlistPath,
+  ]).catch(() => {});
+  await spawnAsync('plutil', [
+    '-replace',
+    'CFBundleSupportedPlatforms',
+    '-json',
+    '["iPhoneSimulator"]',
+    infoPlistPath,
+  ]).catch(() => {});
+
+  // 3. Re-sign ad-hoc, inner-out: nested code first (deepest paths), then the
+  //    app bundle itself, which seals everything signed above. `codesign
+  //    --deep` is unreliable on large bundles, so we sign explicitly.
+  const nestedCode: string[] = [];
+  for await (const filePath of walkFilesAsync(convertedAppPath)) {
+    if (filePath.endsWith('.dylib')) {
+      nestedCode.push(filePath);
+    }
+  }
+  const collectDirs = async (dir: string): Promise<void> => {
+    for (const entry of await fs.promises.readdir(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.isSymbolicLink()) {
+        continue;
+      }
+      const fullPath = path.join(dir, entry.name);
+      if (
+        fullPath !== convertedAppPath &&
+        (fullPath.endsWith('.framework') ||
+          fullPath.endsWith('.appex') ||
+          fullPath.endsWith('.app'))
+      ) {
+        nestedCode.push(fullPath);
+      }
+      await collectDirs(fullPath);
+    }
+  };
+  await collectDirs(convertedAppPath);
+
+  // Sign deepest paths first so containers seal already-signed contents.
+  nestedCode.sort((a, b) => b.split(path.sep).length - a.split(path.sep).length);
+  for (const target of nestedCode) {
+    await codesignAsync(target).catch((error) =>
+      Log.debug(`codesign failed for ${path.relative(convertedAppPath, target)}: ${error.message}`)
+    );
+  }
+  await codesignAsync(convertedAppPath);
+
+  Log.succeed('Converted the device build to run on the simulator.');
+  return convertedAppPath;
+}

--- a/packages/eas-shared/src/run/ios/simulator.ts
+++ b/packages/eas-shared/src/run/ios/simulator.ts
@@ -21,6 +21,8 @@ import { parseBinaryPlistAsync } from '../../utils/parseBinaryPlistAsync';
 import { sleepAsync } from '../../utils/promise';
 import * as Versions from '../../versions';
 
+export { convertDeviceAppToSimulatorAsync } from './convertAppToSimulator';
+
 const INSTALL_WARNING_TIMEOUT = 60 * 1000;
 const SIMCTL_INSTALL_MAX_RETRIES = 3;
 const SIMCTL_INSTALL_RETRY_DELAY_MS = 2000;


### PR DESCRIPTION
Adds an experimental, opt-in conversion that re-tags and re-signs an iOS device build so it can run on the simulator, instead of dead-ending with an error.

- eas-shared: convertAppToSimulatorAsync re-tags every Mach-O's build-version platform to iOS-Simulator (thinning fat slices to arm64), updates the Info.plist, and re-signs ad-hoc inner-out. Operates on a copy so the cached device build stays intact for physical-device installs. Rejects FairPlay (App Store) builds, and is macOS-only.
- cli: install-and-launch gains --force-simulator. Without it, a device build targeting a simulator now throws a typed DEVICE_BUILD_ON_SIMULATOR error.
- menu-bar: honors an explicit simulator selection for a device build and, on the DEVICE_BUILD_ON_SIMULATOR error, prompts the user to attempt the conversion before re-installing with --force-simulator.

# Why

<!-- 
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests. 
-->

# How

<!-- 
How did you build this feature or fix this bug and why? 
-->

# Test Plan

<!-- 
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction. 
-->
