### PR TITLE
[eas-shared] Fix NO_RESOURCES retry counter and open-file slot leak in AFCClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix Android code pairing input width on Windows and Linux. ([#357](https://github.com/expo/orbit/pull/357) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fix NO_RESOURCES retry counter and open-file slot leak in AFCClient. ([#366](https://github.com/expo/orbit/pull/366) by [@YuriNachos](https://github.com/YuriNachos))
 
 ### 💡 Others
 

--- a/packages/eas-shared/src/run/ios/appleDevice/__tests__/AFCClient.test.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/__tests__/AFCClient.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { AFCClient } from '../client/AFCClient';
+import { AFC_STATUS, AFCError } from '../protocol/AFCProtocol';
+
+// The constructor builds a real AFCProtocolClient that subscribes to socket
+// 'data' events. We never push any data, so a minimal fake socket is enough to
+// construct the client; all behaviour is driven through mocked instance methods.
+function createClient(): AFCClient {
+  const fakeSocket: any = { on: jest.fn(), write: jest.fn() };
+  return new AFCClient(fakeSocket);
+}
+
+describe('AFCClient.uploadDirectory', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'afc-upload-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  it('retries a persistent NO_RESOURCES a bounded number of times, then fails the upload', async () => {
+    // Regression: the retry used to recurse with `uploadFile(tries++)`, which
+    // passes the *old* value, so the counter never advanced and a persistent
+    // NO_RESOURCES retried forever. It must stop after MAX_UPLOAD_RETRIES
+    // retries and surface the error.
+    fs.writeFileSync(path.join(tmpDir, 'starved.txt'), 'a');
+    fs.writeFileSync(path.join(tmpDir, 'healthy.txt'), 'b');
+
+    const client = createClient();
+    const noResources = new AFCError('NO_RESOURCES', AFC_STATUS.NO_RESOURCES);
+
+    jest.spyOn(client, 'makeDirectory').mockResolvedValue(undefined as any);
+    const uploadFile = jest
+      .spyOn(client as any, 'uploadFile')
+      .mockImplementation((filePath: unknown) => {
+        // `starved.txt` never recovers; `healthy.txt` uploads fine.
+        return path.basename(String(filePath)) === 'starved.txt'
+          ? Promise.reject(noResources)
+          : Promise.resolve();
+      });
+
+    await expect(client.uploadDirectory(tmpDir, '/remote/dir')).rejects.toBe(noResources);
+
+    // Initial attempt + MAX_UPLOAD_RETRIES (= 10) retries, then give up.
+    const starvedCalls = uploadFile.mock.calls.filter(
+      ([p]) => path.basename(String(p)) === 'starved.txt'
+    );
+    expect(starvedCalls.length).toBe(1 + 10);
+  });
+
+  it('retries a transient NO_RESOURCES and then succeeds', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'only.txt'), 'x');
+
+    const client = createClient();
+    const noResources = new AFCError('NO_RESOURCES', AFC_STATUS.NO_RESOURCES);
+
+    jest.spyOn(client, 'makeDirectory').mockResolvedValue(undefined as any);
+    let attempts = 0;
+    jest.spyOn(client as any, 'uploadFile').mockImplementation(() => {
+      attempts++;
+      // Fails twice, then the resource frees up and it succeeds.
+      return attempts < 3 ? Promise.reject(noResources) : Promise.resolve();
+    });
+
+    await expect(client.uploadDirectory(tmpDir, '/remote/dir')).resolves.toBeUndefined();
+    expect(attempts).toBe(3);
+  });
+
+  it('still aborts the whole upload for non-resource errors', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'bad.txt'), 'x');
+    fs.writeFileSync(path.join(tmpDir, 'good.txt'), 'y');
+
+    const client = createClient();
+    const fatal = new AFCError('READ_ERROR', AFC_STATUS.READ_ERROR);
+
+    jest.spyOn(client, 'makeDirectory').mockResolvedValue(undefined as any);
+    jest.spyOn(client as any, 'uploadFile').mockImplementation((filePath: unknown) => {
+      return path.basename(String(filePath)) === 'bad.txt'
+        ? Promise.reject(fatal)
+        : Promise.resolve();
+    });
+
+    // Only NO_RESOURCES is retried; other failures still reject.
+    await expect(client.uploadDirectory(tmpDir, '/remote/dir')).rejects.toBe(fatal);
+  });
+});

--- a/packages/eas-shared/src/run/ios/appleDevice/client/AFCClient.ts
+++ b/packages/eas-shared/src/run/ios/appleDevice/client/AFCClient.ts
@@ -24,6 +24,9 @@ import {
 
 const debug = Debug('expo:apple-device:client:afc');
 const MAX_OPEN_FILES = 240;
+// How many times a single file upload is retried after a transient
+// AFC_STATUS.NO_RESOURCES before the error is surfaced. Tunable.
+const MAX_UPLOAD_RETRIES = 10;
 
 export class AFCClient extends ServiceClient<AFCProtocolClient> {
   constructor(public override socket: Socket) {
@@ -181,9 +184,16 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
               .catch((err: AFCError) => {
                 // Couldn't get fd for whatever reason, try again
                 // # of retries is arbitrary and can be adjusted
-                if (err.status === AFC_STATUS.NO_RESOURCES && tries < 10) {
-                  debug(`Received NO_RESOURCES from AFC, retrying ${filePath} upload. ${tries}`);
-                  uploadFile(tries++);
+                if (err.status === AFC_STATUS.NO_RESOURCES && tries < MAX_UPLOAD_RETRIES) {
+                  debug(
+                    `Received NO_RESOURCES from AFC, retrying ${filePath} upload (try ${
+                      tries + 1
+                    }/${MAX_UPLOAD_RETRIES}).`
+                  );
+                  // Release the slot this attempt held and re-acquire it in the
+                  // recursive call, so retries don't leak against MAX_OPEN_FILES.
+                  numOpenFiles--;
+                  uploadFile(tries + 1);
                 } else {
                   numOpenFiles--;
                   reject(err);


### PR DESCRIPTION
## Summary

Fixes two bugs in the `NO_RESOURCES` retry path of `AFCClient.uploadDirectory`:

- **Retry counter never advanced.** The retry recursed with `uploadFile(tries++)`, and the postfix increment passes the *pre-increment* value into the recursive call. `tries` therefore stayed `0` on every recursion, so `tries < 10` never became false and a persistent `NO_RESOURCES` retried the same file forever instead of giving up after 10 attempts. It now passes `tries + 1`.
- **Open-file slot leaked on every retry.** The retry path re-entered `uploadFile` without releasing the current attempt's `numOpenFiles` slot, so each retry permanently leaked one slot against the `MAX_OPEN_FILES` (240) cap and degraded upload concurrency for the rest of the run. The slot is now released before the recursive call, which re-acquires it (net-neutral).

## Behaviour

Unchanged beyond the fixes: when retries are exhausted — or the error is not `NO_RESOURCES` — the file's promise still rejects and `Promise.all` still aborts the directory upload. The retry count stays 10 (now named `MAX_UPLOAD_RETRIES`).

## Test plan

- `yarn test` in `packages/eas-shared` — adds `AFCClient.test.ts` covering: a persistent `NO_RESOURCES` is retried exactly 10 times and then fails the upload (regression for the counter bug), a transient `NO_RESOURCES` succeeds on retry, and non-`NO_RESOURCES` errors still abort the upload.
- `yarn typecheck` and `yarn lint` pass.