### PR TITLE
[auth] refactor: auth to use default browser

### DIFF
--- a/apps/menu-bar/modules/web-authentication-session/electron/main.ts
+++ b/apps/menu-bar/modules/web-authentication-session/electron/main.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow } from 'electron';
+import { app, shell } from 'electron';
 
 import {
   WebBrowserResult,
@@ -7,61 +7,32 @@ import {
 } from '../src/WebAuthenticationSession.types';
 
 async function openAuthSessionAsync(urlString: string): Promise<WebBrowserResult> {
-  const window = new BrowserWindow({
-    width: 860,
-    height: 740,
-  });
-  window.menuBarVisible = false;
-  window.loadURL(urlString);
+  await shell.openExternal(urlString);
 
-  return new Promise((resolve, reject) => {
-    let resolved = false;
-
-    function completeWithSuccess(resultUrl: string) {
-      if (resolved) return;
-      resolved = true;
-      window.close();
-      resolve({ type: WebBrowserResultType.SUCCESS, url: resultUrl });
+  return new Promise((resolve) => {
+    function cleanup() {
+      app.removeListener('open-url', handleOpenUrl);
+      app.removeListener('second-instance', handleSecondInstance);
     }
 
-    function handleRedirect(
-      event: Electron.Event<
-        Electron.WebContentsWillRedirectEventParams | Electron.WebContentsWillNavigateEventParams
-      >
-    ) {
-      if (event.isSameDocument) {
-        return;
-      }
-
-      const redirectProtocol = new URL(event.url).protocol;
-      if (redirectProtocol === 'https:' || redirectProtocol === 'http:') {
-        return;
-      }
-
-      event.preventDefault();
-      completeWithSuccess(event.url);
+    function handleOpenUrl(_event: Electron.Event, url: string) {
+      const protocol = new URL(url).protocol;
+      if (protocol === 'https:' || protocol === 'http:') return;
+      cleanup();
+      resolve({ type: WebBrowserResultType.SUCCESS, url });
     }
 
-    window.webContents.on('will-redirect', handleRedirect);
-    window.webContents.on('will-navigate', handleRedirect);
+    function handleSecondInstance(_event: Electron.Event, argv: string[]) {
+      const url = argv[argv.length - 1];
+      if (!url || !url.includes('://')) return;
+      const protocol = new URL(url).protocol;
+      if (protocol === 'https:' || protocol === 'http:') return;
+      cleanup();
+      resolve({ type: WebBrowserResultType.SUCCESS, url });
+    }
 
-    // Allow OAuth provider popups (e.g. Google sign-in) and monitor them for redirects
-    window.webContents.setWindowOpenHandler(() => ({ action: 'allow' }));
-    window.webContents.on('did-create-window', (childWindow) => {
-      childWindow.webContents.on('will-redirect', handleRedirect);
-      childWindow.webContents.on('will-navigate', handleRedirect);
-    });
-
-    window.on('closed', () => {
-      if (!resolved) {
-        resolved = true;
-        resolve({ type: WebBrowserResultType.CANCEL });
-      }
-    });
-
-    window.webContents.on('render-process-gone', (event, details) => {
-      reject(new Error(details.reason));
-    });
+    app.on('open-url', handleOpenUrl);
+    app.on('second-instance', handleSecondInstance);
   });
 }
 

--- a/apps/menu-bar/modules/web-authentication-session/src/WebAuthenticationSessionModule.ts
+++ b/apps/menu-bar/modules/web-authentication-session/src/WebAuthenticationSessionModule.ts
@@ -1,7 +1,24 @@
-import { openAuthSessionAsync as expoOpenAuthSessionAsync } from 'expo-web-browser';
+import { Linking } from 'react-native';
 
-import { WebAuthenticationSessionModuleType } from './WebAuthenticationSession.types';
+import {
+  WebAuthenticationSessionModuleType,
+  WebBrowserResult,
+  WebBrowserResultType,
+} from './WebAuthenticationSession.types';
+
+async function openAuthSessionAsync(url: string): Promise<WebBrowserResult> {
+  await Linking.openURL(url);
+
+  return new Promise((resolve) => {
+    const subscription = Linking.addEventListener('url', ({ url: callbackUrl }) => {
+      const protocol = new URL(callbackUrl).protocol;
+      if (protocol === 'https:' || protocol === 'http:') return;
+      subscription.remove();
+      resolve({ type: WebBrowserResultType.SUCCESS, url: callbackUrl });
+    });
+  });
+}
 
 export default {
-  openAuthSessionAsync: (url: string) => expoOpenAuthSessionAsync(url, 'expo-orbit:///'),
+  openAuthSessionAsync,
 } as WebAuthenticationSessionModuleType;

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -163,7 +163,7 @@ const Settings = () => {
     const authSessionURL = `${
       Config.website.origin
     }/${type}?confirm_account=1&app_redirect_uri=${encodeURIComponent(redirectBase)}`;
-    console.log('handleAuthentication')
+
     const result = await openAuthSessionAsync(authSessionURL);
 
     if (result.type === WebBrowserResultType.SUCCESS) {

--- a/apps/menu-bar/src/windows/Settings.tsx
+++ b/apps/menu-bar/src/windows/Settings.tsx
@@ -163,6 +163,7 @@ const Settings = () => {
     const authSessionURL = `${
       Config.website.origin
     }/${type}?confirm_account=1&app_redirect_uri=${encodeURIComponent(redirectBase)}`;
+    console.log('handleAuthentication')
     const result = await openAuthSessionAsync(authSessionURL);
 
     if (result.type === WebBrowserResultType.SUCCESS) {


### PR DESCRIPTION
## Why
I was trying to login but the BrowserWindow window function of electron use always Safari, but my default browser is Arc.
Maybe be this is a common issue with mac users.

## How

I replaced the browser approach with `Linking.openURL()`... still working on it

## Test Plan

1. build and run the app
2. open Settings and trigger the login flow
3. verify the auth URL opens in your default browser (not Safari / an embedded window)
4. complete sign-in in the browser
5. verify the app receives the callback and completes login successfully