### PR TITLE
[eas-shared] Fix formatBytes returning wrong values for sizes >= 102.4 GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix Android code pairing input width on Windows and Linux. ([#357](https://github.com/expo/orbit/pull/357) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Fix `formatBytes` returning values off by a factor of 1024² for sizes of at least 102.4 GB. ([#NNN](https://github.com/expo/orbit/pull/NNN) by [@YuriNachos](https://github.com/YuriNachos))
+- Fix `formatBytes` returning values off by a factor of 1024² for sizes of at least 102.4 GB. ([#363](https://github.com/expo/orbit/pull/363) by [@YuriNachos](https://github.com/YuriNachos))
 
 ### 💡 Others
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix Android code pairing input width on Windows and Linux. ([#357](https://github.com/expo/orbit/pull/357) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix `formatBytes` returning values off by a factor of 1024² for sizes of at least 102.4 GB. ([#NNN](https://github.com/expo/orbit/pull/NNN) by [@YuriNachos](https://github.com/YuriNachos))
 
 ### 💡 Others
 

--- a/packages/eas-shared/src/__tests__/files.test.ts
+++ b/packages/eas-shared/src/__tests__/files.test.ts
@@ -1,0 +1,16 @@
+import { formatBytes } from '../files';
+
+describe('formatBytes', () => {
+  it.each([
+    { bytes: 0, expected: '0' },
+    { bytes: 1, expected: '1 B' },
+    { bytes: 1024, expected: '1.0 KB' },
+    { bytes: 1048576, expected: '1.0 MB' },
+    { bytes: 200 * 1024 * 1024, expected: '200 MB' },
+    { bytes: 50 * 1024 ** 3, expected: '50.0 GB' },
+    { bytes: 200 * 1024 ** 3, expected: '200 GB' },
+    { bytes: 1024 ** 4, expected: '1024 GB' },
+  ])('formats $bytes bytes as $expected', ({ bytes, expected }) => {
+    expect(formatBytes(bytes)).toBe(expected);
+  });
+});

--- a/packages/eas-shared/src/files.ts
+++ b/packages/eas-shared/src/files.ts
@@ -24,5 +24,5 @@ export function formatBytes(bytes: number): string {
   if (bytes < 102.4 * multiplier) {
     return `${(bytes / multiplier).toFixed(1)} GB`;
   }
-  return `${Math.floor(bytes / 1024)} GB`;
+  return `${Math.floor(bytes / multiplier)} GB`;
 }


### PR DESCRIPTION
## Summary

`formatBytes` returned wrong values for sizes ≥ 102.4 GB. The final GB fallback divided by the literal `1024` instead of `multiplier` (which is `1024**3` in that branch), so `formatBytes(200 GB)` returned `"209715200 GB"` instead of `"200 GB"`. Every other tier correctly divides by `multiplier`; only the GB fallback was wrong.

## Fix

One expression: `bytes / 1024` → `bytes / multiplier`, mirroring the MB fallback on the line above verbatim.

## Test

New `files.test.ts` with 8 cases spanning B / KB / MB / GB (incl. the 200 GB bug reproducer and a 1024 GB boundary). `yarn test` (eas-shared) — **20 passed, 0 failed**.

---

Authored by `@YuriNachos`. Implementation written by a `cccc` (Claude Code, GLM-5.2) worker under orchestrator acceptance — gate green (20 passed).
