### PR TITLE
[menu-bar][electron] Fix Android code pairing input width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Android code pairing input width on Windows and Linux. ([#357](https://github.com/expo/orbit/pull/357) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 2.8.0 — 2026-06-24

--- a/apps/menu-bar/src/components/PairAndroidDeviceForm.tsx
+++ b/apps/menu-bar/src/components/PairAndroidDeviceForm.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TextInput as RNTextInput,
   TouchableOpacity,
+  Platform,
 } from 'react-native';
 
 import Button from './Button';
@@ -495,6 +496,11 @@ const styles = StyleSheet.create({
   },
   codeBox: {
     flex: 1,
+    ...Platform.select({
+      web: {
+        minWidth: 0,
+      },
+    }),
     paddingVertical: 13,
     textAlign: 'center',
     textAlignVertical: 'center',


### PR DESCRIPTION
# Why

Closes https://github.com/expo/orbit/issues/356

# How
 
On Electron the `TextInput` renders as a DOM <input>, which has an intrinsic minimum width. Flex items don't shrink below their min-content width unless you set minWidth: 0, so your 6 boxes overflow the container and only the centered ones are visible. Native RN has no such intrinsic min-width, so it looks fine there.

# Test Plan

Test Android Wifi pairing via code on macOS and Electron
