### PR TITLE
[menu-bar] Add workflow to publish releases to WinGet

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,26 @@
+name: Publish to WinGet
+
+# Opens a PR on microsoft/winget-pkgs whenever a GitHub release is published.
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏷️ Get version from tag
+        id: version
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: echo "version=${TAG#expo-orbit-v}" >> "$GITHUB_OUTPUT"
+
+      - name: 🚀 Publish Expo.Orbit to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Expo.Orbit
+          version: ${{ steps.version.outputs.version }}
+          installers-regex: '\.Setup\.exe$'
+          fork-user: expo
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
# Why

Now that Orbit ships a signed Windows installer, we can publish to the [Windows Package Manager Community Repository](https://github.com/microsoft/winget-pkgs), which lets users install and upgrade with `winget install Expo.Orbit`.  

# How

Adds a `Publish to WinGet` workflow that runs when a GitHub release is published. This uses `vedantmgoyal9/winget-releaser@v2` to generate manifests for the new version and open a PR on `microsoft/winget-pkgs` through the `expo/winget-pkgs` fork.

# Test Plan

We can't really run the workflow itself until a release is published, so this will get its first real exercise on the next release, and the resulting winget-pkgs PR is reviewed by that repo's validation pipeline before anything ships to users.
